### PR TITLE
Add a placeholder for CollisionGroups in customProperties.

### DIFF
--- a/plugin/rbx_dom_lua/customProperties.lua
+++ b/plugin/rbx_dom_lua/customProperties.lua
@@ -41,4 +41,15 @@ return {
 			end,
 		},
 	},
+	Workspace = {
+		-- Placeholder to avoid errors with collision groups
+		CollisionGroups = {
+			read = function(instance, key)
+				return true, nil
+			end,
+			write = function(instance, key, value)
+				return true
+			end,
+		}
+	},
 }


### PR DESCRIPTION
Currently if you use CollisionGroups inside of a project.json the project will fail to sync, this means that projects using CollisionGroups need 2 project.jsons's one for syncing and one for building. 
This PR fixes this by adding a placeholder for CollisionGroups inside of customProperties.lua

Fixes #476 