### PR TITLE
Track patch sources, make the plugin ignore its own changes

### DIFF
--- a/plugin/http/init.lua
+++ b/plugin/http/init.lua
@@ -63,4 +63,8 @@ function Http.jsonDecode(source)
 	return HttpService:JSONDecode(source)
 end
 
+function Http.generateGuid()
+	return HttpService:GenerateGUID(false):lower()
+end
+
 return Http

--- a/plugin/src/ApiContext.lua
+++ b/plugin/src/ApiContext.lua
@@ -88,6 +88,8 @@ function ApiContext.new(baseUrl)
 	assert(type(baseUrl) == "string")
 
 	local self = {
+		clientId = Http.generateGuid(),
+
 		__baseUrl = baseUrl,
 		__sessionId = nil,
 		__messageCursor = -1,
@@ -182,6 +184,7 @@ function ApiContext:write(patch)
 
 	local body = {
 		sessionId = self.__sessionId,
+		source = self.clientId,
 		removed = patch.removed,
 		updated = updated,
 		added = added,

--- a/plugin/src/ServeSession.lua
+++ b/plugin/src/ServeSession.lua
@@ -272,6 +272,10 @@ function ServeSession:__mainSyncLoop()
 	return self.__apiContext:retrieveMessages()
 		:andThen(function(messages)
 			for _, message in ipairs(messages) do
+				if message.source == self.__apiContext.clientId then
+					continue
+				end
+
 				local unappliedPatch = self.__reconciler:applyPatch(message)
 
 				if not PatchSet.isEmpty(unappliedPatch) then

--- a/plugin/src/Types.lua
+++ b/plugin/src/Types.lua
@@ -38,6 +38,7 @@ local ApiSubscribeMessage = t.interface({
 
 local ApiInfoResponse = t.interface({
 	sessionId = t.string,
+	serverId = t.string,
 	serverVersion = t.string,
 	protocolVersion = t.number,
 	expectedPlaceIds = t.optional(t.array(t.number)),

--- a/plugin/src/Types.lua
+++ b/plugin/src/Types.lua
@@ -30,6 +30,7 @@ local ApiInstanceUpdate = t.interface({
 })
 
 local ApiSubscribeMessage = t.interface({
+	source = t.string,
 	removed = t.array(RbxId),
 	added = t.map(RbxId, ApiInstance),
 	updated = t.array(ApiInstanceUpdate),

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__add_folder_all-2.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__add_folder_all-2.snap
@@ -1,26 +1,28 @@
 ---
 source: tests/tests/serve.rs
 expression: "read_response.intern_and_redact(&mut redactions, root_id)"
+
 ---
 instances:
-  id-2:
+  id-3:
     Children:
-      - id-3
+      - id-4
     ClassName: Folder
-    Id: id-2
+    Id: id-3
     Metadata:
       ignoreUnknownInstances: false
     Name: add_folder
     Parent: "00000000000000000000000000000000"
     Properties: {}
-  id-3:
+  id-4:
     Children: []
     ClassName: Folder
-    Id: id-3
+    Id: id-4
     Metadata:
       ignoreUnknownInstances: false
     Name: my-new-folder
-    Parent: id-2
+    Parent: id-3
     Properties: {}
 messageCursor: 1
 sessionId: id-1
+

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__add_folder_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__add_folder_all.snap
@@ -1,12 +1,13 @@
 ---
 source: tests/tests/serve.rs
 expression: "read_response.intern_and_redact(&mut redactions, root_id)"
+
 ---
 instances:
-  id-2:
+  id-3:
     Children: []
     ClassName: Folder
-    Id: id-2
+    Id: id-3
     Metadata:
       ignoreUnknownInstances: false
     Name: add_folder
@@ -14,3 +15,4 @@ instances:
     Properties: {}
 messageCursor: 0
 sessionId: id-1
+

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__add_folder_info.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__add_folder_info.snap
@@ -8,7 +8,8 @@ gameId: ~
 placeId: ~
 projectName: add_folder
 protocolVersion: 4
-rootInstanceId: id-2
+rootInstanceId: id-3
+serverId: id-2
 serverVersion: "[server-version]"
 sessionId: id-1
 

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__add_folder_subscribe.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__add_folder_subscribe.snap
@@ -1,19 +1,22 @@
 ---
 source: tests/tests/serve.rs
 expression: "subscribe_response.intern_and_redact(&mut redactions, ())"
+
 ---
 messageCursor: 1
 messages:
   - added:
-      id-3:
+      id-4:
         Children: []
         ClassName: Folder
-        Id: id-3
+        Id: id-4
         Metadata:
           ignoreUnknownInstances: false
         Name: my-new-folder
-        Parent: id-2
+        Parent: id-3
         Properties: {}
     removed: []
+    source: id-2
     updated: []
 sessionId: id-1
+

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__edit_init_all-2.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__edit_init_all-2.snap
@@ -4,10 +4,10 @@ expression: "read_response.intern_and_redact(&mut redactions, root_id)"
 
 ---
 instances:
-  id-2:
+  id-3:
     Children: []
     ClassName: ModuleScript
-    Id: id-2
+    Id: id-3
     Metadata:
       ignoreUnknownInstances: false
     Name: edit_init

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__edit_init_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__edit_init_all.snap
@@ -4,10 +4,10 @@ expression: "read_response.intern_and_redact(&mut redactions, root_id)"
 
 ---
 instances:
-  id-2:
+  id-3:
     Children: []
     ClassName: ModuleScript
-    Id: id-2
+    Id: id-3
     Metadata:
       ignoreUnknownInstances: false
     Name: edit_init

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__edit_init_info.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__edit_init_info.snap
@@ -8,7 +8,8 @@ gameId: ~
 placeId: ~
 projectName: edit_init
 protocolVersion: 4
-rootInstanceId: id-2
+rootInstanceId: id-3
+serverId: id-2
 serverVersion: "[server-version]"
 sessionId: id-1
 

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__edit_init_subscribe.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__edit_init_subscribe.snap
@@ -7,6 +7,7 @@ messageCursor: 1
 messages:
   - added: {}
     removed: []
+    source: id-2
     updated:
       - changedClassName: ~
         changedMetadata: ~
@@ -14,6 +15,6 @@ messages:
         changedProperties:
           Source:
             String: "-- Edited contents"
-        id: id-2
+        id: id-3
 sessionId: id-1
 

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_all.snap
@@ -1,12 +1,13 @@
 ---
 source: tests/tests/serve.rs
 expression: "read_response.intern_and_redact(&mut redactions, root_id)"
+
 ---
 instances:
-  id-2:
+  id-3:
     Children: []
     ClassName: Folder
-    Id: id-2
+    Id: id-3
     Metadata:
       ignoreUnknownInstances: true
     Name: empty
@@ -14,3 +15,4 @@ instances:
     Properties: {}
 messageCursor: 0
 sessionId: id-1
+

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_info.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_info.snap
@@ -8,7 +8,8 @@ gameId: ~
 placeId: ~
 projectName: empty
 protocolVersion: 4
-rootInstanceId: id-2
+rootInstanceId: id-3
+serverId: id-2
 serverVersion: "[server-version]"
 sessionId: id-1
 

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_json_model_all-2.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_json_model_all-2.snap
@@ -4,24 +4,24 @@ expression: "read_response.intern_and_redact(&mut redactions, root_id)"
 
 ---
 instances:
-  id-2:
+  id-3:
     Children:
-      - id-3
+      - id-4
     ClassName: Folder
-    Id: id-2
+    Id: id-3
     Metadata:
       ignoreUnknownInstances: false
     Name: empty_folder
     Parent: "00000000000000000000000000000000"
     Properties: {}
-  id-3:
+  id-4:
     Children: []
     ClassName: Model
-    Id: id-3
+    Id: id-4
     Metadata:
       ignoreUnknownInstances: false
     Name: test
-    Parent: id-2
+    Parent: id-3
     Properties: {}
 messageCursor: 1
 sessionId: id-1

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_json_model_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_json_model_all.snap
@@ -4,10 +4,10 @@ expression: "read_response.intern_and_redact(&mut redactions, root_id)"
 
 ---
 instances:
-  id-2:
+  id-3:
     Children: []
     ClassName: Folder
-    Id: id-2
+    Id: id-3
     Metadata:
       ignoreUnknownInstances: false
     Name: empty_folder

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_json_model_info.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_json_model_info.snap
@@ -8,7 +8,8 @@ gameId: ~
 placeId: ~
 projectName: empty_folder
 protocolVersion: 4
-rootInstanceId: id-2
+rootInstanceId: id-3
+serverId: id-2
 serverVersion: "[server-version]"
 sessionId: id-1
 

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_json_model_subscribe.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_json_model_subscribe.snap
@@ -6,16 +6,17 @@ expression: "subscribe_response.intern_and_redact(&mut redactions, ())"
 messageCursor: 1
 messages:
   - added:
-      id-3:
+      id-4:
         Children: []
         ClassName: Model
-        Id: id-3
+        Id: id-4
         Metadata:
           ignoreUnknownInstances: false
         Name: test
-        Parent: id-2
+        Parent: id-3
         Properties: {}
     removed: []
+    source: id-2
     updated: []
 sessionId: id-1
 

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__move_folder_of_stuff_all-2.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__move_folder_of_stuff_all-2.snap
@@ -10,57 +10,67 @@ instances:
     Id: id-10
     Metadata:
       ignoreUnknownInstances: false
-    Name: "6"
-    Parent: id-3
+    Name: "5"
+    Parent: id-4
     Properties:
       Value:
-        String: "File #6"
+        String: "File #5"
   id-11:
     Children: []
     ClassName: StringValue
     Id: id-11
     Metadata:
       ignoreUnknownInstances: false
-    Name: "7"
-    Parent: id-3
+    Name: "6"
+    Parent: id-4
     Properties:
       Value:
-        String: "File #7"
+        String: "File #6"
   id-12:
     Children: []
     ClassName: StringValue
     Id: id-12
     Metadata:
       ignoreUnknownInstances: false
-    Name: "8"
-    Parent: id-3
+    Name: "7"
+    Parent: id-4
     Properties:
       Value:
-        String: "File #8"
+        String: "File #7"
   id-13:
     Children: []
     ClassName: StringValue
     Id: id-13
     Metadata:
       ignoreUnknownInstances: false
+    Name: "8"
+    Parent: id-4
+    Properties:
+      Value:
+        String: "File #8"
+  id-14:
+    Children: []
+    ClassName: StringValue
+    Id: id-14
+    Metadata:
+      ignoreUnknownInstances: false
     Name: "9"
-    Parent: id-3
+    Parent: id-4
     Properties:
       Value:
         String: "File #9"
-  id-2:
+  id-3:
     Children:
-      - id-3
+      - id-4
     ClassName: Folder
-    Id: id-2
+    Id: id-3
     Metadata:
       ignoreUnknownInstances: false
     Name: move_folder_of_stuff
     Parent: "00000000000000000000000000000000"
     Properties: {}
-  id-3:
+  id-4:
     Children:
-      - id-4
       - id-5
       - id-6
       - id-7
@@ -70,79 +80,69 @@ instances:
       - id-11
       - id-12
       - id-13
+      - id-14
     ClassName: Folder
-    Id: id-3
-    Metadata:
-      ignoreUnknownInstances: false
-    Name: new-stuff
-    Parent: id-2
-    Properties: {}
-  id-4:
-    Children: []
-    ClassName: StringValue
     Id: id-4
     Metadata:
       ignoreUnknownInstances: false
-    Name: "0"
+    Name: new-stuff
     Parent: id-3
-    Properties:
-      Value:
-        String: "File #0"
+    Properties: {}
   id-5:
     Children: []
     ClassName: StringValue
     Id: id-5
     Metadata:
       ignoreUnknownInstances: false
-    Name: "1"
-    Parent: id-3
+    Name: "0"
+    Parent: id-4
     Properties:
       Value:
-        String: "File #1"
+        String: "File #0"
   id-6:
     Children: []
     ClassName: StringValue
     Id: id-6
     Metadata:
       ignoreUnknownInstances: false
-    Name: "2"
-    Parent: id-3
+    Name: "1"
+    Parent: id-4
     Properties:
       Value:
-        String: "File #2"
+        String: "File #1"
   id-7:
     Children: []
     ClassName: StringValue
     Id: id-7
     Metadata:
       ignoreUnknownInstances: false
-    Name: "3"
-    Parent: id-3
+    Name: "2"
+    Parent: id-4
     Properties:
       Value:
-        String: "File #3"
+        String: "File #2"
   id-8:
     Children: []
     ClassName: StringValue
     Id: id-8
     Metadata:
       ignoreUnknownInstances: false
-    Name: "4"
-    Parent: id-3
+    Name: "3"
+    Parent: id-4
     Properties:
       Value:
-        String: "File #4"
+        String: "File #3"
   id-9:
     Children: []
     ClassName: StringValue
     Id: id-9
     Metadata:
       ignoreUnknownInstances: false
-    Name: "5"
-    Parent: id-3
+    Name: "4"
+    Parent: id-4
     Properties:
       Value:
-        String: "File #5"
+        String: "File #4"
 messageCursor: 1
 sessionId: id-1
 

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__move_folder_of_stuff_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__move_folder_of_stuff_all.snap
@@ -1,12 +1,13 @@
 ---
 source: tests/tests/serve.rs
 expression: "read_response.intern_and_redact(&mut redactions, root_id)"
+
 ---
 instances:
-  id-2:
+  id-3:
     Children: []
     ClassName: Folder
-    Id: id-2
+    Id: id-3
     Metadata:
       ignoreUnknownInstances: false
     Name: move_folder_of_stuff
@@ -14,3 +15,4 @@ instances:
     Properties: {}
 messageCursor: 0
 sessionId: id-1
+

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__move_folder_of_stuff_info.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__move_folder_of_stuff_info.snap
@@ -8,7 +8,8 @@ gameId: ~
 placeId: ~
 projectName: move_folder_of_stuff
 protocolVersion: 4
-rootInstanceId: id-2
+rootInstanceId: id-3
+serverId: id-2
 serverVersion: "[server-version]"
 sessionId: id-1
 

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__move_folder_of_stuff_subscribe.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__move_folder_of_stuff_subscribe.snap
@@ -12,47 +12,57 @@ messages:
         Id: id-10
         Metadata:
           ignoreUnknownInstances: false
-        Name: "6"
-        Parent: id-3
+        Name: "5"
+        Parent: id-4
         Properties:
           Value:
-            String: "File #6"
+            String: "File #5"
       id-11:
         Children: []
         ClassName: StringValue
         Id: id-11
         Metadata:
           ignoreUnknownInstances: false
-        Name: "7"
-        Parent: id-3
+        Name: "6"
+        Parent: id-4
         Properties:
           Value:
-            String: "File #7"
+            String: "File #6"
       id-12:
         Children: []
         ClassName: StringValue
         Id: id-12
         Metadata:
           ignoreUnknownInstances: false
-        Name: "8"
-        Parent: id-3
+        Name: "7"
+        Parent: id-4
         Properties:
           Value:
-            String: "File #8"
+            String: "File #7"
       id-13:
         Children: []
         ClassName: StringValue
         Id: id-13
         Metadata:
           ignoreUnknownInstances: false
+        Name: "8"
+        Parent: id-4
+        Properties:
+          Value:
+            String: "File #8"
+      id-14:
+        Children: []
+        ClassName: StringValue
+        Id: id-14
+        Metadata:
+          ignoreUnknownInstances: false
         Name: "9"
-        Parent: id-3
+        Parent: id-4
         Properties:
           Value:
             String: "File #9"
-      id-3:
+      id-4:
         Children:
-          - id-4
           - id-5
           - id-6
           - id-7
@@ -62,80 +72,71 @@ messages:
           - id-11
           - id-12
           - id-13
+          - id-14
         ClassName: Folder
-        Id: id-3
-        Metadata:
-          ignoreUnknownInstances: false
-        Name: new-stuff
-        Parent: id-2
-        Properties: {}
-      id-4:
-        Children: []
-        ClassName: StringValue
         Id: id-4
         Metadata:
           ignoreUnknownInstances: false
-        Name: "0"
+        Name: new-stuff
         Parent: id-3
-        Properties:
-          Value:
-            String: "File #0"
+        Properties: {}
       id-5:
         Children: []
         ClassName: StringValue
         Id: id-5
         Metadata:
           ignoreUnknownInstances: false
-        Name: "1"
-        Parent: id-3
+        Name: "0"
+        Parent: id-4
         Properties:
           Value:
-            String: "File #1"
+            String: "File #0"
       id-6:
         Children: []
         ClassName: StringValue
         Id: id-6
         Metadata:
           ignoreUnknownInstances: false
-        Name: "2"
-        Parent: id-3
+        Name: "1"
+        Parent: id-4
         Properties:
           Value:
-            String: "File #2"
+            String: "File #1"
       id-7:
         Children: []
         ClassName: StringValue
         Id: id-7
         Metadata:
           ignoreUnknownInstances: false
-        Name: "3"
-        Parent: id-3
+        Name: "2"
+        Parent: id-4
         Properties:
           Value:
-            String: "File #3"
+            String: "File #2"
       id-8:
         Children: []
         ClassName: StringValue
         Id: id-8
         Metadata:
           ignoreUnknownInstances: false
-        Name: "4"
-        Parent: id-3
+        Name: "3"
+        Parent: id-4
         Properties:
           Value:
-            String: "File #4"
+            String: "File #3"
       id-9:
         Children: []
         ClassName: StringValue
         Id: id-9
         Metadata:
           ignoreUnknownInstances: false
-        Name: "5"
-        Parent: id-3
+        Name: "4"
+        Parent: id-4
         Properties:
           Value:
-            String: "File #5"
+            String: "File #4"
     removed: []
+    source: id-2
     updated: []
 sessionId: id-1
 

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__remove_file_all-2.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__remove_file_all-2.snap
@@ -1,12 +1,13 @@
 ---
 source: tests/tests/serve.rs
 expression: "read_response.intern_and_redact(&mut redactions, root_id)"
+
 ---
 instances:
-  id-2:
+  id-3:
     Children: []
     ClassName: Folder
-    Id: id-2
+    Id: id-3
     Metadata:
       ignoreUnknownInstances: false
     Name: remove_file
@@ -14,3 +15,4 @@ instances:
     Properties: {}
 messageCursor: 1
 sessionId: id-1
+

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__remove_file_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__remove_file_all.snap
@@ -4,24 +4,24 @@ expression: "read_response.intern_and_redact(&mut redactions, root_id)"
 
 ---
 instances:
-  id-2:
+  id-3:
     Children:
-      - id-3
+      - id-4
     ClassName: Folder
-    Id: id-2
+    Id: id-3
     Metadata:
       ignoreUnknownInstances: false
     Name: remove_file
     Parent: "00000000000000000000000000000000"
     Properties: {}
-  id-3:
+  id-4:
     Children: []
     ClassName: StringValue
-    Id: id-3
+    Id: id-4
     Metadata:
       ignoreUnknownInstances: false
     Name: hello
-    Parent: id-2
+    Parent: id-3
     Properties:
       Value:
         String: This file will be removed!

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__remove_file_info.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__remove_file_info.snap
@@ -8,7 +8,8 @@ gameId: ~
 placeId: ~
 projectName: remove_file
 protocolVersion: 4
-rootInstanceId: id-2
+rootInstanceId: id-3
+serverId: id-2
 serverVersion: "[server-version]"
 sessionId: id-1
 

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__remove_file_subscribe.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__remove_file_subscribe.snap
@@ -1,11 +1,14 @@
 ---
 source: tests/tests/serve.rs
 expression: "subscribe_response.intern_and_redact(&mut redactions, ())"
+
 ---
 messageCursor: 1
 messages:
   - added: {}
     removed:
-      - id-3
+      - id-4
+    source: id-2
     updated: []
 sessionId: id-1
+

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__scripts_all-2.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__scripts_all-2.snap
@@ -4,36 +4,36 @@ expression: "read_response.intern_and_redact(&mut redactions, root_id)"
 
 ---
 instances:
-  id-2:
+  id-3:
     Children:
-      - id-3
       - id-4
+      - id-5
     ClassName: Folder
-    Id: id-2
+    Id: id-3
     Metadata:
       ignoreUnknownInstances: false
     Name: scripts
     Parent: "00000000000000000000000000000000"
     Properties: {}
-  id-3:
-    Children: []
-    ClassName: Script
-    Id: id-3
-    Metadata:
-      ignoreUnknownInstances: false
-    Name: bar
-    Parent: id-2
-    Properties:
-      Source:
-        String: "-- Hello, from bar!"
   id-4:
     Children: []
-    ClassName: ModuleScript
+    ClassName: Script
     Id: id-4
     Metadata:
       ignoreUnknownInstances: false
+    Name: bar
+    Parent: id-3
+    Properties:
+      Source:
+        String: "-- Hello, from bar!"
+  id-5:
+    Children: []
+    ClassName: ModuleScript
+    Id: id-5
+    Metadata:
+      ignoreUnknownInstances: false
     Name: foo
-    Parent: id-2
+    Parent: id-3
     Properties:
       Source:
         String: Updated foo!

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__scripts_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__scripts_all.snap
@@ -4,36 +4,36 @@ expression: "read_response.intern_and_redact(&mut redactions, root_id)"
 
 ---
 instances:
-  id-2:
+  id-3:
     Children:
-      - id-3
       - id-4
+      - id-5
     ClassName: Folder
-    Id: id-2
+    Id: id-3
     Metadata:
       ignoreUnknownInstances: false
     Name: scripts
     Parent: "00000000000000000000000000000000"
     Properties: {}
-  id-3:
-    Children: []
-    ClassName: Script
-    Id: id-3
-    Metadata:
-      ignoreUnknownInstances: false
-    Name: bar
-    Parent: id-2
-    Properties:
-      Source:
-        String: "-- Hello, from bar!"
   id-4:
     Children: []
-    ClassName: ModuleScript
+    ClassName: Script
     Id: id-4
     Metadata:
       ignoreUnknownInstances: false
+    Name: bar
+    Parent: id-3
+    Properties:
+      Source:
+        String: "-- Hello, from bar!"
+  id-5:
+    Children: []
+    ClassName: ModuleScript
+    Id: id-5
+    Metadata:
+      ignoreUnknownInstances: false
     Name: foo
-    Parent: id-2
+    Parent: id-3
     Properties:
       Source:
         String: "-- Hello, from foo!"

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__scripts_info.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__scripts_info.snap
@@ -8,7 +8,8 @@ gameId: ~
 placeId: ~
 projectName: scripts
 protocolVersion: 4
-rootInstanceId: id-2
+rootInstanceId: id-3
+serverId: id-2
 serverVersion: "[server-version]"
 sessionId: id-1
 

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__scripts_subscribe.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__scripts_subscribe.snap
@@ -7,6 +7,7 @@ messageCursor: 1
 messages:
   - added: {}
     removed: []
+    source: id-2
     updated:
       - changedClassName: ~
         changedMetadata: ~
@@ -14,6 +15,6 @@ messages:
         changedProperties:
           Source:
             String: Updated foo!
-        id: id-4
+        id: id-5
 sessionId: id-1
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod lua_ast;
 mod message_queue;
 mod multimap;
 mod path_serializer;
+mod peer_id;
 mod project;
 mod resolution;
 mod serve_session;

--- a/src/peer_id.rs
+++ b/src/peer_id.rs
@@ -1,0 +1,20 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Uniquely identifies a client or server during a serve session.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PeerId(Uuid);
+
+impl PeerId {
+    pub fn new() -> PeerId {
+        PeerId(Uuid::new_v4())
+    }
+}
+
+impl fmt::Display for PeerId {
+    fn fmt(&self, writer: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(writer, "{}", self.0)
+    }
+}

--- a/src/serve_session.rs
+++ b/src/serve_session.rs
@@ -65,6 +65,9 @@ pub struct ServeSession {
     /// an operation that needs to be atomic.
     session_id: SessionId,
 
+    /// An ID uniquely identifying the server.
+    server_id: PeerId,
+
     /// The tree of Roblox instances associated with this session that will be
     /// updated in real-time. This is derived from the session's VFS and will
     /// eventually be mutable to connected clients.
@@ -159,6 +162,7 @@ impl ServeSession {
             change_processor,
             start_time,
             session_id,
+            server_id,
             root_project,
             tree,
             message_queue,
@@ -190,6 +194,10 @@ impl ServeSession {
 
     pub fn session_id(&self) -> SessionId {
         self.session_id
+    }
+
+    pub fn server_id(&self) -> PeerId {
+        self.server_id
     }
 
     pub fn project_name(&self) -> &str {

--- a/src/serve_session.rs
+++ b/src/serve_session.rs
@@ -15,6 +15,7 @@ use thiserror::Error;
 use crate::{
     change_processor::ChangeProcessor,
     message_queue::MessageQueue,
+    peer_id::PeerId,
     project::{Project, ProjectError},
     session_id::SessionId,
     snapshot::{
@@ -122,6 +123,7 @@ impl ServeSession {
         let mut tree = RojoTree::new(InstanceSnapshot::new());
 
         let root_id = tree.get_root_id();
+        let server_id = PeerId::new();
 
         let instance_context = InstanceContext::default();
 
@@ -130,7 +132,7 @@ impl ServeSession {
             .expect("snapshot did not return an instance");
 
         log::trace!("Computing initial patch set");
-        let patch_set = compute_patch_set(&snapshot, &tree, root_id);
+        let patch_set = compute_patch_set(&snapshot, &tree, root_id, server_id);
 
         log::trace!("Applying initial patch set");
         apply_patch_set(&mut tree, patch_set);
@@ -150,6 +152,7 @@ impl ServeSession {
             Arc::clone(&vfs),
             Arc::clone(&message_queue),
             tree_mutation_receiver,
+            server_id,
         );
 
         Ok(Self {

--- a/src/snapshot/patch.rs
+++ b/src/snapshot/patch.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 use rbx_dom_weak::types::{Ref, Variant};
 use serde::{Deserialize, Serialize};
 
+use crate::peer_id::PeerId;
+
 use super::{InstanceMetadata, InstanceSnapshot};
 
 /// A set of different kinds of patches that can be applied to an WeakDom.
@@ -14,14 +16,16 @@ use super::{InstanceMetadata, InstanceSnapshot};
 /// conflict!
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PatchSet {
+    pub source: PeerId,
     pub removed_instances: Vec<Ref>,
     pub added_instances: Vec<PatchAdd>,
     pub updated_instances: Vec<PatchUpdate>,
 }
 
 impl<'a> PatchSet {
-    pub fn new() -> Self {
+    pub fn new(source: PeerId) -> Self {
         PatchSet {
+            source,
             removed_instances: Vec::new(),
             added_instances: Vec::new(),
             updated_instances: Vec::new(),
@@ -63,14 +67,16 @@ pub struct PatchUpdate {
 // current values in all fields.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AppliedPatchSet {
+    pub source: PeerId,
     pub removed: Vec<Ref>,
     pub added: Vec<Ref>,
     pub updated: Vec<AppliedPatchUpdate>,
 }
 
 impl AppliedPatchSet {
-    pub fn new() -> Self {
+    pub fn new(source: PeerId) -> Self {
         AppliedPatchSet {
+            source,
             removed: Vec::new(),
             added: Vec::new(),
             updated: Vec::new(),

--- a/src/snapshot/patch_apply.rs
+++ b/src/snapshot/patch_apply.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 
 use rbx_dom_weak::types::{Ref, Variant};
 
+use crate::peer_id::PeerId;
+
 use super::{
     patch::{AppliedPatchSet, AppliedPatchUpdate, PatchSet, PatchUpdate},
     InstanceSnapshot, RojoTree,
@@ -13,7 +15,7 @@ use super::{
 /// tree and returns an `AppliedPatchSet`, which can be used to keep another
 /// tree in sync with Rojo's.
 pub fn apply_patch_set(tree: &mut RojoTree, patch_set: PatchSet) -> AppliedPatchSet {
-    let mut context = PatchApplyContext::default();
+    let mut context = PatchApplyContext::new(patch_set.source);
 
     for removed_id in patch_set.removed_instances {
         apply_remove_instance(&mut context, tree, removed_id);
@@ -72,6 +74,16 @@ struct PatchApplyContext {
 
     /// The current applied patch result, describing changes made to the tree.
     applied_patch_set: AppliedPatchSet,
+}
+
+impl PatchApplyContext {
+    fn new(source: PeerId) -> PatchApplyContext {
+        Self {
+            snapshot_id_to_instance_id: HashMap::default(),
+            added_instance_properties: HashMap::default(),
+            applied_patch_set: AppliedPatchSet::new(source),
+        }
+    }
 }
 
 /// Finalize this patch application, consuming the context, applying any

--- a/src/snapshot/patch_compute.rs
+++ b/src/snapshot/patch_compute.rs
@@ -5,13 +5,20 @@ use std::collections::{HashMap, HashSet};
 
 use rbx_dom_weak::types::{Ref, Variant};
 
+use crate::peer_id::PeerId;
+
 use super::{
     patch::{PatchAdd, PatchSet, PatchUpdate},
     InstanceSnapshot, InstanceWithMeta, RojoTree,
 };
 
-pub fn compute_patch_set(snapshot: &InstanceSnapshot, tree: &RojoTree, id: Ref) -> PatchSet {
-    let mut patch_set = PatchSet::new();
+pub fn compute_patch_set(
+    snapshot: &InstanceSnapshot,
+    tree: &RojoTree,
+    id: Ref,
+    source: PeerId,
+) -> PatchSet {
+    let mut patch_set = PatchSet::new(source);
     let mut context = ComputePatchContext::default();
 
     compute_patch_set_internal(&mut context, snapshot, tree, id, &mut patch_set);
@@ -246,9 +253,11 @@ mod test {
             children: Vec::new(),
         };
 
-        let patch_set = compute_patch_set(&snapshot, &tree, root_id);
+        let source = PeerId::new();
+        let patch_set = compute_patch_set(&snapshot, &tree, root_id, source);
 
         let expected_patch_set = PatchSet {
+            source,
             updated_instances: vec![PatchUpdate {
                 id: root_id,
                 changed_name: None,
@@ -296,9 +305,11 @@ mod test {
             class_name: Cow::Borrowed("foo"),
         };
 
-        let patch_set = compute_patch_set(&snapshot, &tree, root_id);
+        let source = PeerId::new();
+        let patch_set = compute_patch_set(&snapshot, &tree, root_id, source);
 
         let expected_patch_set = PatchSet {
+            source,
             added_instances: vec![PatchAdd {
                 parent_id: root_id,
                 instance: InstanceSnapshot {

--- a/src/snapshot/tests/compute.rs
+++ b/src/snapshot/tests/compute.rs
@@ -5,7 +5,10 @@ use maplit::hashmap;
 
 use rojo_insta_ext::RedactionMap;
 
-use crate::snapshot::{compute_patch_set, InstanceSnapshot, RojoTree};
+use crate::{
+    peer_id::PeerId,
+    snapshot::{compute_patch_set, InstanceSnapshot, RojoTree},
+};
 
 #[test]
 fn set_name_and_class_name() {
@@ -13,6 +16,9 @@ fn set_name_and_class_name() {
 
     let tree = empty_tree();
     redactions.intern(tree.get_root_id());
+
+    let source = PeerId::new();
+    redactions.intern(source);
 
     let snapshot = InstanceSnapshot {
         snapshot_id: None,
@@ -23,7 +29,7 @@ fn set_name_and_class_name() {
         children: Vec::new(),
     };
 
-    let patch_set = compute_patch_set(&snapshot, &tree, tree.get_root_id());
+    let patch_set = compute_patch_set(&snapshot, &tree, tree.get_root_id(), source);
     let patch_value = redactions.redacted_yaml(patch_set);
 
     assert_yaml_snapshot!(patch_value);
@@ -36,6 +42,9 @@ fn set_property() {
     let tree = empty_tree();
     redactions.intern(tree.get_root_id());
 
+    let source = PeerId::new();
+    redactions.intern(source);
+
     let snapshot = InstanceSnapshot {
         snapshot_id: None,
         metadata: Default::default(),
@@ -47,7 +56,7 @@ fn set_property() {
         children: Vec::new(),
     };
 
-    let patch_set = compute_patch_set(&snapshot, &tree, tree.get_root_id());
+    let patch_set = compute_patch_set(&snapshot, &tree, tree.get_root_id(), source);
     let patch_value = redactions.redacted_yaml(patch_set);
 
     assert_yaml_snapshot!(patch_value);
@@ -59,6 +68,9 @@ fn remove_property() {
 
     let mut tree = empty_tree();
     redactions.intern(tree.get_root_id());
+
+    let source = PeerId::new();
+    redactions.intern(source);
 
     {
         let root_id = tree.get_root_id();
@@ -78,7 +90,7 @@ fn remove_property() {
         children: Vec::new(),
     };
 
-    let patch_set = compute_patch_set(&snapshot, &tree, tree.get_root_id());
+    let patch_set = compute_patch_set(&snapshot, &tree, tree.get_root_id(), source);
     let patch_value = redactions.redacted_yaml(patch_set);
 
     assert_yaml_snapshot!(patch_value);
@@ -90,6 +102,9 @@ fn add_child() {
 
     let tree = empty_tree();
     redactions.intern(tree.get_root_id());
+
+    let source = PeerId::new();
+    redactions.intern(source);
 
     let snapshot = InstanceSnapshot {
         snapshot_id: None,
@@ -107,7 +122,7 @@ fn add_child() {
         }],
     };
 
-    let patch_set = compute_patch_set(&snapshot, &tree, tree.get_root_id());
+    let patch_set = compute_patch_set(&snapshot, &tree, tree.get_root_id(), source);
     let patch_value = redactions.redacted_yaml(patch_set);
 
     assert_yaml_snapshot!(patch_value);
@@ -119,6 +134,9 @@ fn remove_child() {
 
     let mut tree = empty_tree();
     redactions.intern(tree.get_root_id());
+
+    let source = PeerId::new();
+    redactions.intern(source);
 
     {
         let root_id = tree.get_root_id();
@@ -139,7 +157,7 @@ fn remove_child() {
         children: Vec::new(),
     };
 
-    let patch_set = compute_patch_set(&snapshot, &tree, tree.get_root_id());
+    let patch_set = compute_patch_set(&snapshot, &tree, tree.get_root_id(), source);
     let patch_value = redactions.redacted_yaml(patch_set);
 
     assert_yaml_snapshot!(patch_value);

--- a/src/snapshot/tests/snapshots/librojo__snapshot__tests__apply__add_property-2.snap
+++ b/src/snapshot/tests/snapshots/librojo__snapshot__tests__apply__add_property-2.snap
@@ -3,6 +3,7 @@ source: src/snapshot/tests/apply.rs
 expression: applied_patch_value
 
 ---
+source: 00000000-0000-0000-0000-000000000000
 removed: []
 added: []
 updated:

--- a/src/snapshot/tests/snapshots/librojo__snapshot__tests__apply__remove_property_appied_patch.snap
+++ b/src/snapshot/tests/snapshots/librojo__snapshot__tests__apply__remove_property_appied_patch.snap
@@ -1,7 +1,9 @@
 ---
 source: src/snapshot/tests/apply.rs
 expression: applied_patch_value
+
 ---
+source: 00000000-0000-0000-0000-000000000000
 removed: []
 added: []
 updated:
@@ -11,3 +13,4 @@ updated:
     changed_properties:
       Foo: ~
     changed_metadata: ~
+

--- a/src/snapshot/tests/snapshots/librojo__snapshot__tests__apply__set_name_and_class_name-2.snap
+++ b/src/snapshot/tests/snapshots/librojo__snapshot__tests__apply__set_name_and_class_name-2.snap
@@ -1,7 +1,9 @@
 ---
 source: src/snapshot/tests/apply.rs
 expression: applied_patch_value
+
 ---
+source: 00000000-0000-0000-0000-000000000000
 removed: []
 added: []
 updated:
@@ -10,3 +12,4 @@ updated:
     changed_class_name: Folder
     changed_properties: {}
     changed_metadata: ~
+

--- a/src/snapshot/tests/snapshots/librojo__snapshot__tests__compute__add_child.snap
+++ b/src/snapshot/tests/snapshots/librojo__snapshot__tests__compute__add_child.snap
@@ -1,7 +1,9 @@
 ---
 source: src/snapshot/tests/compute.rs
 expression: patch_value
+
 ---
+source: id-2
 removed_instances: []
 added_instances:
   - parent_id: id-1
@@ -16,3 +18,4 @@ added_instances:
       properties: {}
       children: []
 updated_instances: []
+

--- a/src/snapshot/tests/snapshots/librojo__snapshot__tests__compute__remove_child.snap
+++ b/src/snapshot/tests/snapshots/librojo__snapshot__tests__compute__remove_child.snap
@@ -1,8 +1,11 @@
 ---
 source: src/snapshot/tests/compute.rs
 expression: patch_value
+
 ---
+source: id-2
 removed_instances:
-  - id-2
+  - id-3
 added_instances: []
 updated_instances: []
+

--- a/src/snapshot/tests/snapshots/librojo__snapshot__tests__compute__remove_property.snap
+++ b/src/snapshot/tests/snapshots/librojo__snapshot__tests__compute__remove_property.snap
@@ -1,7 +1,9 @@
 ---
 source: src/snapshot/tests/compute.rs
 expression: patch_value
+
 ---
+source: id-2
 removed_instances: []
 added_instances: []
 updated_instances:
@@ -11,3 +13,4 @@ updated_instances:
     changed_properties:
       Foo: ~
     changed_metadata: ~
+

--- a/src/snapshot/tests/snapshots/librojo__snapshot__tests__compute__set_name_and_class_name.snap
+++ b/src/snapshot/tests/snapshots/librojo__snapshot__tests__compute__set_name_and_class_name.snap
@@ -1,7 +1,9 @@
 ---
 source: src/snapshot/tests/compute.rs
 expression: patch_value
+
 ---
+source: id-2
 removed_instances: []
 added_instances: []
 updated_instances:
@@ -10,3 +12,4 @@ updated_instances:
     changed_class_name: Folder
     changed_properties: {}
     changed_metadata: ~
+

--- a/src/snapshot/tests/snapshots/librojo__snapshot__tests__compute__set_property.snap
+++ b/src/snapshot/tests/snapshots/librojo__snapshot__tests__compute__set_property.snap
@@ -3,6 +3,7 @@ source: src/snapshot/tests/compute.rs
 expression: patch_value
 
 ---
+source: id-2
 removed_instances: []
 added_instances: []
 updated_instances:

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -132,6 +132,7 @@ impl ApiService {
                             .collect();
 
                         SubscribeMessage {
+                            source: message.source,
                             removed,
                             added,
                             updated,
@@ -189,6 +190,7 @@ impl ApiService {
 
         tree_mutation_sender
             .send(PatchSet {
+                source: request.source,
                 removed_instances: Vec::new(),
                 added_instances: Vec::new(),
                 updated_instances,

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -61,6 +61,7 @@ impl ApiService {
             server_version: SERVER_VERSION.to_owned(),
             protocol_version: PROTOCOL_VERSION,
             session_id: self.serve_session.session_id(),
+            server_id: self.serve_session.server_id(),
             project_name: self.serve_session.project_name().to_owned(),
             expected_place_ids: self.serve_session.serve_place_ids().cloned(),
             place_id: self.serve_session.place_id(),

--- a/src/web/interface.rs
+++ b/src/web/interface.rs
@@ -105,6 +105,7 @@ impl<'a> Instance<'a> {
 pub struct ServerInfoResponse {
     pub session_id: SessionId,
     pub server_version: String,
+    pub server_id: PeerId,
     pub protocol_version: u64,
     pub project_name: String,
     pub expected_place_ids: Option<HashSet<u64>>,

--- a/src/web/interface.rs
+++ b/src/web/interface.rs
@@ -11,6 +11,7 @@ use rbx_dom_weak::types::{Ref, Variant};
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    peer_id::PeerId,
     session_id::SessionId,
     snapshot::{InstanceMetadata as RojoInstanceMetadata, InstanceWithMeta},
 };
@@ -25,6 +26,7 @@ pub const PROTOCOL_VERSION: u64 = 4;
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscribeMessage<'a> {
+    pub source: PeerId,
     pub removed: Vec<Ref>,
     pub added: HashMap<Ref, Instance<'a>>,
     pub updated: Vec<InstanceUpdate>,
@@ -124,6 +126,7 @@ pub struct ReadResponse<'a> {
 #[serde(rename_all = "camelCase")]
 pub struct WriteRequest {
     pub session_id: SessionId,
+    pub source: PeerId,
     pub removed: Vec<Ref>,
 
     #[serde(default)]

--- a/tests/rojo_test/serve_util.rs
+++ b/tests/rojo_test/serve_util.rs
@@ -34,6 +34,7 @@ pub fn run_serve_test(test_name: &str, callback: impl FnOnce(TestServeSession, R
     let info = session.wait_to_come_online();
 
     redactions.intern(info.session_id);
+    redactions.intern(info.server_id);
     redactions.intern(info.root_instance_id);
 
     let mut settings = insta::Settings::new();


### PR DESCRIPTION
Closes #295.

This PR adds the newtype `PeerId` and adds a `source: PeerId` member to patch sets; this allows a subscriber to identify who was responsible for any given patch set. It uses this to make the plugin ignore changes that the plugin itself sent during two-way sync.