### PR TITLE
Remove outer VFS locking

### DIFF
--- a/src/common_setup.rs
+++ b/src/common_setup.rs
@@ -14,7 +14,7 @@ use crate::{
 
 pub fn start<F: VfsFetcher>(
     fuzzy_project_path: &Path,
-    vfs: &mut Vfs<F>,
+    vfs: &Vfs<F>,
 ) -> (Option<Project>, RojoTree) {
     log::trace!("Loading project file from {}", fuzzy_project_path.display());
     let maybe_project = match Project::load_fuzzy(fuzzy_project_path) {

--- a/src/serve_session.rs
+++ b/src/serve_session.rs
@@ -52,7 +52,7 @@ pub struct ServeSession<F> {
     ///
     /// The main use for accessing it from the session is for debugging issues
     /// with Rojo's live-sync protocol.
-    vfs: Arc<Mutex<Vfs<F>>>,
+    vfs: Arc<Vfs<F>>,
 
     /// A queue of changes that have been applied to `tree` that affect clients.
     ///
@@ -71,7 +71,7 @@ pub struct ServeSession<F> {
 /// Methods that need thread-safety bounds on VfsFetcher are limited to this
 /// block to prevent needing to spread Send + Sync + 'static into everything
 /// that handles ServeSession.
-impl<F: VfsFetcher + Send + 'static> ServeSession<F> {
+impl<F: VfsFetcher + Send + Sync + 'static> ServeSession<F> {
     /// Start a new serve session from the given in-memory filesystem  and start
     /// path.
     ///
@@ -92,7 +92,7 @@ impl<F: VfsFetcher + Send + 'static> ServeSession<F> {
 
         let tree = Arc::new(Mutex::new(tree));
         let message_queue = Arc::new(message_queue);
-        let vfs = Arc::new(Mutex::new(vfs));
+        let vfs = Arc::new(vfs);
 
         log::trace!("Starting ChangeProcessor");
         let change_processor = ChangeProcessor::start(
@@ -122,8 +122,8 @@ impl<F: VfsFetcher> ServeSession<F> {
         self.tree.lock().unwrap()
     }
 
-    pub fn vfs(&self) -> MutexGuard<'_, Vfs<F>> {
-        self.vfs.lock().unwrap()
+    pub fn vfs(&self) -> &Vfs<F> {
+        &self.vfs
     }
 
     pub fn message_queue(&self) -> &MessageQueue<AppliedPatchSet> {

--- a/src/snapshot_middleware/csv.rs
+++ b/src/snapshot_middleware/csv.rs
@@ -21,7 +21,7 @@ pub struct SnapshotCsv;
 impl SnapshotMiddleware for SnapshotCsv {
     fn from_vfs<F: VfsFetcher>(
         _context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         if entry.is_directory() {

--- a/src/snapshot_middleware/dir.rs
+++ b/src/snapshot_middleware/dir.rs
@@ -20,7 +20,7 @@ pub struct SnapshotDir;
 impl SnapshotMiddleware for SnapshotDir {
     fn from_vfs<F: VfsFetcher>(
         context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         if entry.is_file() {

--- a/src/snapshot_middleware/json_model.rs
+++ b/src/snapshot_middleware/json_model.rs
@@ -20,7 +20,7 @@ pub struct SnapshotJsonModel;
 impl SnapshotMiddleware for SnapshotJsonModel {
     fn from_vfs<F: VfsFetcher>(
         _context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         if entry.is_directory() {

--- a/src/snapshot_middleware/lua.rs
+++ b/src/snapshot_middleware/lua.rs
@@ -21,7 +21,7 @@ pub struct SnapshotLua;
 impl SnapshotMiddleware for SnapshotLua {
     fn from_vfs<F: VfsFetcher>(
         context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         let file_name = entry.path().file_name().unwrap().to_string_lossy();
@@ -54,7 +54,7 @@ impl SnapshotMiddleware for SnapshotLua {
 
 /// Core routine for turning Lua files into snapshots.
 fn snapshot_lua_file<F: VfsFetcher>(
-    vfs: &mut Vfs<F>,
+    vfs: &Vfs<F>,
     entry: &VfsEntry,
 ) -> SnapshotInstanceResult<'static> {
     let file_name = entry.path().file_name().unwrap().to_string_lossy();
@@ -117,7 +117,7 @@ fn snapshot_lua_file<F: VfsFetcher>(
 /// their parents, which acts similarly to `__init__.py` from the Python world.
 fn snapshot_init<F: VfsFetcher>(
     context: &mut InstanceSnapshotContext,
-    vfs: &mut Vfs<F>,
+    vfs: &Vfs<F>,
     folder_entry: &VfsEntry,
     init_name: &str,
 ) -> SnapshotInstanceResult<'static> {

--- a/src/snapshot_middleware/middleware.rs
+++ b/src/snapshot_middleware/middleware.rs
@@ -15,7 +15,7 @@ pub type SnapshotFileResult = Option<(String, VfsSnapshot)>;
 pub trait SnapshotMiddleware {
     fn from_vfs<F: VfsFetcher>(
         context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static>;
 

--- a/src/snapshot_middleware/mod.rs
+++ b/src/snapshot_middleware/mod.rs
@@ -44,7 +44,7 @@ macro_rules! middlewares {
         /// Generates a snapshot of instances from the given VfsEntry.
         pub fn snapshot_from_vfs<F: VfsFetcher>(
             context: &mut InstanceSnapshotContext,
-            vfs: &mut Vfs<F>,
+            vfs: &Vfs<F>,
             entry: &VfsEntry,
         ) -> SnapshotInstanceResult<'static> {
             $(

--- a/src/snapshot_middleware/project.rs
+++ b/src/snapshot_middleware/project.rs
@@ -23,7 +23,7 @@ pub struct SnapshotProject;
 impl SnapshotMiddleware for SnapshotProject {
     fn from_vfs<F: VfsFetcher>(
         context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         if entry.is_directory() {
@@ -80,7 +80,7 @@ fn snapshot_project_node<F: VfsFetcher>(
     context: &mut InstanceSnapshotContext,
     instance_name: &str,
     node: &ProjectNode,
-    vfs: &mut Vfs<F>,
+    vfs: &Vfs<F>,
 ) -> SnapshotInstanceResult<'static> {
     let name = Cow::Owned(instance_name.to_owned());
     let mut class_name = node

--- a/src/snapshot_middleware/rbxlx.rs
+++ b/src/snapshot_middleware/rbxlx.rs
@@ -16,7 +16,7 @@ pub struct SnapshotRbxlx;
 impl SnapshotMiddleware for SnapshotRbxlx {
     fn from_vfs<F: VfsFetcher>(
         _context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         if entry.is_directory() {

--- a/src/snapshot_middleware/rbxm.rs
+++ b/src/snapshot_middleware/rbxm.rs
@@ -18,7 +18,7 @@ pub struct SnapshotRbxm;
 impl SnapshotMiddleware for SnapshotRbxm {
     fn from_vfs<F: VfsFetcher>(
         _context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         if entry.is_directory() {

--- a/src/snapshot_middleware/rbxmx.rs
+++ b/src/snapshot_middleware/rbxmx.rs
@@ -16,7 +16,7 @@ pub struct SnapshotRbxmx;
 impl SnapshotMiddleware for SnapshotRbxmx {
     fn from_vfs<F: VfsFetcher>(
         _context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         if entry.is_directory() {

--- a/src/snapshot_middleware/txt.rs
+++ b/src/snapshot_middleware/txt.rs
@@ -21,7 +21,7 @@ pub struct SnapshotTxt;
 impl SnapshotMiddleware for SnapshotTxt {
     fn from_vfs<F: VfsFetcher>(
         _context: &mut InstanceSnapshotContext,
-        vfs: &mut Vfs<F>,
+        vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         if entry.is_directory() {

--- a/src/snapshot_middleware/user_plugins.rs
+++ b/src/snapshot_middleware/user_plugins.rs
@@ -16,7 +16,7 @@ pub struct SnapshotUserPlugins;
 impl SnapshotMiddleware for SnapshotUserPlugins {
     fn from_vfs<F: VfsFetcher>(
         context: &mut InstanceSnapshotContext,
-        _vfs: &mut Vfs<F>,
+        _vfs: &Vfs<F>,
         _entry: &VfsEntry,
     ) -> SnapshotInstanceResult<'static> {
         // User plugins are only enabled if present on the snapshot context.


### PR DESCRIPTION
This PR strips out any case where we're accepting a `&mut Vfs` as well as any case where we're holding a `Mutex<Vfs>`. These should no longer be necessary with #259, which this PR has as a prerequisite.