### PR TITLE
change server bind address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Rojo Changelog
 
 ## Unreleased Changes
+* Added `--address` flag to `rojo serve` to allow for external connections. ([#403][pr-403])
+
+[pr-403]: https://github.com/rojo-rbx/rojo/pull/403
 
 ## [7.0.0-alpha.2][7.0.0-alpha.2] (February 19, 2021)
 * Fixed incorrect protocol version between the client and server.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,7 +7,15 @@ mod plugin;
 mod serve;
 mod upload;
 
-use std::{borrow::Cow, env, error::Error, fmt, net::IpAddr, path::{Path, PathBuf}, str::FromStr};
+use std::{
+    borrow::Cow,
+    env,
+    error::Error,
+    fmt,
+    net::IpAddr,
+    path::{Path, PathBuf},
+    str::FromStr
+};
 
 use structopt::StructOpt;
 use thiserror::Error;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -187,7 +187,7 @@ pub struct ServeCommand {
     #[structopt(default_value = "")]
     pub project: PathBuf,
 
-    /// The IPv4 address to listen on. Defaults to `127.0.0.1`
+    /// The IP address to listen on. Defaults to `127.0.0.1`.
     #[structopt(long)]
     pub address: Option<IpAddr>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,7 +14,7 @@ use std::{
     fmt,
     net::IpAddr,
     path::{Path, PathBuf},
-    str::FromStr
+    str::FromStr,
 };
 
 use structopt::StructOpt;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,14 +7,7 @@ mod plugin;
 mod serve;
 mod upload;
 
-use std::{
-    borrow::Cow,
-    env,
-    error::Error,
-    fmt,
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use std::{borrow::Cow, env, error::Error, fmt, net::IpAddr, path::{Path, PathBuf}, str::FromStr};
 
 use structopt::StructOpt;
 use thiserror::Error;
@@ -186,7 +179,11 @@ pub struct ServeCommand {
     #[structopt(default_value = "")]
     pub project: PathBuf,
 
-    /// The port to listen on. Defaults to the project's preference, or 34872 if
+    /// The IPv4 address to listen on. Defaults to `127.0.0.1`
+    #[structopt(long)]
+    pub address: Option<IpAddr>,
+
+    /// The port to listen on. Defaults to the project's preference, or `34872` if
     /// it has none.
     #[structopt(long)]
     pub port: Option<u16>,

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -46,7 +46,12 @@ fn show_start_message(bind_address: IpAddr, port: u16, color: ColorChoice) -> io
 
     write!(&mut buffer, "  Address: ")?;
     buffer.set_color(ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true))?;
-    writeln!(&mut buffer, "{}", bind_address)?;
+
+    if bind_address.is_loopback() {
+        writeln!(&mut buffer, "localhost")?;
+    } else {
+        writeln!(&mut buffer, "{}", bind_address)?;
+    }
 
     buffer.set_color(&ColorSpec::new())?;
     write!(&mut buffer, "  Port:    ")?;

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -15,7 +15,7 @@ use crate::{
     web::LiveServer,
 };
 
-const DEFAULT_BIND_ADDRESS: [u8; 4] = [127, 0, 0, 1];
+const DEFAULT_BIND_ADDRESS: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
 const DEFAULT_PORT: u16 = 34872;
 
 pub fn serve(global: GlobalOptions, options: ServeCommand) -> Result<()> {
@@ -23,9 +23,7 @@ pub fn serve(global: GlobalOptions, options: ServeCommand) -> Result<()> {
 
     let session = Arc::new(ServeSession::new(vfs, &options.absolute_project())?);
 
-    let bind_address = options
-        .address
-        .unwrap_or(IpAddr::V4(Ipv4Addr::from(DEFAULT_BIND_ADDRESS)));
+    let ip = options.address.unwrap_or(DEFAULT_BIND_ADDRESS.into());
 
     let port = options
         .port
@@ -34,8 +32,8 @@ pub fn serve(global: GlobalOptions, options: ServeCommand) -> Result<()> {
 
     let server = LiveServer::new(session);
 
-    let _ = show_start_message(bind_address, port, global.color.into());
-    server.start(bind_address, port);
+    let _ = show_start_message(ip, port, global.color.into());
+    server.start((ip, port).into());
 
     Ok(())
 }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -1,4 +1,9 @@
-use std::{io::{self, Write}, net::IpAddr, net::Ipv4Addr, sync::Arc};
+use std::{
+    io::{self, Write},
+    net::IpAddr,
+    net::Ipv4Addr,
+    sync::Arc,
+};
 
 use anyhow::Result;
 use memofs::Vfs;
@@ -10,7 +15,7 @@ use crate::{
     web::LiveServer,
 };
 
-const DEFAULT_BIND_ADDRESS: [u8;4] = [127, 0, 0, 1];
+const DEFAULT_BIND_ADDRESS: [u8; 4] = [127, 0, 0, 1];
 const DEFAULT_PORT: u16 = 34872;
 
 pub fn serve(global: GlobalOptions, options: ServeCommand) -> Result<()> {

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -1,7 +1,4 @@
-use std::{
-    io::{self, Write},
-    sync::Arc,
-};
+use std::{io::{self, Write}, net::IpAddr, net::Ipv4Addr, sync::Arc};
 
 use anyhow::Result;
 use memofs::Vfs;
@@ -13,12 +10,17 @@ use crate::{
     web::LiveServer,
 };
 
+const DEFAULT_BIND_ADDRESS: [u8;4] = [127, 0, 0, 1];
 const DEFAULT_PORT: u16 = 34872;
 
 pub fn serve(global: GlobalOptions, options: ServeCommand) -> Result<()> {
     let vfs = Vfs::new_default();
 
     let session = Arc::new(ServeSession::new(vfs, &options.absolute_project())?);
+
+    let bind_address = options
+        .address
+        .unwrap_or(IpAddr::V4(Ipv4Addr::from(DEFAULT_BIND_ADDRESS)));
 
     let port = options
         .port
@@ -27,13 +29,13 @@ pub fn serve(global: GlobalOptions, options: ServeCommand) -> Result<()> {
 
     let server = LiveServer::new(session);
 
-    let _ = show_start_message(port, global.color.into());
-    server.start(port);
+    let _ = show_start_message(bind_address, port, global.color.into());
+    server.start(bind_address, port);
 
     Ok(())
 }
 
-fn show_start_message(port: u16, color: ColorChoice) -> io::Result<()> {
+fn show_start_message(bind_address: IpAddr, port: u16, color: ColorChoice) -> io::Result<()> {
     let writer = BufferWriter::stdout(color);
     let mut buffer = writer.buffer();
 
@@ -41,7 +43,7 @@ fn show_start_message(port: u16, color: ColorChoice) -> io::Result<()> {
 
     write!(&mut buffer, "  Address: ")?;
     buffer.set_color(ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true))?;
-    writeln!(&mut buffer, "localhost")?;
+    writeln!(&mut buffer, "{}", bind_address)?;
 
     buffer.set_color(&ColorSpec::new())?;
     write!(&mut buffer, "  Port:    ")?;

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -4,7 +4,7 @@ pub mod interface;
 mod ui;
 mod util;
 
-use std::sync::Arc;
+use std::{net::IpAddr, sync::Arc};
 
 use futures::{
     future::{self, FutureResult},
@@ -57,8 +57,8 @@ impl LiveServer {
         LiveServer { serve_session }
     }
 
-    pub fn start(self, port: u16) {
-        let address = ([0, 0, 0, 0], port).into();
+    pub fn start(self, bind_address: IpAddr, port: u16) {
+        let address = (bind_address, port).into();
 
         let server = Server::bind(&address)
             .serve(move || {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -4,7 +4,7 @@ pub mod interface;
 mod ui;
 mod util;
 
-use std::{net::IpAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc};
 
 use futures::{
     future::{self, FutureResult},
@@ -57,9 +57,7 @@ impl LiveServer {
         LiveServer { serve_session }
     }
 
-    pub fn start(self, bind_address: IpAddr, port: u16) {
-        let address = (bind_address, port).into();
-
+    pub fn start(self, address: SocketAddr) {
         let server = Server::bind(&address)
             .serve(move || {
                 let service: FutureResult<_, hyper::Error> =

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -58,7 +58,7 @@ impl LiveServer {
     }
 
     pub fn start(self, port: u16) {
-        let address = ([127, 0, 0, 1], port).into();
+        let address = ([0, 0, 0, 0], port).into();
 
         let server = Server::bind(&address)
             .serve(move || {


### PR DESCRIPTION
127.0.0.1 is a loopback interface, and only works on the same host
binding to 0.0.0.0 will allow connections from other hosts and will actually give purpose to the IP field on the plugin

i have a laptop running linux (so cannot use studio) and another host running windows, where i RDP to for studio - i was wondering why it couldn't connect. rebuilt with these changes and it can now listen to the linux host

previously:
```
[Rojo-Warn] Disconnected from an error: Couldn't connect to the Rojo server.
[Rojo-Warn] Make sure the server is running — use 'rojo serve' to run it!
```
now:
![image](https://user-images.githubusercontent.com/27443298/110217836-01dc4c00-7ebf-11eb-9dbc-bcb945125085.png)
*using stable, but change is universal*