### PR TITLE
Update nil Ref check and property decode warning to new Rojo protocol

### DIFF
--- a/plugin/src/Reconciler/decodeValue.lua
+++ b/plugin/src/Reconciler/decodeValue.lua
@@ -11,7 +11,7 @@ local function decodeValue(encodedValue, instanceMap)
 
 	-- Refs are represented as IDs in the same space that Rojo's protocol uses.
 	if ty == "Ref" then
-		if value == nil then
+		if value == "00000000000000000000000000000000" then
 			return true, nil
 		end
 

--- a/plugin/src/Reconciler/diff.lua
+++ b/plugin/src/Reconciler/diff.lua
@@ -75,7 +75,9 @@ local function diff(instanceMap, virtualInstances, rootId)
 						changedProperties[propertyName] = virtualValue
 					end
 				else
-					Log.warn("Failed to decode property of type {}", virtualValue.Type)
+					-- virtualValue can be empty in certain cases, and this may print out nil to the user.
+					local propertyType = next(virtualValue)
+					Log.warn("Failed to decode property of type {}", propertyType)
 				end
 			else
 				local err = existingValueOrErr


### PR DESCRIPTION
I had ran into an issue with Refs in #465 on an older version of Rojo, and was guided to try out the latest version and still had issues. These parts of the plugin were relying on the old Rojo protocol and I've now updated them.

Regarding the comment I left on diff.lua#78, I've described one instance that can cause the table to be empty in #467.

*The unverified is because my GPG for Windows is kinda messed up. The next commit is verified me!*