### PR TITLE
Implement 'rojo build --watch'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ serde_json = "1.0"
 snafu = "0.6.0"
 structopt = "0.3.5"
 termcolor = "1.0.5"
+tokio = "0.1.22"
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 
 [target.'cfg(windows)'.dependencies]
@@ -89,5 +90,4 @@ paste = "0.1"
 pretty_assertions = "0.6.1"
 serde_yaml = "0.8.9"
 tempfile = "3.0"
-tokio = "0.1.22"
 walkdir = "2.1"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -140,6 +140,10 @@ pub struct BuildCommand {
     /// Where to output the result.
     #[structopt(long, short)]
     pub output: PathBuf,
+
+    /// Whether to automatically rebuild when any input files change.
+    #[structopt(long)]
+    pub watch: bool,
 }
 
 impl BuildCommand {


### PR DESCRIPTION
Closes #92.

This PR refactors the build command slightly to add a `--watch` argument. When set, Rojo will continuously rebuild the model when any of its inputs change.