### PR TITLE
Add ChangeBatcher for two-way sync

### DIFF
--- a/plugin/src/ChangeBatcher.lua
+++ b/plugin/src/ChangeBatcher.lua
@@ -1,0 +1,155 @@
+--[[
+	The ChangeBatcher is responsible for collecting and dispatching changes made
+	to tracked instances during two-way sync.
+]]
+
+local RunService = game:GetService("RunService")
+
+local PatchSet = require(script.Parent.PatchSet)
+local RbxDom = require(script.Parent.Parent.RbxDom)
+local Log = require(script.Parent.Parent.Log)
+
+local ChangeBatcher = {}
+ChangeBatcher.__index = ChangeBatcher
+
+local BATCH_INTERVAL = 0.2
+
+function ChangeBatcher.new(instanceMap, onChangesFlushed)
+	local instancesToUnpause = {}
+	local accumulator = 0
+	local self
+
+	local heartbeatConnection = RunService.Heartbeat:Connect(function(dt)
+		accumulator += dt
+
+		if accumulator >= BATCH_INTERVAL then
+			accumulator -= BATCH_INTERVAL
+
+			local patch = self:__flush()
+
+			if patch then
+				onChangesFlushed(patch)
+			end
+		end
+
+		-- Instances updates that were paused during the previous cycle should
+		-- be unpaused.
+		for instance in pairs(instancesToUnpause) do
+			instanceMap.pausedBatchInstances[instance] = nil
+			instancesToUnpause[instance] = nil
+		end
+
+		-- Instances updates that were paused during this cycle should be
+		-- unpaused in the next cycle.
+		for instance in pairs(instanceMap.pausedBatchInstances) do
+			instancesToUnpause[instance] = true
+		end
+	end)
+
+	self = setmetatable({
+		__pendingChanges = {},
+		__instanceMap = instanceMap,
+		__heartbeatConnection = heartbeatConnection,
+	}, ChangeBatcher)
+
+	return self
+end
+
+function ChangeBatcher:stop()
+	self.__heartbeatConnection:Disconnect()
+	self.__pendingChanges = {}
+end
+
+function ChangeBatcher:add(instance, propertyName)
+	local properties = self.__pendingChanges[instance]
+
+	if not properties then
+		properties = {}
+		self.__pendingChanges[instance] = properties
+	end
+
+	properties[propertyName] = true
+end
+
+function ChangeBatcher:__flush()
+	if not next(self.__pendingChanges) then
+		return nil
+	end
+
+	local patch = {
+		updated = {},
+		removed = {},
+		added = {},
+	}
+
+	for instance, properties in pairs(self.__pendingChanges) do
+		local instanceId = self.__instanceMap.fromInstances[instance]
+
+		if instanceId == nil then
+			Log.warn("Ignoring change for instance {:?} as it is unknown to Rojo", instance)
+			continue
+		end
+
+		for propertyName in pairs(properties) do
+			local remove = nil
+			local update = {
+				id = instanceId,
+				changedProperties = {},
+			}
+
+			if propertyName == "Name" then
+				update.changedName = instance.Name
+			elseif propertyName == "Parent" then
+				if instance.Parent == nil then
+					update = nil
+					remove = instanceId
+				else
+					Log.warn("Cannot sync non-nil Parent property changes yet")
+					continue
+				end
+			else
+				local propertyDescriptor = RbxDom.findCanonicalPropertyDescriptor(
+					instance.ClassName,
+					propertyName
+				)
+
+				if not propertyDescriptor then
+					Log.debug("Could not sync back property {:?}.{}", instance, propertyName)
+					continue
+				end
+
+				local readSuccess, readResult = propertyDescriptor:read(instance)
+
+				if not readSuccess then
+					Log.warn("Could not sync back property {:?}.{}: {}",
+						instance, propertyName, readResult)
+					continue
+				end
+
+				local dataType = propertyDescriptor.dataType
+				local encodeSuccess, encodeResult = RbxDom.EncodedValue.encode(readResult, dataType)
+
+				if not encodeSuccess then
+					Log.warn("Could not sync back property {:?}.{}: {}",
+						instance, propertyName, encodeResult)
+					continue
+				end
+
+				update.changedProperties[propertyName] = encodeResult
+			end
+
+			table.insert(patch.updated, update)
+			table.insert(patch.removed, remove)
+		end
+
+		self.__pendingChanges[instance] = nil
+	end
+
+	if PatchSet.isEmpty(patch) then
+		return nil
+	end
+
+	return patch
+end
+
+return ChangeBatcher


### PR DESCRIPTION
Closes #294.

Depends on changes from rojo-rbx/rbx-dom#210.

This PR implements `ChangeBatcher`. Its job is to collect any instance changes and periodically try to turn them into a patch to send to the Rojo server. Right now, this happens every 200ms.

There is one small bump I hit during implementation. When a change is made to the `Source` property of a `LuaSourceContainer`, AND the change is made from a script or the command bar, AND the script is open in Studio, the `Changed` event fires three times for `Source`. The first event occurs right when the change is made (or, if deferred events are enabled, at the next invocation point), while the latter two events occur some time after the current `Heartbeat` cycle. 

If this is left unchecked, the `ChangeBatcher` detects a spurious change to `Source` after a patch application. To fix it, I added `InstanceMap:pauseInstanceForBatch`. It pauses an instance until the `ChangeBatcher` decides to unpause it (in this case, after the next `Heartbeat` cycle). I also made `InstanceMap:pauseInstance` no longer take a callback and added `InstanceMap:unpauseInstance` to avoid having to create a closure for every set of property updates during patch application.