### PR TITLE
Introduce InstanceContext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ regex = "1.0"
 reqwest = "0.9.20"
 ritz = "0.1.0"
 rlua = "0.16.3"
-serde = { version = "1.0", features = ["derive", "rc"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 termcolor = "1.0.5"
 uuid = { version = "0.7", features = ["v4", "serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ regex = "1.0"
 reqwest = "0.9.20"
 ritz = "0.1.0"
 rlua = "0.16.3"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 termcolor = "1.0.5"
 uuid = { version = "0.7", features = ["v4", "serde"] }

--- a/src/snapshot/metadata.rs
+++ b/src/snapshot/metadata.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use serde::{Deserialize, Serialize};
@@ -43,6 +44,14 @@ pub struct InstanceMetadata {
     // TODO: Change this to be a SmallVec for performance in common cases?
     #[serde(serialize_with = "path_serializer::serialize_vec_absolute")]
     pub relevant_paths: Vec<PathBuf>,
+
+    /// Contains information about this instance that should persist between
+    /// snapshot invocations and is generally inherited.
+    ///
+    /// If an instance has a piece of context attached to it, then the next time
+    /// that instance's instigating source is snapshotted directly, the same
+    /// context will be passed into it.
+    pub context: InstanceContext,
 }
 
 impl InstanceMetadata {
@@ -51,6 +60,7 @@ impl InstanceMetadata {
             ignore_unknown_instances: false,
             instigating_source: None,
             relevant_paths: Vec::new(),
+            context: InstanceContext::default(),
         }
     }
 
@@ -74,11 +84,31 @@ impl InstanceMetadata {
             ..self
         }
     }
+
+    pub fn context(self, context: &InstanceContext) -> Self {
+        Self {
+            context: context.clone(),
+            ..self
+        }
+    }
 }
 
 impl Default for InstanceMetadata {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InstanceContext {
+    pub ignore_paths: Arc<Vec<()>>,
+}
+
+impl Default for InstanceContext {
+    fn default() -> Self {
+        InstanceContext {
+            ignore_paths: Arc::new(Vec::new()),
+        }
     }
 }
 

--- a/src/snapshot/metadata.rs
+++ b/src/snapshot/metadata.rs
@@ -1,7 +1,6 @@
 use std::{
     fmt,
     path::{Path, PathBuf},
-    sync::Arc,
 };
 
 use serde::{Deserialize, Serialize};
@@ -100,15 +99,11 @@ impl Default for InstanceMetadata {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct InstanceContext {
-    pub ignore_paths: Arc<Vec<()>>,
-}
+pub struct InstanceContext {}
 
 impl Default for InstanceContext {
     fn default() -> Self {
-        InstanceContext {
-            ignore_paths: Arc::new(Vec::new()),
-        }
+        InstanceContext {}
     }
 }
 

--- a/src/snapshot/tests/snapshots/apply__add_property.snap
+++ b/src/snapshot/tests/snapshots/apply__add_property.snap
@@ -1,6 +1,6 @@
 ---
 source: src/snapshot/tests/apply.rs
-expression: tree_value
+expression: tree_view
 ---
 id: id-1
 name: ROOT
@@ -12,4 +12,6 @@ properties:
 metadata:
   ignore_unknown_instances: false
   relevant_paths: []
+  context:
+    ignore_paths: []
 children: []

--- a/src/snapshot/tests/snapshots/apply__add_property.snap
+++ b/src/snapshot/tests/snapshots/apply__add_property.snap
@@ -12,6 +12,5 @@ properties:
 metadata:
   ignore_unknown_instances: false
   relevant_paths: []
-  context:
-    ignore_paths: []
+  context: {}
 children: []

--- a/src/snapshot/tests/snapshots/apply__remove_property_after_patch.snap
+++ b/src/snapshot/tests/snapshots/apply__remove_property_after_patch.snap
@@ -9,6 +9,5 @@ properties: {}
 metadata:
   ignore_unknown_instances: false
   relevant_paths: []
-  context:
-    ignore_paths: []
+  context: {}
 children: []

--- a/src/snapshot/tests/snapshots/apply__remove_property_after_patch.snap
+++ b/src/snapshot/tests/snapshots/apply__remove_property_after_patch.snap
@@ -1,6 +1,6 @@
 ---
 source: src/snapshot/tests/apply.rs
-expression: tree_value
+expression: tree_view
 ---
 id: id-1
 name: ROOT
@@ -9,4 +9,6 @@ properties: {}
 metadata:
   ignore_unknown_instances: false
   relevant_paths: []
+  context:
+    ignore_paths: []
 children: []

--- a/src/snapshot/tests/snapshots/apply__remove_property_initial.snap
+++ b/src/snapshot/tests/snapshots/apply__remove_property_initial.snap
@@ -1,6 +1,6 @@
 ---
 source: src/snapshot/tests/apply.rs
-expression: tree_value
+expression: tree_view
 ---
 id: id-1
 name: ROOT
@@ -12,4 +12,6 @@ properties:
 metadata:
   ignore_unknown_instances: false
   relevant_paths: []
+  context:
+    ignore_paths: []
 children: []

--- a/src/snapshot/tests/snapshots/apply__remove_property_initial.snap
+++ b/src/snapshot/tests/snapshots/apply__remove_property_initial.snap
@@ -12,6 +12,5 @@ properties:
 metadata:
   ignore_unknown_instances: false
   relevant_paths: []
-  context:
-    ignore_paths: []
+  context: {}
 children: []

--- a/src/snapshot/tests/snapshots/apply__set_name_and_class_name.snap
+++ b/src/snapshot/tests/snapshots/apply__set_name_and_class_name.snap
@@ -9,6 +9,5 @@ properties: {}
 metadata:
   ignore_unknown_instances: false
   relevant_paths: []
-  context:
-    ignore_paths: []
+  context: {}
 children: []

--- a/src/snapshot/tests/snapshots/apply__set_name_and_class_name.snap
+++ b/src/snapshot/tests/snapshots/apply__set_name_and_class_name.snap
@@ -1,6 +1,6 @@
 ---
 source: src/snapshot/tests/apply.rs
-expression: tree_value
+expression: tree_view
 ---
 id: id-1
 name: "Hello, world!"
@@ -9,4 +9,6 @@ properties: {}
 metadata:
   ignore_unknown_instances: false
   relevant_paths: []
+  context:
+    ignore_paths: []
 children: []

--- a/src/snapshot/tests/snapshots/compute__add_child.snap
+++ b/src/snapshot/tests/snapshots/compute__add_child.snap
@@ -10,8 +10,7 @@ added_instances:
       metadata:
         ignore_unknown_instances: false
         relevant_paths: []
-        context:
-          ignore_paths: []
+        context: {}
       name: New
       class_name: Folder
       properties: {}

--- a/src/snapshot/tests/snapshots/compute__add_child.snap
+++ b/src/snapshot/tests/snapshots/compute__add_child.snap
@@ -10,6 +10,8 @@ added_instances:
       metadata:
         ignore_unknown_instances: false
         relevant_paths: []
+        context:
+          ignore_paths: []
       name: New
       class_name: Folder
       properties: {}

--- a/src/snapshot_middleware/snapshots/test__client_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/test__client_from_vfs.snap
@@ -10,8 +10,7 @@ metadata:
   relevant_paths:
     - /foo.client.lua
     - /foo.meta.json
-  context:
-    ignore_paths: []
+  context: {}
 name: foo
 class_name: LocalScript
 properties:

--- a/src/snapshot_middleware/snapshots/test__client_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/test__client_from_vfs.snap
@@ -10,6 +10,8 @@ metadata:
   relevant_paths:
     - /foo.client.lua
     - /foo.meta.json
+  context:
+    ignore_paths: []
 name: foo
 class_name: LocalScript
 properties:

--- a/src/snapshot_middleware/snapshots/test__csv_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/test__csv_from_vfs.snap
@@ -10,6 +10,8 @@ metadata:
   relevant_paths:
     - /foo.csv
     - /foo.meta.json
+  context:
+    ignore_paths: []
 name: foo
 class_name: LocalizationTable
 properties:

--- a/src/snapshot_middleware/snapshots/test__csv_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/test__csv_from_vfs.snap
@@ -10,8 +10,7 @@ metadata:
   relevant_paths:
     - /foo.csv
     - /foo.meta.json
-  context:
-    ignore_paths: []
+  context: {}
 name: foo
 class_name: LocalizationTable
 properties:

--- a/src/snapshot_middleware/snapshots/test__csv_with_meta.snap
+++ b/src/snapshot_middleware/snapshots/test__csv_with_meta.snap
@@ -10,6 +10,8 @@ metadata:
   relevant_paths:
     - /foo.csv
     - /foo.meta.json
+  context:
+    ignore_paths: []
 name: foo
 class_name: LocalizationTable
 properties:

--- a/src/snapshot_middleware/snapshots/test__csv_with_meta.snap
+++ b/src/snapshot_middleware/snapshots/test__csv_with_meta.snap
@@ -10,8 +10,7 @@ metadata:
   relevant_paths:
     - /foo.csv
     - /foo.meta.json
-  context:
-    ignore_paths: []
+  context: {}
 name: foo
 class_name: LocalizationTable
 properties:

--- a/src/snapshot_middleware/snapshots/test__empty_folder.snap
+++ b/src/snapshot_middleware/snapshots/test__empty_folder.snap
@@ -13,8 +13,7 @@ metadata:
     - /foo/init.lua
     - /foo/init.server.lua
     - /foo/init.client.lua
-  context:
-    ignore_paths: []
+  context: {}
 name: foo
 class_name: Folder
 properties: {}

--- a/src/snapshot_middleware/snapshots/test__empty_folder.snap
+++ b/src/snapshot_middleware/snapshots/test__empty_folder.snap
@@ -13,6 +13,8 @@ metadata:
     - /foo/init.lua
     - /foo/init.server.lua
     - /foo/init.client.lua
+  context:
+    ignore_paths: []
 name: foo
 class_name: Folder
 properties: {}

--- a/src/snapshot_middleware/snapshots/test__folder_in_folder.snap
+++ b/src/snapshot_middleware/snapshots/test__folder_in_folder.snap
@@ -13,6 +13,8 @@ metadata:
     - /foo/init.lua
     - /foo/init.server.lua
     - /foo/init.client.lua
+  context:
+    ignore_paths: []
 name: foo
 class_name: Folder
 properties: {}
@@ -28,6 +30,8 @@ children:
         - /foo/Child/init.lua
         - /foo/Child/init.server.lua
         - /foo/Child/init.client.lua
+      context:
+        ignore_paths: []
     name: Child
     class_name: Folder
     properties: {}

--- a/src/snapshot_middleware/snapshots/test__folder_in_folder.snap
+++ b/src/snapshot_middleware/snapshots/test__folder_in_folder.snap
@@ -13,8 +13,7 @@ metadata:
     - /foo/init.lua
     - /foo/init.server.lua
     - /foo/init.client.lua
-  context:
-    ignore_paths: []
+  context: {}
 name: foo
 class_name: Folder
 properties: {}
@@ -30,8 +29,7 @@ children:
         - /foo/Child/init.lua
         - /foo/Child/init.server.lua
         - /foo/Child/init.client.lua
-      context:
-        ignore_paths: []
+      context: {}
     name: Child
     class_name: Folder
     properties: {}

--- a/src/snapshot_middleware/snapshots/test__init_module_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/test__init_module_from_vfs.snap
@@ -13,6 +13,8 @@ metadata:
     - /root/init.lua
     - /root/init.server.lua
     - /root/init.client.lua
+  context:
+    ignore_paths: []
 name: root
 class_name: ModuleScript
 properties:

--- a/src/snapshot_middleware/snapshots/test__init_module_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/test__init_module_from_vfs.snap
@@ -13,8 +13,7 @@ metadata:
     - /root/init.lua
     - /root/init.server.lua
     - /root/init.client.lua
-  context:
-    ignore_paths: []
+  context: {}
 name: root
 class_name: ModuleScript
 properties:

--- a/src/snapshot_middleware/snapshots/test__instance_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/test__instance_from_vfs.snap
@@ -10,8 +10,7 @@ metadata:
   relevant_paths:
     - /foo.txt
     - /foo.meta.json
-  context:
-    ignore_paths: []
+  context: {}
 name: foo
 class_name: StringValue
 properties:

--- a/src/snapshot_middleware/snapshots/test__instance_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/test__instance_from_vfs.snap
@@ -10,6 +10,8 @@ metadata:
   relevant_paths:
     - /foo.txt
     - /foo.meta.json
+  context:
+    ignore_paths: []
 name: foo
 class_name: StringValue
 properties:

--- a/src/snapshot_middleware/snapshots/test__model_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/test__model_from_vfs.snap
@@ -9,6 +9,8 @@ metadata:
     Path: /foo.model.json
   relevant_paths:
     - /foo.model.json
+  context:
+    ignore_paths: []
 name: foo
 class_name: IntValue
 properties:
@@ -20,6 +22,8 @@ children:
     metadata:
       ignore_unknown_instances: false
       relevant_paths: []
+      context:
+        ignore_paths: []
     name: The Child
     class_name: StringValue
     properties: {}

--- a/src/snapshot_middleware/snapshots/test__model_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/test__model_from_vfs.snap
@@ -9,8 +9,7 @@ metadata:
     Path: /foo.model.json
   relevant_paths:
     - /foo.model.json
-  context:
-    ignore_paths: []
+  context: {}
 name: foo
 class_name: IntValue
 properties:
@@ -22,8 +21,7 @@ children:
     metadata:
       ignore_unknown_instances: false
       relevant_paths: []
-      context:
-        ignore_paths: []
+      context: {}
     name: The Child
     class_name: StringValue
     properties: {}

--- a/src/snapshot_middleware/snapshots/test__module_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/test__module_from_vfs.snap
@@ -10,8 +10,7 @@ metadata:
   relevant_paths:
     - /foo.lua
     - /foo.meta.json
-  context:
-    ignore_paths: []
+  context: {}
 name: foo
 class_name: ModuleScript
 properties:

--- a/src/snapshot_middleware/snapshots/test__module_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/test__module_from_vfs.snap
@@ -10,6 +10,8 @@ metadata:
   relevant_paths:
     - /foo.lua
     - /foo.meta.json
+  context:
+    ignore_paths: []
 name: foo
 class_name: ModuleScript
 properties:

--- a/src/snapshot_middleware/snapshots/test__module_with_meta.snap
+++ b/src/snapshot_middleware/snapshots/test__module_with_meta.snap
@@ -10,8 +10,7 @@ metadata:
   relevant_paths:
     - /foo.lua
     - /foo.meta.json
-  context:
-    ignore_paths: []
+  context: {}
 name: foo
 class_name: ModuleScript
 properties:

--- a/src/snapshot_middleware/snapshots/test__module_with_meta.snap
+++ b/src/snapshot_middleware/snapshots/test__module_with_meta.snap
@@ -10,6 +10,8 @@ metadata:
   relevant_paths:
     - /foo.lua
     - /foo.meta.json
+  context:
+    ignore_paths: []
 name: foo
 class_name: ModuleScript
 properties:

--- a/src/snapshot_middleware/snapshots/test__project_from_direct_file.snap
+++ b/src/snapshot_middleware/snapshots/test__project_from_direct_file.snap
@@ -9,8 +9,7 @@ metadata:
     Path: /foo/hello.project.json
   relevant_paths:
     - /foo/hello.project.json
-  context:
-    ignore_paths: []
+  context: {}
 name: direct-project
 class_name: Model
 properties: {}

--- a/src/snapshot_middleware/snapshots/test__project_from_direct_file.snap
+++ b/src/snapshot_middleware/snapshots/test__project_from_direct_file.snap
@@ -9,6 +9,8 @@ metadata:
     Path: /foo/hello.project.json
   relevant_paths:
     - /foo/hello.project.json
+  context:
+    ignore_paths: []
 name: direct-project
 class_name: Model
 properties: {}

--- a/src/snapshot_middleware/snapshots/test__project_from_folder.snap
+++ b/src/snapshot_middleware/snapshots/test__project_from_folder.snap
@@ -9,8 +9,7 @@ metadata:
     Path: /foo/default.project.json
   relevant_paths:
     - /foo/default.project.json
-  context:
-    ignore_paths: []
+  context: {}
 name: indirect-project
 class_name: Folder
 properties: {}

--- a/src/snapshot_middleware/snapshots/test__project_from_folder.snap
+++ b/src/snapshot_middleware/snapshots/test__project_from_folder.snap
@@ -9,6 +9,8 @@ metadata:
     Path: /foo/default.project.json
   relevant_paths:
     - /foo/default.project.json
+  context:
+    ignore_paths: []
 name: indirect-project
 class_name: Folder
 properties: {}

--- a/src/snapshot_middleware/snapshots/test__project_path_property_overrides.snap
+++ b/src/snapshot_middleware/snapshots/test__project_path_property_overrides.snap
@@ -10,8 +10,7 @@ metadata:
   relevant_paths:
     - /foo/other.project.json
     - /foo/default.project.json
-  context:
-    ignore_paths: []
+  context: {}
 name: path-property-override
 class_name: StringValue
 properties:

--- a/src/snapshot_middleware/snapshots/test__project_path_property_overrides.snap
+++ b/src/snapshot_middleware/snapshots/test__project_path_property_overrides.snap
@@ -10,6 +10,8 @@ metadata:
   relevant_paths:
     - /foo/other.project.json
     - /foo/default.project.json
+  context:
+    ignore_paths: []
 name: path-property-override
 class_name: StringValue
 properties:

--- a/src/snapshot_middleware/snapshots/test__project_with_children.snap
+++ b/src/snapshot_middleware/snapshots/test__project_with_children.snap
@@ -9,8 +9,7 @@ metadata:
     Path: /foo/default.project.json
   relevant_paths:
     - /foo/default.project.json
-  context:
-    ignore_paths: []
+  context: {}
 name: children
 class_name: Folder
 properties: {}
@@ -27,8 +26,7 @@ children:
             ignore_unknown_instances: ~
             path: ~
       relevant_paths: []
-      context:
-        ignore_paths: []
+      context: {}
     name: Child
     class_name: Model
     properties: {}

--- a/src/snapshot_middleware/snapshots/test__project_with_children.snap
+++ b/src/snapshot_middleware/snapshots/test__project_with_children.snap
@@ -9,6 +9,8 @@ metadata:
     Path: /foo/default.project.json
   relevant_paths:
     - /foo/default.project.json
+  context:
+    ignore_paths: []
 name: children
 class_name: Folder
 properties: {}
@@ -25,6 +27,8 @@ children:
             ignore_unknown_instances: ~
             path: ~
       relevant_paths: []
+      context:
+        ignore_paths: []
     name: Child
     class_name: Model
     properties: {}

--- a/src/snapshot_middleware/snapshots/test__project_with_path_to_project.snap
+++ b/src/snapshot_middleware/snapshots/test__project_with_path_to_project.snap
@@ -10,6 +10,8 @@ metadata:
   relevant_paths:
     - /foo/other.project.json
     - /foo/default.project.json
+  context:
+    ignore_paths: []
 name: path-project
 class_name: Model
 properties: {}

--- a/src/snapshot_middleware/snapshots/test__project_with_path_to_project.snap
+++ b/src/snapshot_middleware/snapshots/test__project_with_path_to_project.snap
@@ -10,8 +10,7 @@ metadata:
   relevant_paths:
     - /foo/other.project.json
     - /foo/default.project.json
-  context:
-    ignore_paths: []
+  context: {}
 name: path-project
 class_name: Model
 properties: {}

--- a/src/snapshot_middleware/snapshots/test__project_with_path_to_project_with_children.snap
+++ b/src/snapshot_middleware/snapshots/test__project_with_path_to_project_with_children.snap
@@ -10,8 +10,7 @@ metadata:
   relevant_paths:
     - /foo/other.project.json
     - /foo/default.project.json
-  context:
-    ignore_paths: []
+  context: {}
 name: path-child-project
 class_name: Folder
 properties: {}
@@ -28,8 +27,7 @@ children:
             ignore_unknown_instances: ~
             path: ~
       relevant_paths: []
-      context:
-        ignore_paths: []
+      context: {}
     name: SomeChild
     class_name: Model
     properties: {}

--- a/src/snapshot_middleware/snapshots/test__project_with_path_to_project_with_children.snap
+++ b/src/snapshot_middleware/snapshots/test__project_with_path_to_project_with_children.snap
@@ -10,6 +10,8 @@ metadata:
   relevant_paths:
     - /foo/other.project.json
     - /foo/default.project.json
+  context:
+    ignore_paths: []
 name: path-child-project
 class_name: Folder
 properties: {}
@@ -26,6 +28,8 @@ children:
             ignore_unknown_instances: ~
             path: ~
       relevant_paths: []
+      context:
+        ignore_paths: []
     name: SomeChild
     class_name: Model
     properties: {}

--- a/src/snapshot_middleware/snapshots/test__project_with_path_to_txt.snap
+++ b/src/snapshot_middleware/snapshots/test__project_with_path_to_txt.snap
@@ -11,8 +11,7 @@ metadata:
     - /foo/other.txt
     - /foo/other.meta.json
     - /foo/default.project.json
-  context:
-    ignore_paths: []
+  context: {}
 name: path-project
 class_name: StringValue
 properties:

--- a/src/snapshot_middleware/snapshots/test__project_with_path_to_txt.snap
+++ b/src/snapshot_middleware/snapshots/test__project_with_path_to_txt.snap
@@ -11,6 +11,8 @@ metadata:
     - /foo/other.txt
     - /foo/other.meta.json
     - /foo/default.project.json
+  context:
+    ignore_paths: []
 name: path-project
 class_name: StringValue
 properties:

--- a/src/snapshot_middleware/snapshots/test__project_with_resolved_properties.snap
+++ b/src/snapshot_middleware/snapshots/test__project_with_resolved_properties.snap
@@ -9,6 +9,8 @@ metadata:
     Path: /foo/default.project.json
   relevant_paths:
     - /foo/default.project.json
+  context:
+    ignore_paths: []
 name: resolved-properties
 class_name: StringValue
 properties:

--- a/src/snapshot_middleware/snapshots/test__project_with_resolved_properties.snap
+++ b/src/snapshot_middleware/snapshots/test__project_with_resolved_properties.snap
@@ -9,8 +9,7 @@ metadata:
     Path: /foo/default.project.json
   relevant_paths:
     - /foo/default.project.json
-  context:
-    ignore_paths: []
+  context: {}
 name: resolved-properties
 class_name: StringValue
 properties:

--- a/src/snapshot_middleware/snapshots/test__project_with_unresolved_properties.snap
+++ b/src/snapshot_middleware/snapshots/test__project_with_unresolved_properties.snap
@@ -9,6 +9,8 @@ metadata:
     Path: /foo/default.project.json
   relevant_paths:
     - /foo/default.project.json
+  context:
+    ignore_paths: []
 name: unresolved-properties
 class_name: StringValue
 properties:

--- a/src/snapshot_middleware/snapshots/test__project_with_unresolved_properties.snap
+++ b/src/snapshot_middleware/snapshots/test__project_with_unresolved_properties.snap
@@ -9,8 +9,7 @@ metadata:
     Path: /foo/default.project.json
   relevant_paths:
     - /foo/default.project.json
-  context:
-    ignore_paths: []
+  context: {}
 name: unresolved-properties
 class_name: StringValue
 properties:

--- a/src/snapshot_middleware/snapshots/test__script_disabled.snap
+++ b/src/snapshot_middleware/snapshots/test__script_disabled.snap
@@ -10,8 +10,7 @@ metadata:
   relevant_paths:
     - /bar.server.lua
     - /bar.meta.json
-  context:
-    ignore_paths: []
+  context: {}
 name: bar
 class_name: Script
 properties:

--- a/src/snapshot_middleware/snapshots/test__script_disabled.snap
+++ b/src/snapshot_middleware/snapshots/test__script_disabled.snap
@@ -10,6 +10,8 @@ metadata:
   relevant_paths:
     - /bar.server.lua
     - /bar.meta.json
+  context:
+    ignore_paths: []
 name: bar
 class_name: Script
 properties:

--- a/src/snapshot_middleware/snapshots/test__script_with_meta.snap
+++ b/src/snapshot_middleware/snapshots/test__script_with_meta.snap
@@ -10,8 +10,7 @@ metadata:
   relevant_paths:
     - /foo.server.lua
     - /foo.meta.json
-  context:
-    ignore_paths: []
+  context: {}
 name: foo
 class_name: Script
 properties:

--- a/src/snapshot_middleware/snapshots/test__script_with_meta.snap
+++ b/src/snapshot_middleware/snapshots/test__script_with_meta.snap
@@ -10,6 +10,8 @@ metadata:
   relevant_paths:
     - /foo.server.lua
     - /foo.meta.json
+  context:
+    ignore_paths: []
 name: foo
 class_name: Script
 properties:

--- a/src/snapshot_middleware/snapshots/test__server_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/test__server_from_vfs.snap
@@ -10,8 +10,7 @@ metadata:
   relevant_paths:
     - /foo.server.lua
     - /foo.meta.json
-  context:
-    ignore_paths: []
+  context: {}
 name: foo
 class_name: Script
 properties:

--- a/src/snapshot_middleware/snapshots/test__server_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/test__server_from_vfs.snap
@@ -10,6 +10,8 @@ metadata:
   relevant_paths:
     - /foo.server.lua
     - /foo.meta.json
+  context:
+    ignore_paths: []
 name: foo
 class_name: Script
 properties:

--- a/src/snapshots/serve_session__change_file_in_project_after.snap
+++ b/src/snapshots/serve_session__change_file_in_project_after.snap
@@ -12,8 +12,7 @@ metadata:
     Path: /foo/default.project.json
   relevant_paths:
     - /foo/default.project.json
-  context:
-    ignore_paths: []
+  context: {}
 children:
   - id: id-2
     name: Child
@@ -35,6 +34,5 @@ children:
       relevant_paths:
         - /foo/file.txt
         - /foo/file.meta.json
-      context:
-        ignore_paths: []
+      context: {}
     children: []

--- a/src/snapshots/serve_session__change_file_in_project_after.snap
+++ b/src/snapshots/serve_session__change_file_in_project_after.snap
@@ -12,6 +12,8 @@ metadata:
     Path: /foo/default.project.json
   relevant_paths:
     - /foo/default.project.json
+  context:
+    ignore_paths: []
 children:
   - id: id-2
     name: Child
@@ -33,4 +35,6 @@ children:
       relevant_paths:
         - /foo/file.txt
         - /foo/file.meta.json
+      context:
+        ignore_paths: []
     children: []

--- a/src/snapshots/serve_session__change_file_in_project_before.snap
+++ b/src/snapshots/serve_session__change_file_in_project_before.snap
@@ -12,8 +12,7 @@ metadata:
     Path: /foo/default.project.json
   relevant_paths:
     - /foo/default.project.json
-  context:
-    ignore_paths: []
+  context: {}
 children:
   - id: id-2
     name: Child
@@ -35,6 +34,5 @@ children:
       relevant_paths:
         - /foo/file.txt
         - /foo/file.meta.json
-      context:
-        ignore_paths: []
+      context: {}
     children: []

--- a/src/snapshots/serve_session__change_file_in_project_before.snap
+++ b/src/snapshots/serve_session__change_file_in_project_before.snap
@@ -12,6 +12,8 @@ metadata:
     Path: /foo/default.project.json
   relevant_paths:
     - /foo/default.project.json
+  context:
+    ignore_paths: []
 children:
   - id: id-2
     name: Child
@@ -33,4 +35,6 @@ children:
       relevant_paths:
         - /foo/file.txt
         - /foo/file.meta.json
+      context:
+        ignore_paths: []
     children: []

--- a/src/snapshots/serve_session__change_script_meta_after.snap
+++ b/src/snapshots/serve_session__change_script_meta_after.snap
@@ -16,8 +16,7 @@ metadata:
     - /root/init.lua
     - /root/init.server.lua
     - /root/init.client.lua
-  context:
-    ignore_paths: []
+  context: {}
 children:
   - id: id-2
     name: test
@@ -33,6 +32,5 @@ children:
       relevant_paths:
         - /root/test.lua
         - /root/test.meta.json
-      context:
-        ignore_paths: []
+      context: {}
     children: []

--- a/src/snapshots/serve_session__change_script_meta_after.snap
+++ b/src/snapshots/serve_session__change_script_meta_after.snap
@@ -16,6 +16,8 @@ metadata:
     - /root/init.lua
     - /root/init.server.lua
     - /root/init.client.lua
+  context:
+    ignore_paths: []
 children:
   - id: id-2
     name: test
@@ -31,4 +33,6 @@ children:
       relevant_paths:
         - /root/test.lua
         - /root/test.meta.json
+      context:
+        ignore_paths: []
     children: []

--- a/src/snapshots/serve_session__change_script_meta_before.snap
+++ b/src/snapshots/serve_session__change_script_meta_before.snap
@@ -16,8 +16,7 @@ metadata:
     - /root/init.lua
     - /root/init.server.lua
     - /root/init.client.lua
-  context:
-    ignore_paths: []
+  context: {}
 children:
   - id: id-2
     name: test
@@ -33,6 +32,5 @@ children:
       relevant_paths:
         - /root/test.lua
         - /root/test.meta.json
-      context:
-        ignore_paths: []
+      context: {}
     children: []

--- a/src/snapshots/serve_session__change_script_meta_before.snap
+++ b/src/snapshots/serve_session__change_script_meta_before.snap
@@ -16,6 +16,8 @@ metadata:
     - /root/init.lua
     - /root/init.server.lua
     - /root/init.client.lua
+  context:
+    ignore_paths: []
 children:
   - id: id-2
     name: test
@@ -31,4 +33,6 @@ children:
       relevant_paths:
         - /root/test.lua
         - /root/test.meta.json
+      context:
+        ignore_paths: []
     children: []

--- a/src/snapshots/serve_session__change_script_meta_patch.snap
+++ b/src/snapshots/serve_session__change_script_meta_patch.snap
@@ -17,5 +17,4 @@ expression: redactions.redacted_yaml(changes)
           relevant_paths:
             - /root/test.lua
             - /root/test.meta.json
-          context:
-            ignore_paths: []
+          context: {}

--- a/src/snapshots/serve_session__change_script_meta_patch.snap
+++ b/src/snapshots/serve_session__change_script_meta_patch.snap
@@ -17,3 +17,5 @@ expression: redactions.redacted_yaml(changes)
           relevant_paths:
             - /root/test.lua
             - /root/test.meta.json
+          context:
+            ignore_paths: []

--- a/src/snapshots/serve_session__change_txt_file_after.snap
+++ b/src/snapshots/serve_session__change_txt_file_after.snap
@@ -16,4 +16,6 @@ metadata:
   relevant_paths:
     - /foo.txt
     - /foo.meta.json
+  context:
+    ignore_paths: []
 children: []

--- a/src/snapshots/serve_session__change_txt_file_after.snap
+++ b/src/snapshots/serve_session__change_txt_file_after.snap
@@ -16,6 +16,5 @@ metadata:
   relevant_paths:
     - /foo.txt
     - /foo.meta.json
-  context:
-    ignore_paths: []
+  context: {}
 children: []

--- a/src/snapshots/serve_session__change_txt_file_before.snap
+++ b/src/snapshots/serve_session__change_txt_file_before.snap
@@ -16,4 +16,6 @@ metadata:
   relevant_paths:
     - /foo.txt
     - /foo.meta.json
+  context:
+    ignore_paths: []
 children: []

--- a/src/snapshots/serve_session__change_txt_file_before.snap
+++ b/src/snapshots/serve_session__change_txt_file_before.snap
@@ -16,6 +16,5 @@ metadata:
   relevant_paths:
     - /foo.txt
     - /foo.meta.json
-  context:
-    ignore_paths: []
+  context: {}
 children: []

--- a/src/snapshots/serve_session__just_folder.snap
+++ b/src/snapshots/serve_session__just_folder.snap
@@ -16,4 +16,6 @@ metadata:
     - /foo/init.lua
     - /foo/init.server.lua
     - /foo/init.client.lua
+  context:
+    ignore_paths: []
 children: []

--- a/src/snapshots/serve_session__just_folder.snap
+++ b/src/snapshots/serve_session__just_folder.snap
@@ -16,6 +16,5 @@ metadata:
     - /foo/init.lua
     - /foo/init.server.lua
     - /foo/init.client.lua
-  context:
-    ignore_paths: []
+  context: {}
 children: []

--- a/src/snapshots/serve_session__project_with_folder.snap
+++ b/src/snapshots/serve_session__project_with_folder.snap
@@ -17,8 +17,7 @@ metadata:
     - /foo/src/init.server.lua
     - /foo/src/init.client.lua
     - /foo/default.project.json
-  context:
-    ignore_paths: []
+  context: {}
 children:
   - id: id-2
     name: hello
@@ -34,6 +33,5 @@ children:
       relevant_paths:
         - /foo/src/hello.txt
         - /foo/src/hello.meta.json
-      context:
-        ignore_paths: []
+      context: {}
     children: []

--- a/src/snapshots/serve_session__project_with_folder.snap
+++ b/src/snapshots/serve_session__project_with_folder.snap
@@ -17,6 +17,8 @@ metadata:
     - /foo/src/init.server.lua
     - /foo/src/init.client.lua
     - /foo/default.project.json
+  context:
+    ignore_paths: []
 children:
   - id: id-2
     name: hello
@@ -32,4 +34,6 @@ children:
       relevant_paths:
         - /foo/src/hello.txt
         - /foo/src/hello.meta.json
+      context:
+        ignore_paths: []
     children: []

--- a/src/snapshots/serve_session__script_with_meta.snap
+++ b/src/snapshots/serve_session__script_with_meta.snap
@@ -16,8 +16,7 @@ metadata:
     - /root/init.lua
     - /root/init.server.lua
     - /root/init.client.lua
-  context:
-    ignore_paths: []
+  context: {}
 children:
   - id: id-2
     name: test
@@ -33,6 +32,5 @@ children:
       relevant_paths:
         - /root/test.lua
         - /root/test.meta.json
-      context:
-        ignore_paths: []
+      context: {}
     children: []

--- a/src/snapshots/serve_session__script_with_meta.snap
+++ b/src/snapshots/serve_session__script_with_meta.snap
@@ -16,6 +16,8 @@ metadata:
     - /root/init.lua
     - /root/init.server.lua
     - /root/init.client.lua
+  context:
+    ignore_paths: []
 children:
   - id: id-2
     name: test
@@ -31,4 +33,6 @@ children:
       relevant_paths:
         - /root/test.lua
         - /root/test.meta.json
+      context:
+        ignore_paths: []
     children: []


### PR DESCRIPTION
This is part of #268.

Introduces a new type, `InstanceContext`, that's attached to each snapshot and will be persisted. This PR is effectively introducing it as a dummy type in order to update the affected snapshots, and it'll be filled out as part of the glob feature.