### PR TITLE
Add a check to getProperty for unknown properties.

### DIFF
--- a/plugin/src/Reconciler/getProperty.lua
+++ b/plugin/src/Reconciler/getProperty.lua
@@ -40,6 +40,13 @@ local function getProperty(instance, propertyName)
 			})
 		end
 
+		if err.kind == RbxDom.Error.Kind.Roblox and err.extra:find("is not a valid member of") then
+			return false, Error.new(Error.UnknownProperty, {
+				className = instance.ClassName,
+				propertyName = propertyName,
+			})
+		end
+
 		return false, Error.new(Error.OtherPropertyError, {
 			className = instance.ClassName,
 			propertyName = propertyName,


### PR DESCRIPTION
This commit fixes the issue where the MaterialVariant property of a BasePart would error due to it being a FFlag only feature, and related potential future issues.
