### PR TITLE
Create a PluginAction for toggling connection

### DIFF
--- a/plugin/src/Components/ConnectPanel.lua
+++ b/plugin/src/Components/ConnectPanel.lua
@@ -36,15 +36,9 @@ function ConnectPanel:init()
 			return UDim2.new(0, container.X - other.X - 16, 0, 32)
 		end
 	)
-
-	self:setState({
-		address = "",
-		port = "",
-	})
 end
 
 function ConnectPanel:render()
-	local startSession = self.props.startSession
 	local cancel = self.props.cancel
 
 	return e(FitList, {
@@ -102,13 +96,9 @@ function ConnectPanel:render()
 				Input = e(FormTextInput, {
 					layoutOrder = 2,
 					width = UDim.new(0, 220),
-					value = self.state.address,
+					value = self.props.address,
 					placeholderValue = Config.defaultHost,
-					onValueChange = function(newValue)
-						self:setState({
-							address = newValue,
-						})
-					end,
+					onValueChange = self.props.changeAddress,
 				}),
 			}),
 
@@ -135,13 +125,9 @@ function ConnectPanel:render()
 				Input = e(FormTextInput, {
 					layoutOrder = 2,
 					width = UDim.new(0, 80),
-					value = self.state.port,
+					value = self.props.port,
 					placeholderValue = Config.defaultPort,
-					onValueChange = function(newValue)
-						self:setState({
-							port = newValue,
-						})
-					end,
+					onValueChange = self.props.changePort,
 				}),
 			}),
 		}),
@@ -179,21 +165,7 @@ function ConnectPanel:render()
 			e(FormButton, {
 				layoutOrder = 2,
 				text = "Connect",
-				onClick = function()
-					if startSession ~= nil then
-						local address = self.state.address
-						if address:len() == 0 then
-							address = Config.defaultHost
-						end
-
-						local port = self.state.port
-						if port:len() == 0 then
-							port = Config.defaultPort
-						end
-
-						startSession(address, port)
-					end
-				end,
+				onClick = self.props.connect,
 			}),
 		}),
 


### PR DESCRIPTION
Add's a user-configurable shortcut to start/stop connections to the Rojo server.

![image](https://user-images.githubusercontent.com/3081936/58680758-36f55b00-8337-11e9-955b-e0dd5163abe1.png)

Had to hoist up some state from ConnectPanel which I would rather have not done, but not sure if there's a better way without Rodux.