### PR TITLE
Upgrade to Tokio 1.x, futures 0.3, Hyper 0.14, etc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: [stable, "1.43.1"]
+        rust_version: [stable, "1.46.0"]
 
     steps:
     - uses: actions/checkout@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+
+[[package]]
 name = "cast"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,13 +717,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
+name = "futures"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+
+[[package]]
 name = "futures-cpupool"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 dependencies = [
- "futures",
+ "futures 0.1.31",
  "num_cpus",
+]
+
+[[package]]
+name = "futures-executor"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
+dependencies = [
+ "autocfg 1.0.1",
+ "proc-macro-hack",
+ "proc-macro2 1.0.28",
+ "quote 1.0.9",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+
+[[package]]
+name = "futures-task"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+
+[[package]]
+name = "futures-util"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+dependencies = [
+ "autocfg 1.0.1",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
 ]
 
 [[package]]
@@ -777,10 +877,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 dependencies = [
  "byteorder",
- "bytes",
+ "bytes 0.4.12",
  "fnv",
- "futures",
- "http",
+ "futures 0.1.31",
+ "http 0.1.21",
  "indexmap",
  "log",
  "slab",
@@ -830,7 +930,18 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+dependencies = [
+ "bytes 1.0.1",
  "fnv",
  "itoa",
 ]
@@ -841,10 +952,21 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 dependencies = [
- "bytes",
- "futures",
- "http",
+ "bytes 0.4.12",
+ "futures 0.1.31",
+ "http 0.1.21",
  "tokio-buf",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+dependencies = [
+ "bytes 1.0.1",
+ "http 0.2.4",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -852,6 +974,12 @@ name = "httparse"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
+
+[[package]]
+name = "httpdate"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "humantime"
@@ -865,12 +993,12 @@ version = "0.12.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c843caf6296fc1f93444735205af9ed4e109a539005abb2564ae1d6fad34c52"
 dependencies = [
- "bytes",
- "futures",
+ "bytes 0.4.12",
+ "futures 0.1.31",
  "futures-cpupool",
  "h2",
- "http",
- "http-body",
+ "http 0.1.21",
+ "http-body 0.1.0",
  "httparse",
  "iovec",
  "itoa",
@@ -878,7 +1006,7 @@ dependencies = [
  "net2",
  "rustc_version 0.2.3",
  "time",
- "tokio",
+ "tokio 0.1.22",
  "tokio-buf",
  "tokio-executor",
  "tokio-io",
@@ -886,7 +1014,29 @@ dependencies = [
  "tokio-tcp",
  "tokio-threadpool",
  "tokio-timer",
- "want",
+ "want 0.2.0",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.4",
+ "http-body 0.4.2",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "tokio 1.9.0",
+ "tower-service",
+ "tracing",
+ "want 0.3.0",
 ]
 
 [[package]]
@@ -895,9 +1045,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 dependencies = [
- "bytes",
- "futures",
- "hyper",
+ "bytes 0.4.12",
+ "futures 0.1.31",
+ "hyper 0.12.36",
  "native-tls",
  "tokio-io",
 ]
@@ -1192,17 +1342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio",
-]
-
-[[package]]
 name = "miow"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1584,18 @@ dependencies = [
  "pest",
  "sha-1",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1939,14 +2090,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab"
 dependencies = [
  "base64 0.10.1",
- "bytes",
+ "bytes 0.4.12",
  "cookie",
  "cookie_store",
  "encoding_rs",
  "flate2",
- "futures",
- "http",
- "hyper",
+ "futures 0.1.31",
+ "http 0.1.21",
+ "hyper 0.12.36",
  "hyper-tls",
  "log",
  "mime",
@@ -1956,7 +2107,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "time",
- "tokio",
+ "tokio 0.1.22",
  "tokio-executor",
  "tokio-io",
  "tokio-threadpool",
@@ -2047,10 +2198,10 @@ dependencies = [
  "csv",
  "env_logger",
  "fs-err",
- "futures",
+ "futures 0.3.16",
  "globset",
  "humantime",
- "hyper",
+ "hyper 0.14.11",
  "insta",
  "jod-thread",
  "lazy_static",
@@ -2079,7 +2230,7 @@ dependencies = [
  "tempfile",
  "termcolor",
  "thiserror",
- "tokio",
+ "tokio 1.9.0",
  "uuid 0.8.2",
  "walkdir",
  "winreg 0.9.0",
@@ -2305,7 +2456,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
 ]
 
 [[package]]
@@ -2470,22 +2621,28 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 dependencies = [
- "bytes",
- "futures",
+ "bytes 0.4.12",
+ "futures 0.1.31",
  "mio",
  "num_cpus",
- "tokio-codec",
  "tokio-current-thread",
  "tokio-executor",
- "tokio-fs",
  "tokio-io",
  "tokio-reactor",
- "tokio-sync",
  "tokio-tcp",
  "tokio-threadpool",
  "tokio-timer",
- "tokio-udp",
- "tokio-uds",
+]
+
+[[package]]
+name = "tokio"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
+dependencies = [
+ "autocfg 1.0.1",
+ "num_cpus",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2494,20 +2651,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "either",
- "futures",
-]
-
-[[package]]
-name = "tokio-codec"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
-dependencies = [
- "bytes",
- "futures",
- "tokio-io",
+ "futures 0.1.31",
 ]
 
 [[package]]
@@ -2516,7 +2662,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e"
 dependencies = [
- "futures",
+ "futures 0.1.31",
  "tokio-executor",
 ]
 
@@ -2527,18 +2673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
  "crossbeam-utils 0.7.2",
- "futures",
-]
-
-[[package]]
-name = "tokio-fs"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4"
-dependencies = [
- "futures",
- "tokio-io",
- "tokio-threadpool",
+ "futures 0.1.31",
 ]
 
 [[package]]
@@ -2547,8 +2682,8 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
- "bytes",
- "futures",
+ "bytes 0.4.12",
+ "futures 0.1.31",
  "log",
 ]
 
@@ -2559,7 +2694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
  "crossbeam-utils 0.7.2",
- "futures",
+ "futures 0.1.31",
  "lazy_static",
  "log",
  "mio",
@@ -2578,7 +2713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
 dependencies = [
  "fnv",
- "futures",
+ "futures 0.1.31",
 ]
 
 [[package]]
@@ -2587,8 +2722,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
 dependencies = [
- "bytes",
- "futures",
+ "bytes 0.4.12",
+ "futures 0.1.31",
  "iovec",
  "mio",
  "tokio-io",
@@ -2604,7 +2739,7 @@ dependencies = [
  "crossbeam-deque 0.7.3",
  "crossbeam-queue",
  "crossbeam-utils 0.7.2",
- "futures",
+ "futures 0.1.31",
  "lazy_static",
  "log",
  "num_cpus",
@@ -2619,42 +2754,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
  "crossbeam-utils 0.7.2",
- "futures",
+ "futures 0.1.31",
  "slab",
  "tokio-executor",
 ]
 
 [[package]]
-name = "tokio-udp"
-version = "0.1.6"
+name = "tower-service"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+
+[[package]]
+name = "tracing"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
- "bytes",
- "futures",
- "log",
- "mio",
- "tokio-codec",
- "tokio-io",
- "tokio-reactor",
+ "cfg-if 1.0.0",
+ "pin-project-lite",
+ "tracing-core",
 ]
 
 [[package]]
-name = "tokio-uds"
-version = "0.2.7"
+name = "tracing-core"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab57a4ac4111c8c9dbcf70779f6fc8bc35ae4b2454809febac840ad19bd7e4e0"
+checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
- "bytes",
- "futures",
- "iovec",
- "libc",
- "log",
- "mio",
- "mio-uds",
- "tokio-codec",
- "tokio-io",
- "tokio-reactor",
+ "lazy_static",
 ]
 
 [[package]]
@@ -2812,7 +2940,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 dependencies = [
- "futures",
+ "futures 0.1.31",
+ "log",
+ "try-lock",
+]
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
  "log",
  "try-lock",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,6 +1033,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "socket2",
  "tokio 1.9.0",
  "tower-service",
  "tracing",
@@ -1323,10 +1324,23 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+dependencies = [
+ "libc",
+ "log",
+ "miow 0.3.7",
+ "ntapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1337,7 +1351,7 @@ checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
  "log",
- "mio",
+ "mio 0.6.23",
  "slab",
 ]
 
@@ -1351,6 +1365,15 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1394,9 +1417,18 @@ dependencies = [
  "fsevent-sys",
  "inotify",
  "libc",
- "mio",
+ "mio 0.6.23",
  "mio-extras",
  "walkdir",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
  "winapi 0.3.9",
 ]
 
@@ -2451,6 +2483,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "string"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2623,7 +2665,7 @@ checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
- "mio",
+ "mio 0.6.23",
  "num_cpus",
  "tokio-current-thread",
  "tokio-executor",
@@ -2641,8 +2683,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
 dependencies = [
  "autocfg 1.0.1",
+ "libc",
+ "mio 0.7.13",
  "num_cpus",
  "pin-project-lite",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2697,7 +2742,7 @@ dependencies = [
  "futures 0.1.31",
  "lazy_static",
  "log",
- "mio",
+ "mio 0.6.23",
  "num_cpus",
  "parking_lot",
  "slab",
@@ -2725,7 +2770,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
  "iovec",
- "mio",
+ "mio 0.6.23",
  "tokio-io",
  "tokio-reactor",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ fs-err = "2.2.0"
 futures = "0.3.16"
 globset = "0.4.4"
 humantime = "2.1.0"
-hyper = "0.14.11"
+hyper = { version = "0.14.11", features = ["server", "http1"] }
 jod-thread = "0.1.0"
 lazy_static = "1.4.0"
 log = "0.4.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ fs-err = "2.2.0"
 futures = "0.3.16"
 globset = "0.4.4"
 humantime = "2.1.0"
-hyper = { version = "0.14.11", features = ["server", "http1"] }
+hyper = { version = "0.14.11", features = ["server", "tcp", "http1"] }
 jod-thread = "0.1.0"
 lazy_static = "1.4.0"
 log = "0.4.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,10 +67,10 @@ crossbeam-channel = "0.5.1"
 csv = "1.1.1"
 env_logger = "0.9.0"
 fs-err = "2.2.0"
-futures = "0.1.29"
+futures = "0.3.16"
 globset = "0.4.4"
 humantime = "2.1.0"
-hyper = "0.12.35"
+hyper = "0.14.11"
 jod-thread = "0.1.0"
 lazy_static = "1.4.0"
 log = "0.4.8"
@@ -87,7 +87,7 @@ serde_json = "1.0"
 structopt = "0.3.5"
 termcolor = "1.0.5"
 thiserror = "1.0.11"
-tokio = "0.1.22"
+tokio = { version = "1.9.0", features = ["rt", "rt-multi-thread"] }
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Check out our [contribution guide](CONTRIBUTING.md) for detailed instructions fo
 
 Pull requests are welcome!
 
-Rojo supports Rust 1.43.1 and newer. The minimum supported version of Rust is based on the latest versions of the dependencies that Rojo has.
+Rojo supports Rust 1.46.0 and newer. The minimum supported version of Rust is based on the latest versions of the dependencies that Rojo has.
 
 ## License
 Rojo is available under the terms of the Mozilla Public License, Version 2.0. See [LICENSE.txt](LICENSE.txt) for details.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,13 @@
 <div align="center">
-    <a href="https://rojo.space">
-        <img src="assets/logo-512.png" alt="Rojo" height="217" />
-    </a>
+    <a href="https://rojo.space"><img src="assets/logo-512.png" alt="Rojo" height="217" /></a>
 </div>
 
 <div>&nbsp;</div>
 
 <div align="center">
-    <a href="https://github.com/rojo-rbx/rojo/actions">
-        <img src="https://github.com/rojo-rbx/rojo/workflows/CI/badge.svg" alt="Actions status" />
-    </a>
-    <a href="https://crates.io/crates/rojo">
-        <img src="https://img.shields.io/crates/v/rojo.svg?label=latest%20release" alt="Latest server version" />
-    </a>
-    <a href="https://rojo.space/docs">
-        <img src="https://img.shields.io/badge/docs-website-brightgreen.svg" alt="Rojo Documentation" />
-    </a>
+    <a href="https://github.com/rojo-rbx/rojo/actions"><img src="https://github.com/rojo-rbx/rojo/workflows/CI/badge.svg" alt="Actions status" /></a>
+    <a href="https://crates.io/crates/rojo"><img src="https://img.shields.io/crates/v/rojo.svg?label=latest%20release" alt="Latest server version" /></a>
+    <a href="https://rojo.space/docs"><img src="https://img.shields.io/badge/docs-website-brightgreen.svg" alt="Rojo Documentation" /></a>
 </div>
 
 <hr />

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -50,7 +50,7 @@ impl BuildCommand {
         write_model(&session, &self.output, output_kind)?;
 
         if self.watch {
-            let mut rt = Runtime::new().unwrap();
+            let rt = Runtime::new().unwrap();
 
             loop {
                 let receiver = session.message_queue().subscribe(cursor);

--- a/src/message_queue.rs
+++ b/src/message_queue.rs
@@ -1,6 +1,6 @@
 use std::sync::{Mutex, RwLock};
 
-use futures::sync::oneshot;
+use futures::channel::oneshot;
 
 /// A message queue with persistent history that can be subscribed to.
 ///

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -3,9 +3,7 @@
 
 use std::{collections::HashMap, fs, path::PathBuf, str::FromStr, sync::Arc};
 
-use futures::{Future, Stream};
-
-use hyper::{service::Service, Body, Method, Request, StatusCode};
+use hyper::{body, Body, Method, Request, Response, StatusCode};
 use rbx_dom_weak::types::Ref;
 
 use crate::{
@@ -21,36 +19,32 @@ use crate::{
     },
 };
 
-pub struct ApiService {
-    serve_session: Arc<ServeSession>,
+pub async fn call(serve_session: Arc<ServeSession>, request: Request<Body>) -> Response<Body> {
+    let service = ApiService::new(serve_session);
+
+    match (request.method(), request.uri().path()) {
+        (&Method::GET, "/api/rojo") => service.handle_api_rojo().await,
+        (&Method::GET, path) if path.starts_with("/api/read/") => {
+            service.handle_api_read(request).await
+        }
+        (&Method::GET, path) if path.starts_with("/api/subscribe/") => {
+            service.handle_api_subscribe(request).await
+        }
+        (&Method::POST, path) if path.starts_with("/api/open/") => {
+            service.handle_api_open(request).await
+        }
+
+        (&Method::POST, "/api/write") => service.handle_api_write(request).await,
+
+        (_method, path) => json(
+            ErrorResponse::not_found(format!("Route not found: {}", path)),
+            StatusCode::NOT_FOUND,
+        ),
+    }
 }
 
-impl Service for ApiService {
-    type ReqBody = Body;
-    type ResBody = Body;
-    type Error = hyper::Error;
-    type Future =
-        Box<dyn Future<Item = hyper::Response<Self::ReqBody>, Error = Self::Error> + Send>;
-
-    fn call(&mut self, request: hyper::Request<Self::ReqBody>) -> Self::Future {
-        match (request.method(), request.uri().path()) {
-            (&Method::GET, "/api/rojo") => self.handle_api_rojo(),
-            (&Method::GET, path) if path.starts_with("/api/read/") => self.handle_api_read(request),
-            (&Method::GET, path) if path.starts_with("/api/subscribe/") => {
-                self.handle_api_subscribe(request)
-            }
-            (&Method::POST, path) if path.starts_with("/api/open/") => {
-                self.handle_api_open(request)
-            }
-
-            (&Method::POST, "/api/write") => self.handle_api_write(request),
-
-            (_method, path) => json(
-                ErrorResponse::not_found(format!("Route not found: {}", path)),
-                StatusCode::NOT_FOUND,
-            ),
-        }
-    }
+pub struct ApiService {
+    serve_session: Arc<ServeSession>,
 }
 
 impl ApiService {
@@ -59,7 +53,7 @@ impl ApiService {
     }
 
     /// Get a summary of information about the server
-    fn handle_api_rojo(&self) -> <Self as Service>::Future {
+    async fn handle_api_rojo(&self) -> Response<Body> {
         let tree = self.serve_session.tree();
         let root_instance_id = tree.get_root_id();
 
@@ -77,7 +71,7 @@ impl ApiService {
 
     /// Retrieve any messages past the given cursor index, and if
     /// there weren't any, subscribe to receive any new messages.
-    fn handle_api_subscribe(&self, request: Request<Body>) -> <Self as Service>::Future {
+    async fn handle_api_subscribe(&self, request: Request<Body>) -> Response<Body> {
         let argument = &request.uri().path()["/api/subscribe/".len()..];
         let input_cursor: u32 = match argument.parse() {
             Ok(v) => v,
@@ -91,11 +85,15 @@ impl ApiService {
 
         let session_id = self.serve_session.session_id();
 
-        let receiver = self.serve_session.message_queue().subscribe(input_cursor);
+        let result = self
+            .serve_session
+            .message_queue()
+            .subscribe(input_cursor)
+            .await;
 
         let tree_handle = self.serve_session.tree_handle();
 
-        Box::new(receiver.then(move |result| match result {
+        match result {
             Ok((message_cursor, messages)) => {
                 let tree = tree_handle.lock().unwrap();
 
@@ -151,56 +149,56 @@ impl ApiService {
                 ErrorResponse::internal_error("Message queue disconnected sender"),
                 StatusCode::INTERNAL_SERVER_ERROR,
             ),
-        }))
+        }
     }
 
-    fn handle_api_write(&self, request: Request<Body>) -> <Self as Service>::Future {
+    async fn handle_api_write(&self, request: Request<Body>) -> Response<Body> {
         let session_id = self.serve_session.session_id();
         let tree_mutation_sender = self.serve_session.tree_mutation_sender();
 
-        Box::new(request.into_body().concat2().and_then(move |body| {
-            let request: WriteRequest = match serde_json::from_slice(&body) {
-                Ok(request) => request,
-                Err(err) => {
-                    return json(
-                        ErrorResponse::bad_request(format!("Invalid body: {}", err)),
-                        StatusCode::BAD_REQUEST,
-                    );
-                }
-            };
+        let body = body::to_bytes(request.into_body()).await.unwrap();
 
-            if request.session_id != session_id {
+        let request: WriteRequest = match serde_json::from_slice(&body) {
+            Ok(request) => request,
+            Err(err) => {
                 return json(
-                    ErrorResponse::bad_request("Wrong session ID"),
+                    ErrorResponse::bad_request(format!("Invalid body: {}", err)),
                     StatusCode::BAD_REQUEST,
                 );
             }
+        };
 
-            let updated_instances = request
-                .updated
-                .into_iter()
-                .map(|update| PatchUpdate {
-                    id: update.id,
-                    changed_class_name: update.changed_class_name,
-                    changed_name: update.changed_name,
-                    changed_properties: update.changed_properties,
-                    changed_metadata: None,
-                })
-                .collect();
+        if request.session_id != session_id {
+            return json(
+                ErrorResponse::bad_request("Wrong session ID"),
+                StatusCode::BAD_REQUEST,
+            );
+        }
 
-            tree_mutation_sender
-                .send(PatchSet {
-                    removed_instances: Vec::new(),
-                    added_instances: Vec::new(),
-                    updated_instances,
-                })
-                .unwrap();
+        let updated_instances = request
+            .updated
+            .into_iter()
+            .map(|update| PatchUpdate {
+                id: update.id,
+                changed_class_name: update.changed_class_name,
+                changed_name: update.changed_name,
+                changed_properties: update.changed_properties,
+                changed_metadata: None,
+            })
+            .collect();
 
-            json_ok(&WriteResponse { session_id })
-        }))
+        tree_mutation_sender
+            .send(PatchSet {
+                removed_instances: Vec::new(),
+                added_instances: Vec::new(),
+                updated_instances,
+            })
+            .unwrap();
+
+        json_ok(&WriteResponse { session_id })
     }
 
-    fn handle_api_read(&self, request: Request<Body>) -> <Self as Service>::Future {
+    async fn handle_api_read(&self, request: Request<Body>) -> Response<Body> {
         let argument = &request.uri().path()["/api/read/".len()..];
         let requested_ids: Result<Vec<Ref>, _> = argument.split(',').map(Ref::from_str).collect();
 
@@ -239,7 +237,7 @@ impl ApiService {
     }
 
     /// Open a script with the given ID in the user's default text editor.
-    fn handle_api_open(&self, request: Request<Body>) -> <Self as Service>::Future {
+    async fn handle_api_open(&self, request: Request<Body>) -> Response<Body> {
         let argument = &request.uri().path()["/api/open/".len()..];
         let requested_id = match Ref::from_str(argument) {
             Ok(id) => id,

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -37,19 +37,26 @@ impl LiveServer {
         let make_service = make_service_fn(move |_conn| {
             let serve_session = Arc::clone(&serve_session);
 
-            let service = move |_req: Request<Body>| {
-                let content = serve_session.project_name().to_owned();
+            async {
+                let service = move |_req: Request<Body>| {
+                    let serve_session = Arc::clone(&serve_session);
 
-                future::ready(Ok::<_, Infallible>(Response::new(Body::from(content))))
-                // if req.uri().path().starts_with("api") {
-                //     api.call(req).await
-                // } else {
-                //     ui.call(req).await
-                // }
-            };
+                    async move {
+                        let content = serve_session.project_name().to_owned();
 
-            future::ready(Ok::<_, Infallible>(service_fn(service)))
+                        Ok::<_, Infallible>(Response::new(Body::from(content)))
+                    }
+                };
+
+                Ok::<_, Infallible>(service_fn(service))
+            }
         });
+
+        // if req.uri().path().starts_with("api") {
+        //     api.call(req).await
+        // } else {
+        //     ui.call(req).await
+        // }
 
         let rt = Runtime::new().unwrap();
         let _guard = rt.enter();

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -2,7 +2,7 @@
 //! communicates with. Eventually, we'll make this API stable, produce better
 //! documentation for it, and open it up for other consumers.
 
-// mod api;
+mod api;
 mod assets;
 pub mod interface;
 mod ui;
@@ -41,12 +41,11 @@ impl LiveServer {
                     let serve_session = Arc::clone(&serve_session);
 
                     async move {
-                        Ok::<_, Infallible>(ui::call(serve_session, req).await)
-
-                        // if req.uri().path().starts_with("api") {
-                        //     api.call(req).await
-                        // } else {
-                        // }
+                        if req.uri().path().starts_with("/api") {
+                            Ok::<_, Infallible>(api::call(serve_session, req).await)
+                        } else {
+                            Ok::<_, Infallible>(ui::call(serve_session, req).await)
+                        }
                     }
                 };
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -5,18 +5,17 @@
 // mod api;
 mod assets;
 pub mod interface;
-// mod ui;
-// mod util;
+mod ui;
+mod util;
 
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use futures::future;
 use hyper::{
     server::Server,
     service::{make_service_fn, service_fn},
-    Body, Request, Response,
+    Body, Request,
 };
 use tokio::runtime::Runtime;
 
@@ -38,25 +37,22 @@ impl LiveServer {
             let serve_session = Arc::clone(&serve_session);
 
             async {
-                let service = move |_req: Request<Body>| {
+                let service = move |req: Request<Body>| {
                     let serve_session = Arc::clone(&serve_session);
 
                     async move {
-                        let content = serve_session.project_name().to_owned();
+                        Ok::<_, Infallible>(ui::call(serve_session, req).await)
 
-                        Ok::<_, Infallible>(Response::new(Body::from(content)))
+                        // if req.uri().path().starts_with("api") {
+                        //     api.call(req).await
+                        // } else {
+                        // }
                     }
                 };
 
                 Ok::<_, Infallible>(service_fn(service))
             }
         });
-
-        // if req.uri().path().starts_with("api") {
-        //     api.call(req).await
-        // } else {
-        //     ui.call(req).await
-        // }
 
         let rt = Runtime::new().unwrap();
         let _guard = rt.enter();

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -8,48 +8,23 @@ pub mod interface;
 mod ui;
 mod util;
 
-use std::{net::SocketAddr, sync::Arc};
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::sync::Arc;
 
-use futures::{
-    future::{self, FutureResult},
-    Future,
+use hyper::{
+    server::Server,
+    service::{make_service_fn, service_fn, Service},
+    Body, Request,
 };
-use hyper::{service::Service, Body, Request, Response, Server};
-use log::trace;
+use tokio::runtime::Runtime;
 
 use crate::serve_session::ServeSession;
 
 use self::{api::ApiService, ui::UiService};
 
-pub struct RootService {
-    api: ApiService,
-    ui: UiService,
-}
-
-impl Service for RootService {
-    type ReqBody = Body;
-    type ResBody = Body;
-    type Error = hyper::Error;
-    type Future = Box<dyn Future<Item = Response<Self::ReqBody>, Error = Self::Error> + Send>;
-
-    fn call(&mut self, request: Request<Self::ReqBody>) -> Self::Future {
-        trace!("{} {}", request.method(), request.uri().path());
-
-        if request.uri().path().starts_with("/api") {
-            self.api.call(request)
-        } else {
-            self.ui.call(request)
-        }
-    }
-}
-
-impl RootService {
-    pub fn new(serve_session: Arc<ServeSession>) -> Self {
-        RootService {
-            api: ApiService::new(Arc::clone(&serve_session)),
-            ui: UiService::new(Arc::clone(&serve_session)),
-        }
-    }
+fn mock_service() -> impl Service {
+    todo!()
 }
 
 pub struct LiveServer {
@@ -62,14 +37,26 @@ impl LiveServer {
     }
 
     pub fn start(self, address: SocketAddr) {
-        let server = Server::bind(&address)
-            .serve(move || {
-                let service: FutureResult<_, hyper::Error> =
-                    future::ok(RootService::new(Arc::clone(&self.serve_session)));
-                service
-            })
-            .map_err(|e| eprintln!("Server error: {}", e));
+        let api = mock_service();
+        let ui = mock_service();
 
-        hyper::rt::run(server);
+        let serve_session = Arc::clone(&self.serve_session);
+        let service = |req: Request<Body>| async move {
+            if req.uri().path().starts_with("api") {
+                api.call(req).await
+            } else {
+                ui.call(req).await
+            }
+        };
+
+        let make_service =
+            make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(service)) });
+
+        let server = Server::bind(&address)
+            .serve(make_service)
+            .map_err(|e| log::error!("Server error: {}", e));
+
+        let rt = Runtime::new().unwrap();
+        rt.block_on(server);
     }
 }

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -22,6 +22,8 @@ use crate::{
     },
 };
 
+pub async fn call(serve_session: Arc<ServeSession>, request: Request<Body>) {}
+
 pub struct UiService {
     serve_session: Arc<ServeSession>,
 }

--- a/src/web/util.rs
+++ b/src/web/util.rs
@@ -1,23 +1,11 @@
-use futures::{future, Future};
 use hyper::{header::CONTENT_TYPE, Body, Response, StatusCode};
 use serde::Serialize;
 
-/// Respond to a request with JSON and the given status code.
-pub fn json<T: Serialize>(
-    value: T,
-    code: StatusCode,
-) -> Box<dyn Future<Item = hyper::Response<hyper::Body>, Error = hyper::Error> + Send> {
-    Box::new(future::ok(response_json(value, code)))
-}
-
-/// Respond to a request with a 200 OK response containing JSON.
-pub fn json_ok<T: Serialize>(
-    value: T,
-) -> Box<dyn Future<Item = hyper::Response<hyper::Body>, Error = hyper::Error> + Send> {
+pub fn json_ok<T: Serialize>(value: T) -> Response<Body> {
     json(value, StatusCode::OK)
 }
 
-fn response_json<T: Serialize>(value: T, code: StatusCode) -> Response<Body> {
+pub fn json<T: Serialize>(value: T, code: StatusCode) -> Response<Body> {
     let serialized = match serde_json::to_string(&value) {
         Ok(v) => v,
         Err(err) => {


### PR DESCRIPTION
This has been a long time coming.

Rojo's HTTP code pre-dates Rust's support for async/await. We can simplify the code a lot by switching to async/await and dropping a lot of the long-winded Hyper code that I wrote originally.

That's what this PR does!

Everything should be functionally the same. I've tested it manually a little bit and of course our automated end-to-end tests still pass.