### PR TITLE
Automatically enable the HttpService if running from BuiltInPlugins folder.

### DIFF
--- a/plugin/src/Http.lua
+++ b/plugin/src/Http.lua
@@ -8,13 +8,28 @@ local HttpResponse = require(script.Parent.HttpResponse)
 
 local lastRequestId = 0
 
+local isBuiltInPlugin = pcall(function ()
+	-- This is a hack, but there is no explicit way to detect the security context of a thread.
+	-- If this routine runs without throwing, then we are running from the BuiltInPlugins folder!
+	local CorePackages = game:GetService("CorePackages")
+	tostring(CorePackages)
+end)
+
 -- TODO: Factor out into separate library, especially error handling
 local Http = {}
+
+local function tryEnableHttp()
+	if isBuiltInPlugin and not HttpService:GetHttpEnabled() then
+		Logging.warn("Automatically enabling the HttpService.")
+		HttpService:SetHttpEnabled(true)
+	end
+end
 
 function Http.get(url)
 	local requestId = lastRequestId + 1
 	lastRequestId = requestId
-
+	
+	tryEnableHttp()
 	Logging.trace("GET(%d) %s", requestId, url)
 
 	return Promise.new(function(resolve, reject)
@@ -41,6 +56,7 @@ function Http.post(url, body)
 	local requestId = lastRequestId + 1
 	lastRequestId = requestId
 
+	tryEnableHttp()
 	Logging.trace("POST(%d) %s\n%s", requestId, url, body)
 
 	return Promise.new(function(resolve, reject)


### PR DESCRIPTION
If the Rojo plugin is running locally in Roblox Studio's BuiltInPlugins folder, then it has access to enable the HttpService automatically. Roblox added methods for manipulating its value for the Game Settings plugin. This commit adds code to try and enable the HttpService if the module detects that its running from the BuiltInPlugin security context level.