### PR TITLE
Fix Ref reification

### DIFF
--- a/plugin/src/Reconciler/reify.lua
+++ b/plugin/src/Reconciler/reify.lua
@@ -70,7 +70,7 @@ function reifyInner(instanceMap, virtualInstances, id, parentInstance, unapplied
 	for propertyName, virtualValue in pairs(virtualInstance.Properties) do
 		-- Because refs may refer to instances that we haven't constructed yet,
 		-- we defer applying any ref properties until all instances are created.
-		if virtualValue.Type == "Ref" then
+		if next(virtualValue) == "Ref" then
 			table.insert(deferredRefs, {
 				id = id,
 				instance = instance,
@@ -136,21 +136,21 @@ function applyDeferredRefs(instanceMap, deferredRefs, unappliedPatch)
 	end
 
 	for _, entry in ipairs(deferredRefs) do
-		local virtualValue = entry.virtualValue
+		local _, refId = next(entry.virtualValue)
 
-		if virtualValue.Value == nil then
+		if refId == nil then
 			continue
 		end
 
-		local targetInstance = instanceMap.fromIds[virtualValue.Value]
+		local targetInstance = instanceMap.fromIds[refId]
 		if targetInstance == nil then
-			markFailed(entry.id, entry.propertyName, virtualValue)
+			markFailed(entry.id, entry.propertyName, entry.virtualValue)
 			continue
 		end
 
 		local ok = setProperty(entry.instance, entry.propertyName, targetInstance)
 		if not ok then
-			markFailed(entry.id, entry.propertyName, virtualValue)
+			markFailed(entry.id, entry.propertyName, entry.virtualValue)
 		end
 	end
 end

--- a/plugin/src/Types.lua
+++ b/plugin/src/Types.lua
@@ -5,10 +5,7 @@ local strict = require(script.Parent.strict)
 
 local RbxId = t.string
 
-local ApiValue = t.interface({
-	Type = t.string,
-	Value = t.optional(t.any),
-})
+local ApiValue = t.keys(t.string)
 
 local ApiInstanceMetadata = t.interface({
 	ignoreUnknownInstances = t.optional(t.boolean),


### PR DESCRIPTION
The reconciler's reify function was still using the old value format for Refs, causing Ref properties to fail to sync. This PR also updates the ApiValue type to use the new value format (this caused problems when type checking was enabled).