### PR TITLE
Attach context to instances from snapshots

### DIFF
--- a/src/snapshot_middleware/dir.rs
+++ b/src/snapshot_middleware/dir.rs
@@ -64,7 +64,8 @@ impl SnapshotMiddleware for SnapshotDir {
             .metadata(
                 InstanceMetadata::new()
                     .instigating_source(entry.path())
-                    .relevant_paths(relevant_paths),
+                    .relevant_paths(relevant_paths)
+                    .context(context),
             );
 
         if let Some(meta_entry) = vfs.get(meta_path).with_not_found()? {

--- a/src/snapshot_middleware/json_model.rs
+++ b/src/snapshot_middleware/json_model.rs
@@ -18,7 +18,7 @@ pub struct SnapshotJsonModel;
 
 impl SnapshotMiddleware for SnapshotJsonModel {
     fn from_vfs<F: VfsFetcher>(
-        _context: &InstanceContext,
+        context: &InstanceContext,
         vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult {
@@ -54,8 +54,11 @@ impl SnapshotMiddleware for SnapshotJsonModel {
 
         let mut snapshot = instance.core.into_snapshot(instance_name.to_owned());
 
-        snapshot.metadata.instigating_source = Some(entry.path().to_path_buf().into());
-        snapshot.metadata.relevant_paths = vec![entry.path().to_path_buf()];
+        snapshot.metadata = snapshot
+            .metadata
+            .instigating_source(entry.path())
+            .relevant_paths(vec![entry.path().to_path_buf()])
+            .context(context);
 
         Ok(Some(snapshot))
     }

--- a/src/snapshot_middleware/rbxlx.rs
+++ b/src/snapshot_middleware/rbxlx.rs
@@ -12,7 +12,7 @@ pub struct SnapshotRbxlx;
 
 impl SnapshotMiddleware for SnapshotRbxlx {
     fn from_vfs<F: VfsFetcher>(
-        _context: &InstanceContext,
+        context: &InstanceContext,
         vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult {
@@ -38,7 +38,8 @@ impl SnapshotMiddleware for SnapshotRbxlx {
             .metadata(
                 InstanceMetadata::new()
                     .instigating_source(entry.path())
-                    .relevant_paths(vec![entry.path().to_path_buf()]),
+                    .relevant_paths(vec![entry.path().to_path_buf()])
+                    .context(context),
             );
 
         Ok(Some(snapshot))

--- a/src/snapshot_middleware/rbxm.rs
+++ b/src/snapshot_middleware/rbxm.rs
@@ -16,7 +16,7 @@ pub struct SnapshotRbxm;
 
 impl SnapshotMiddleware for SnapshotRbxm {
     fn from_vfs<F: VfsFetcher>(
-        _context: &InstanceContext,
+        context: &InstanceContext,
         vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult {
@@ -48,7 +48,8 @@ impl SnapshotMiddleware for SnapshotRbxm {
                 .metadata(
                     InstanceMetadata::new()
                         .instigating_source(entry.path())
-                        .relevant_paths(vec![entry.path().to_path_buf()]),
+                        .relevant_paths(vec![entry.path().to_path_buf()])
+                        .context(context),
                 );
 
             Ok(Some(snapshot))

--- a/src/snapshot_middleware/rbxmx.rs
+++ b/src/snapshot_middleware/rbxmx.rs
@@ -12,7 +12,7 @@ pub struct SnapshotRbxmx;
 
 impl SnapshotMiddleware for SnapshotRbxmx {
     fn from_vfs<F: VfsFetcher>(
-        _context: &InstanceContext,
+        context: &InstanceContext,
         vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult {
@@ -40,7 +40,8 @@ impl SnapshotMiddleware for SnapshotRbxmx {
                 .metadata(
                     InstanceMetadata::new()
                         .instigating_source(entry.path())
-                        .relevant_paths(vec![entry.path().to_path_buf()]),
+                        .relevant_paths(vec![entry.path().to_path_buf()])
+                        .context(context),
                 );
 
             Ok(Some(snapshot))

--- a/src/snapshot_middleware/txt.rs
+++ b/src/snapshot_middleware/txt.rs
@@ -19,7 +19,7 @@ pub struct SnapshotTxt;
 
 impl SnapshotMiddleware for SnapshotTxt {
     fn from_vfs<F: VfsFetcher>(
-        _context: &InstanceContext,
+        context: &InstanceContext,
         vfs: &Vfs<F>,
         entry: &VfsEntry,
     ) -> SnapshotInstanceResult {
@@ -54,7 +54,8 @@ impl SnapshotMiddleware for SnapshotTxt {
             .metadata(
                 InstanceMetadata::new()
                     .instigating_source(entry.path())
-                    .relevant_paths(vec![entry.path().to_path_buf(), meta_path.clone()]),
+                    .relevant_paths(vec![entry.path().to_path_buf(), meta_path.clone()])
+                    .context(context),
             );
 
         if let Some(meta_entry) = vfs.get(meta_path).with_not_found()? {


### PR DESCRIPTION
Split off of #268.

This finishes the transition to the new `InstanceContext` concept by attaching it to each instance as necessary.