### PR TITLE
VFS Improvements

### DIFF
--- a/src/common_setup.rs
+++ b/src/common_setup.rs
@@ -14,7 +14,7 @@ use crate::{
 
 pub fn start<F: VfsFetcher>(
     fuzzy_project_path: &Path,
-    vfs: &mut Vfs<F>,
+    vfs: &Vfs<F>,
 ) -> (Option<Project>, RojoTree) {
     log::trace!("Loading project file from {}", fuzzy_project_path.display());
     let maybe_project = match Project::load_fuzzy(fuzzy_project_path) {

--- a/src/serve_session.rs
+++ b/src/serve_session.rs
@@ -179,7 +179,7 @@ mod serve_session {
 
     #[test]
     fn just_folder() {
-        let mut vfs = Vfs::new(NoopFetcher);
+        let vfs = Vfs::new(NoopFetcher);
 
         vfs.debug_load_snapshot("/foo", VfsSnapshot::empty_dir());
 
@@ -191,7 +191,7 @@ mod serve_session {
 
     #[test]
     fn project_with_folder() {
-        let mut vfs = Vfs::new(NoopFetcher);
+        let vfs = Vfs::new(NoopFetcher);
 
         vfs.debug_load_snapshot(
             "/foo",
@@ -218,7 +218,7 @@ mod serve_session {
 
     #[test]
     fn script_with_meta() {
-        let mut vfs = Vfs::new(NoopFetcher);
+        let vfs = Vfs::new(NoopFetcher);
 
         vfs.debug_load_snapshot(
             "/root",

--- a/src/serve_session.rs
+++ b/src/serve_session.rs
@@ -52,7 +52,7 @@ pub struct ServeSession<F> {
     ///
     /// The main use for accessing it from the session is for debugging issues
     /// with Rojo's live-sync protocol.
-    vfs: Arc<Mutex<Vfs<F>>>,
+    vfs: Arc<Vfs<F>>,
 
     /// A queue of changes that have been applied to `tree` that affect clients.
     ///
@@ -71,7 +71,7 @@ pub struct ServeSession<F> {
 /// Methods that need thread-safety bounds on VfsFetcher are limited to this
 /// block to prevent needing to spread Send + Sync + 'static into everything
 /// that handles ServeSession.
-impl<F: VfsFetcher + Send + 'static> ServeSession<F> {
+impl<F: VfsFetcher + Send + Sync + 'static> ServeSession<F> {
     /// Start a new serve session from the given in-memory filesystem  and start
     /// path.
     ///
@@ -92,7 +92,7 @@ impl<F: VfsFetcher + Send + 'static> ServeSession<F> {
 
         let tree = Arc::new(Mutex::new(tree));
         let message_queue = Arc::new(message_queue);
-        let vfs = Arc::new(Mutex::new(vfs));
+        let vfs = Arc::new(vfs);
 
         log::trace!("Starting ChangeProcessor");
         let change_processor = ChangeProcessor::start(
@@ -122,8 +122,8 @@ impl<F: VfsFetcher> ServeSession<F> {
         self.tree.lock().unwrap()
     }
 
-    pub fn vfs(&self) -> MutexGuard<'_, Vfs<F>> {
-        self.vfs.lock().unwrap()
+    pub fn vfs(&self) -> &Vfs<F> {
+        &self.vfs
     }
 
     pub fn message_queue(&self) -> &MessageQueue<AppliedPatchSet> {

--- a/src/snapshot_middleware/csv.rs
+++ b/src/snapshot_middleware/csv.rs
@@ -21,7 +21,7 @@ pub struct SnapshotCsv;
 impl SnapshotMiddleware for SnapshotCsv {
     fn from_vfs<F: VfsFetcher>(
         _context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         if entry.is_directory() {

--- a/src/snapshot_middleware/dir.rs
+++ b/src/snapshot_middleware/dir.rs
@@ -20,7 +20,7 @@ pub struct SnapshotDir;
 impl SnapshotMiddleware for SnapshotDir {
     fn from_vfs<F: VfsFetcher>(
         context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         if entry.is_file() {

--- a/src/snapshot_middleware/json_model.rs
+++ b/src/snapshot_middleware/json_model.rs
@@ -20,7 +20,7 @@ pub struct SnapshotJsonModel;
 impl SnapshotMiddleware for SnapshotJsonModel {
     fn from_vfs<F: VfsFetcher>(
         _context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         if entry.is_directory() {

--- a/src/snapshot_middleware/lua.rs
+++ b/src/snapshot_middleware/lua.rs
@@ -21,7 +21,7 @@ pub struct SnapshotLua;
 impl SnapshotMiddleware for SnapshotLua {
     fn from_vfs<F: VfsFetcher>(
         context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         let file_name = entry.path().file_name().unwrap().to_string_lossy();
@@ -54,7 +54,7 @@ impl SnapshotMiddleware for SnapshotLua {
 
 /// Core routine for turning Lua files into snapshots.
 fn snapshot_lua_file<F: VfsFetcher>(
-    vfs: &mut Vfs<F>,
+    vfs: &Vfs<F>,
     entry: &VfsEntry,
 ) -> SnapshotInstanceResult<'static> {
     let file_name = entry.path().file_name().unwrap().to_string_lossy();
@@ -117,7 +117,7 @@ fn snapshot_lua_file<F: VfsFetcher>(
 /// their parents, which acts similarly to `__init__.py` from the Python world.
 fn snapshot_init<F: VfsFetcher>(
     context: &mut InstanceSnapshotContext,
-    vfs: &mut Vfs<F>,
+    vfs: &Vfs<F>,
     folder_entry: &VfsEntry,
     init_name: &str,
 ) -> SnapshotInstanceResult<'static> {

--- a/src/snapshot_middleware/middleware.rs
+++ b/src/snapshot_middleware/middleware.rs
@@ -15,7 +15,7 @@ pub type SnapshotFileResult = Option<(String, VfsSnapshot)>;
 pub trait SnapshotMiddleware {
     fn from_vfs<F: VfsFetcher>(
         context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static>;
 

--- a/src/snapshot_middleware/mod.rs
+++ b/src/snapshot_middleware/mod.rs
@@ -44,7 +44,7 @@ macro_rules! middlewares {
         /// Generates a snapshot of instances from the given VfsEntry.
         pub fn snapshot_from_vfs<F: VfsFetcher>(
             context: &mut InstanceSnapshotContext,
-            vfs: &mut Vfs<F>,
+            vfs: &Vfs<F>,
             entry: &VfsEntry,
         ) -> SnapshotInstanceResult<'static> {
             $(

--- a/src/snapshot_middleware/project.rs
+++ b/src/snapshot_middleware/project.rs
@@ -23,7 +23,7 @@ pub struct SnapshotProject;
 impl SnapshotMiddleware for SnapshotProject {
     fn from_vfs<F: VfsFetcher>(
         context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         if entry.is_directory() {
@@ -80,7 +80,7 @@ fn snapshot_project_node<F: VfsFetcher>(
     context: &mut InstanceSnapshotContext,
     instance_name: &str,
     node: &ProjectNode,
-    vfs: &mut Vfs<F>,
+    vfs: &Vfs<F>,
 ) -> SnapshotInstanceResult<'static> {
     let name = Cow::Owned(instance_name.to_owned());
     let mut class_name = node

--- a/src/snapshot_middleware/rbxlx.rs
+++ b/src/snapshot_middleware/rbxlx.rs
@@ -16,7 +16,7 @@ pub struct SnapshotRbxlx;
 impl SnapshotMiddleware for SnapshotRbxlx {
     fn from_vfs<F: VfsFetcher>(
         _context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         if entry.is_directory() {

--- a/src/snapshot_middleware/rbxm.rs
+++ b/src/snapshot_middleware/rbxm.rs
@@ -18,7 +18,7 @@ pub struct SnapshotRbxm;
 impl SnapshotMiddleware for SnapshotRbxm {
     fn from_vfs<F: VfsFetcher>(
         _context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         if entry.is_directory() {

--- a/src/snapshot_middleware/rbxmx.rs
+++ b/src/snapshot_middleware/rbxmx.rs
@@ -16,7 +16,7 @@ pub struct SnapshotRbxmx;
 impl SnapshotMiddleware for SnapshotRbxmx {
     fn from_vfs<F: VfsFetcher>(
         _context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         if entry.is_directory() {

--- a/src/snapshot_middleware/txt.rs
+++ b/src/snapshot_middleware/txt.rs
@@ -21,7 +21,7 @@ pub struct SnapshotTxt;
 impl SnapshotMiddleware for SnapshotTxt {
     fn from_vfs<F: VfsFetcher>(
         _context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         if entry.is_directory() {

--- a/src/snapshot_middleware/user_plugins.rs
+++ b/src/snapshot_middleware/user_plugins.rs
@@ -16,7 +16,7 @@ pub struct SnapshotUserPlugins;
 impl SnapshotMiddleware for SnapshotUserPlugins {
     fn from_vfs<F: VfsFetcher>(
         context: &mut InstanceSnapshotContext,
-        _vfs: &mut Vfs<F>,
+        _vfs: &Vfs<F>,
         _entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         // User plugins are only enabled if present on the snapshot context.

--- a/src/vfs/fetcher.rs
+++ b/src/vfs/fetcher.rs
@@ -17,20 +17,21 @@ pub enum FileType {
 /// In tests, it's stubbed out to do different versions of absolutely nothing
 /// depending on the test.
 pub trait VfsFetcher {
-    fn file_type(&mut self, path: &Path) -> io::Result<FileType>;
-    fn read_children(&mut self, path: &Path) -> io::Result<Vec<PathBuf>>;
-    fn read_contents(&mut self, path: &Path) -> io::Result<Vec<u8>>;
+    fn file_type(&self, path: &Path) -> io::Result<FileType>;
+    fn read_children(&self, path: &Path) -> io::Result<Vec<PathBuf>>;
+    fn read_contents(&self, path: &Path) -> io::Result<Vec<u8>>;
 
-    fn create_directory(&mut self, path: &Path) -> io::Result<()>;
-    fn write_file(&mut self, path: &Path, contents: &[u8]) -> io::Result<()>;
-    fn remove(&mut self, path: &Path) -> io::Result<()>;
+    fn create_directory(&self, path: &Path) -> io::Result<()>;
+    fn write_file(&self, path: &Path, contents: &[u8]) -> io::Result<()>;
+    fn remove(&self, path: &Path) -> io::Result<()>;
 
-    fn watch(&mut self, path: &Path);
-    fn unwatch(&mut self, path: &Path);
     fn receiver(&self) -> Receiver<VfsEvent>;
 
+    fn watch(&self, _path: &Path) {}
+    fn unwatch(&self, _path: &Path) {}
+
     /// A method intended for debugging what paths the fetcher is watching.
-    fn watched_paths(&self) -> Vec<&Path> {
+    fn watched_paths(&self) -> Vec<PathBuf> {
         Vec::new()
     }
 }

--- a/src/vfs/noop_fetcher.rs
+++ b/src/vfs/noop_fetcher.rs
@@ -19,42 +19,42 @@ use super::{
 pub struct NoopFetcher;
 
 impl VfsFetcher for NoopFetcher {
-    fn file_type(&mut self, _path: &Path) -> io::Result<FileType> {
+    fn file_type(&self, _path: &Path) -> io::Result<FileType> {
         Err(io::Error::new(
             io::ErrorKind::NotFound,
             "NoopFetcher always returns NotFound",
         ))
     }
 
-    fn read_children(&mut self, _path: &Path) -> io::Result<Vec<PathBuf>> {
+    fn read_children(&self, _path: &Path) -> io::Result<Vec<PathBuf>> {
         Err(io::Error::new(
             io::ErrorKind::NotFound,
             "NoopFetcher always returns NotFound",
         ))
     }
 
-    fn read_contents(&mut self, _path: &Path) -> io::Result<Vec<u8>> {
+    fn read_contents(&self, _path: &Path) -> io::Result<Vec<u8>> {
         Err(io::Error::new(
             io::ErrorKind::NotFound,
             "NoopFetcher always returns NotFound",
         ))
     }
 
-    fn create_directory(&mut self, _path: &Path) -> io::Result<()> {
+    fn create_directory(&self, _path: &Path) -> io::Result<()> {
         Ok(())
     }
 
-    fn write_file(&mut self, _path: &Path, _contents: &[u8]) -> io::Result<()> {
+    fn write_file(&self, _path: &Path, _contents: &[u8]) -> io::Result<()> {
         Ok(())
     }
 
-    fn remove(&mut self, _path: &Path) -> io::Result<()> {
+    fn remove(&self, _path: &Path) -> io::Result<()> {
         Ok(())
     }
 
-    fn watch(&mut self, _path: &Path) {}
+    fn watch(&self, _path: &Path) {}
 
-    fn unwatch(&mut self, _path: &Path) {}
+    fn unwatch(&self, _path: &Path) {}
 
     fn receiver(&self) -> Receiver<VfsEvent> {
         crossbeam_channel::never()

--- a/src/vfs/test_fetcher.rs
+++ b/src/vfs/test_fetcher.rs
@@ -107,7 +107,7 @@ impl TestFetcher {
 }
 
 impl VfsFetcher for TestFetcher {
-    fn file_type(&mut self, path: &Path) -> io::Result<FileType> {
+    fn file_type(&self, path: &Path) -> io::Result<FileType> {
         let inner = self.state.inner.lock().unwrap();
 
         match inner.entries.get(path) {
@@ -117,7 +117,7 @@ impl VfsFetcher for TestFetcher {
         }
     }
 
-    fn read_children(&mut self, path: &Path) -> io::Result<Vec<PathBuf>> {
+    fn read_children(&self, path: &Path) -> io::Result<Vec<PathBuf>> {
         let inner = self.state.inner.lock().unwrap();
 
         Ok(inner
@@ -129,7 +129,7 @@ impl VfsFetcher for TestFetcher {
             .collect())
     }
 
-    fn read_contents(&mut self, path: &Path) -> io::Result<Vec<u8>> {
+    fn read_contents(&self, path: &Path) -> io::Result<Vec<u8>> {
         let inner = self.state.inner.lock().unwrap();
 
         let node = inner.entries.get(path);
@@ -144,30 +144,26 @@ impl VfsFetcher for TestFetcher {
         }
     }
 
-    fn create_directory(&mut self, _path: &Path) -> io::Result<()> {
+    fn create_directory(&self, _path: &Path) -> io::Result<()> {
         Err(io::Error::new(
             io::ErrorKind::Other,
             "TestFetcher is not mutable yet",
         ))
     }
 
-    fn write_file(&mut self, _path: &Path, _contents: &[u8]) -> io::Result<()> {
+    fn write_file(&self, _path: &Path, _contents: &[u8]) -> io::Result<()> {
         Err(io::Error::new(
             io::ErrorKind::Other,
             "TestFetcher is not mutable yet",
         ))
     }
 
-    fn remove(&mut self, _path: &Path) -> io::Result<()> {
+    fn remove(&self, _path: &Path) -> io::Result<()> {
         Err(io::Error::new(
             io::ErrorKind::Other,
             "TestFetcher is not mutable yet",
         ))
     }
-
-    fn watch(&mut self, _path: &Path) {}
-
-    fn unwatch(&mut self, _path: &Path) {}
 
     fn receiver(&self) -> Receiver<VfsEvent> {
         self.receiver.clone()

--- a/src/vfs/vfs.rs
+++ b/src/vfs/vfs.rs
@@ -381,11 +381,11 @@ impl VfsEntry {
         &self.path
     }
 
-    pub fn contents<'vfs>(&self, vfs: &'vfs mut Vfs<impl VfsFetcher>) -> FsResult<Arc<Vec<u8>>> {
+    pub fn contents(&self, vfs: &Vfs<impl VfsFetcher>) -> FsResult<Arc<Vec<u8>>> {
         vfs.get_contents(&self.path)
     }
 
-    pub fn children(&self, vfs: &mut Vfs<impl VfsFetcher>) -> FsResult<Vec<VfsEntry>> {
+    pub fn children(&self, vfs: &Vfs<impl VfsFetcher>) -> FsResult<Vec<VfsEntry>> {
         vfs.get_children(&self.path)
     }
 

--- a/src/vfs/vfs.rs
+++ b/src/vfs/vfs.rs
@@ -264,7 +264,7 @@ pub trait VfsDebug {
     fn debug_contents<'a>(&'a self, path: &Path) -> Option<&'a [u8]>;
     fn debug_children<'a>(&'a self, path: &Path) -> Option<(bool, Vec<&'a Path>)>;
     fn debug_orphans(&self) -> Vec<&Path>;
-    fn debug_watched_paths(&self) -> Vec<&Path>;
+    fn debug_watched_paths(&self) -> Vec<PathBuf>;
 }
 
 impl<F: VfsFetcher> VfsDebug for Vfs<F> {
@@ -324,7 +324,7 @@ impl<F: VfsFetcher> VfsDebug for Vfs<F> {
         self.inner.orphans().collect()
     }
 
-    fn debug_watched_paths(&self) -> Vec<&Path> {
+    fn debug_watched_paths(&self) -> Vec<PathBuf> {
         self.fetcher.watched_paths()
     }
 }
@@ -470,7 +470,7 @@ mod test {
         }
 
         impl VfsFetcher for MockFetcher {
-            fn file_type(&mut self, path: &Path) -> io::Result<FileType> {
+            fn file_type(&self, path: &Path) -> io::Result<FileType> {
                 if path == Path::new("/dir/a.txt") {
                     return Ok(FileType::File);
                 }
@@ -478,7 +478,7 @@ mod test {
                 unimplemented!();
             }
 
-            fn read_contents(&mut self, path: &Path) -> io::Result<Vec<u8>> {
+            fn read_contents(&self, path: &Path) -> io::Result<Vec<u8>> {
                 if path == Path::new("/dir/a.txt") {
                     let inner = self.inner.borrow();
 
@@ -488,25 +488,21 @@ mod test {
                 unimplemented!();
             }
 
-            fn read_children(&mut self, _path: &Path) -> io::Result<Vec<PathBuf>> {
+            fn read_children(&self, _path: &Path) -> io::Result<Vec<PathBuf>> {
                 unimplemented!();
             }
 
-            fn create_directory(&mut self, _path: &Path) -> io::Result<()> {
+            fn create_directory(&self, _path: &Path) -> io::Result<()> {
                 unimplemented!();
             }
 
-            fn write_file(&mut self, _path: &Path, _contents: &[u8]) -> io::Result<()> {
+            fn write_file(&self, _path: &Path, _contents: &[u8]) -> io::Result<()> {
                 unimplemented!();
             }
 
-            fn remove(&mut self, _path: &Path) -> io::Result<()> {
+            fn remove(&self, _path: &Path) -> io::Result<()> {
                 unimplemented!();
             }
-
-            fn watch(&mut self, _path: &Path) {}
-
-            fn unwatch(&mut self, _path: &Path) {}
 
             fn receiver(&self) -> Receiver<VfsEvent> {
                 crossbeam_channel::never()

--- a/src/vfs/vfs.rs
+++ b/src/vfs/vfs.rs
@@ -48,7 +48,7 @@ impl<F: VfsFetcher> Vfs<F> {
         self.fetcher.receiver()
     }
 
-    pub fn commit_change(&mut self, event: &VfsEvent) -> FsResult<()> {
+    pub fn commit_change(&self, event: &VfsEvent) -> FsResult<()> {
         use VfsEvent::*;
 
         log::trace!("Committing Vfs change {:?}", event);
@@ -67,12 +67,12 @@ impl<F: VfsFetcher> Vfs<F> {
         Ok(())
     }
 
-    pub fn get(&mut self, path: impl AsRef<Path>) -> FsResult<VfsEntry> {
+    pub fn get(&self, path: impl AsRef<Path>) -> FsResult<VfsEntry> {
         let mut data = self.data.lock().unwrap();
         Self::get_internal(&mut data, &self.fetcher, path)
     }
 
-    pub fn get_contents(&mut self, path: impl AsRef<Path>) -> FsResult<Arc<Vec<u8>>> {
+    pub fn get_contents(&self, path: impl AsRef<Path>) -> FsResult<Arc<Vec<u8>>> {
         let path = path.as_ref();
 
         let mut data = self.data.lock().unwrap();
@@ -98,7 +98,7 @@ impl<F: VfsFetcher> Vfs<F> {
         }
     }
 
-    pub fn get_children(&mut self, path: impl AsRef<Path>) -> FsResult<Vec<VfsEntry>> {
+    pub fn get_children(&self, path: impl AsRef<Path>) -> FsResult<Vec<VfsEntry>> {
         let path = path.as_ref();
 
         let mut data = self.data.lock().unwrap();
@@ -277,7 +277,7 @@ impl<F: VfsFetcher> Vfs<F> {
 /// Contains extra methods that should only be used for debugging. They're
 /// broken out into a separate trait to make it more explicit to depend on them.
 pub trait VfsDebug {
-    fn debug_load_snapshot<P: AsRef<Path>>(&mut self, path: P, snapshot: VfsSnapshot);
+    fn debug_load_snapshot<P: AsRef<Path>>(&self, path: P, snapshot: VfsSnapshot);
     fn debug_is_file(&self, path: &Path) -> bool;
     fn debug_contents(&self, path: &Path) -> Option<Arc<Vec<u8>>>;
     fn debug_children(&self, path: &Path) -> Option<(bool, Vec<PathBuf>)>;
@@ -286,7 +286,7 @@ pub trait VfsDebug {
 }
 
 impl<F: VfsFetcher> VfsDebug for Vfs<F> {
-    fn debug_load_snapshot<P: AsRef<Path>>(&mut self, path: P, snapshot: VfsSnapshot) {
+    fn debug_load_snapshot<P: AsRef<Path>>(&self, path: P, snapshot: VfsSnapshot) {
         fn load_snapshot<P: AsRef<Path>>(
             data: &mut PathMap<VfsItem>,
             path: P,
@@ -450,7 +450,7 @@ mod test {
 
     #[test]
     fn from_snapshot_file() {
-        let mut vfs = Vfs::new(NoopFetcher);
+        let vfs = Vfs::new(NoopFetcher);
         let file = VfsSnapshot::file("hello, world!");
 
         vfs.debug_load_snapshot("/hello.txt", file);
@@ -461,7 +461,7 @@ mod test {
 
     #[test]
     fn from_snapshot_dir() {
-        let mut vfs = Vfs::new(NoopFetcher);
+        let vfs = Vfs::new(NoopFetcher);
         let dir = VfsSnapshot::dir(hashmap! {
             "a.txt" => VfsSnapshot::file("contents of a.txt"),
             "b.lua" => VfsSnapshot::file("contents of b.lua"),

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -102,7 +102,7 @@ impl<F: VfsFetcher> UiService<F> {
         let orphans: Vec<_> = vfs
             .debug_orphans()
             .into_iter()
-            .map(|path| Self::render_vfs_path(&vfs, path, true))
+            .map(|path| Self::render_vfs_path(&vfs, &path, true))
             .collect();
 
         let watched_list: Vec<_> = vfs
@@ -153,7 +153,7 @@ impl<F: VfsFetcher> UiService<F> {
 
             let children: Vec<_> = children
                 .into_iter()
-                .map(|child| Self::render_vfs_path(vfs, child, false))
+                .map(|child| Self::render_vfs_path(vfs, &child, false))
                 .collect();
 
             let note = if is_exhaustive {


### PR DESCRIPTION
Each commit in this PR can be looked at independently, I made these changes as an incremental refactor of the VFS implementation.

This PR refactors all of the methods on `Vfs` from accepting `&mut self` to accepting `&self` and keeping data wrapped in a mutex. This builds on previous changes to make reference count file contents and cleans up the last places where we're returning borrowed data out of the VFS interface.

Once this change lands, there are two possible directions we can go that I see:
* Conservative: Refactor all remaining `&mut Vfs` handles to `&Vfs`
* Interesting: Embrace ref counting by changing `Vfs` methods to accept `self: Arc<Self>`, which makes the `VfsEntry` API no longer need an explicit `Vfs` argument for its operations.