### PR TITLE
Block usage of "Name" or "Parent" in $properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * Added the `gameId` and `placeId` optional properties to project files.
     * When connecting from the Rojo Roblox Studio plugin, Rojo will set the game and place ID of the current place to these values, if set.
     * This is equivalent to running `game:SetUniverseId(...)` and `game:SetPlaceId(...)` from the command bar in Studio. 
+* Fixed `Name` and `Parent` properties being allowed in Rojo projects. ([#413](pr-413))
+
+[pr-413]: https://github.com/rojo-rbx/rojo/pull/413
 
 ## [7.0.0-alpha.3][7.0.0-alpha.3] (February 19, 2021)
 * Updated dependencies, fixing `OptionalCoordinateFrame`-related issues.

--- a/src/snapshot_middleware/project.rs
+++ b/src/snapshot_middleware/project.rs
@@ -13,6 +13,8 @@ use crate::{
 
 use super::{middleware::SnapshotInstanceResult, snapshot_from_vfs};
 
+const BANNED_PROPERTIES: [&str; 2] = ["Parent", "Name"];
+
 pub fn snapshot_project(
     context: &InstanceContext,
     vfs: &Vfs,
@@ -182,6 +184,15 @@ pub fn snapshot_project_node(
                 )
             })?;
 
+        if BANNED_PROPERTIES.contains(&key.as_str()) {
+            log::warn!(
+                "Property '{}' cannot be set manually, ignoring. Attempted to set in '{}' at {}",
+                key,
+                instance_name,
+                project_path.display()
+            );
+            continue;
+        }
         properties.insert(key.clone(), value);
     }
 

--- a/src/snapshot_middleware/project.rs
+++ b/src/snapshot_middleware/project.rs
@@ -13,8 +13,6 @@ use crate::{
 
 use super::{middleware::SnapshotInstanceResult, snapshot_from_vfs};
 
-const BANNED_PROPERTIES: [&str; 2] = ["Parent", "Name"];
-
 pub fn snapshot_project(
     context: &InstanceContext,
     vfs: &Vfs,
@@ -184,15 +182,20 @@ pub fn snapshot_project_node(
                 )
             })?;
 
-        if BANNED_PROPERTIES.contains(&key.as_str()) {
-            log::warn!(
-                "Property '{}' cannot be set manually, ignoring. Attempted to set in '{}' at {}",
-                key,
-                instance_name,
-                project_path.display()
-            );
-            continue;
+        match key.as_str() {
+            "Name" | "Parent" => {
+                log::warn!(
+                    "Property '{}' cannot be set manually, ignoring. Attempted to set in '{}' at {}",
+                    key,
+                    instance_name,
+                    project_path.display()
+                );
+                continue;
+            }
+
+            _ => {}
         }
+
         properties.insert(key.clone(), value);
     }
 


### PR DESCRIPTION
Closes #391.

This pull makes the usage of "Name"/"Parent" in $properties ignored, with a warning to the user that said properties cannot be set. Maybe exiting with an error would be better?