### PR TITLE
added caching to ci builds to reduce build times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ name: CI
 on:
   push:
     branches:
-    - master
+      - master
 
   pull_request:
     branches:
-    - master
+      - master
 
 jobs:
   build:
@@ -19,21 +19,31 @@ jobs:
         rust_version: [stable, "1.46.0"]
 
     steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: true
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
 
-    - name: Setup Rust toolchain
-      run: rustup default ${{ matrix.rust_version }}
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-rust-${{ matrix.rust_version }}-ci-${{ hashFiles('**/Cargo.lock') }}
 
-    - name: Build
-      run: cargo build --locked --verbose
+      - name: Setup Rust toolchain
+        run: rustup default ${{ matrix.rust_version }}
 
-    - name: Run tests
-      run: cargo test --locked --verbose
+      - name: Build
+        run: cargo build --locked --verbose
 
-    - name: Rustfmt and Clippy
-      run: |
-        cargo fmt -- --check
-        cargo clippy
-      if: matrix.rust_version == 'stable'
+      - name: Run tests
+        run: cargo test --locked --verbose
+
+      - name: Rustfmt and Clippy
+        run: |
+          cargo fmt -- --check
+          cargo clippy
+        if: matrix.rust_version == 'stable'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ name: CI
 on:
   push:
     branches:
-      - master
+    - master
 
   pull_request:
     branches:
-      - master
+    - master
 
 jobs:
   build:
@@ -19,31 +19,31 @@ jobs:
         rust_version: [stable, "1.46.0"]
 
     steps:
-      - uses: actions/checkout@v1
-        with:
-          submodules: true
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
 
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-rust-${{ matrix.rust_version }}-ci-${{ hashFiles('**/Cargo.lock') }}
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-rust-${{ matrix.rust_version }}-ci-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Setup Rust toolchain
-        run: rustup default ${{ matrix.rust_version }}
+    - name: Setup Rust toolchain
+      run: rustup default ${{ matrix.rust_version }}
 
-      - name: Build
-        run: cargo build --locked --verbose
+    - name: Build
+      run: cargo build --locked --verbose
 
-      - name: Run tests
-        run: cargo test --locked --verbose
+    - name: Run tests
+      run: cargo test --locked --verbose
 
-      - name: Rustfmt and Clippy
-        run: |
-          cargo fmt -- --check
-          cargo clippy
-        if: matrix.rust_version == 'stable'
+    - name: Rustfmt and Clippy
+      run: |
+        cargo fmt -- --check
+        cargo clippy
+      if: matrix.rust_version == 'stable'


### PR DESCRIPTION
This adds caching to the CI workflow which should improve build times quite a bit. I used the recommended cache parameters from here: https://github.com/actions/cache/blob/main/examples.md#rust---cargo

I tried this approach in my project and it took build times from ~1min to ~10s:
* before: https://github.com/blake-mealey/rocat/runs/3999515438?check_suite_focus=true
* after: https://github.com/blake-mealey/rocat/runs/4015757268?check_suite_focus=true

Note that I haven't added caching to the release workflow. We could do this as well but I don't think it'll give you any benefit since whenever you run that workflow your Cargo.toml has changed (bumped version number) and therefore it will always have a cache miss.