### PR TITLE
Support the new Open Cloud API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d9ff5d688f1c13395289f67db01d4826b46dd694e7580accdc3e8430f2d98e"
+checksum = "62e1f47f7dc0422027a4e370dd4548d4d66b26782e513e98dca1e689e058a80e"
 
 [[package]]
 name = "arrayref"
@@ -329,9 +329,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "crc32fast"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+checksum = "3825b1e8580894917dc4468cb634a1b4e9745fddc854edad72d9c04644c0319f"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -731,9 +731,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+checksum = "8cd0210d8c325c245ff06fd95a3b13689a1a276ac8cfa8e8720cb840bfb84b9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -746,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -756,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
 
 [[package]]
 name = "futures-cpupool"
@@ -772,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "7b808bf53348a36cab739d7e04755909b9fcaaa69b7d7e588b37b6ec62704c97"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -783,18 +783,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
 dependencies = [
- "autocfg 1.0.1",
- "proc-macro-hack",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
  "syn",
@@ -802,23 +800,22 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
 dependencies = [
- "autocfg 1.0.1",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -828,8 +825,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -2024,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "rbx_reflection_database"
-version = "0.2.3+roblox-503"
+version = "0.2.4+roblox-504"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f720dca247c34e34f73f155bb46e7aa532f1755d5ee8ef77c76a161c7e18d8"
+checksum = "b41e8da85aa697cd04cef48e6dd7d96992786d2e322bafe1d3cc93045f4de1e1"
 dependencies = [
  "lazy_static",
  "rbx_reflection",
@@ -2245,7 +2240,7 @@ dependencies = [
  "embed-resource",
  "env_logger",
  "fs-err",
- "futures 0.3.17",
+ "futures 0.3.18",
  "globset",
  "humantime",
  "hyper 0.14.15",
@@ -2422,9 +2417,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
+checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
 dependencies = [
  "itoa",
  "ryu",
@@ -2554,9 +2549,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",

--- a/plugin/rbx_dom_lua/database.json
+++ b/plugin/rbx_dom_lua/database.json
@@ -1,9 +1,9 @@
 {
   "Version": [
     0,
-    503,
+    504,
     0,
-    5030338
+    5040410
   ],
   "Classes": {
     "ABTestService": {
@@ -12405,6 +12405,7 @@
       "Name": "GamepadService",
       "Tags": [
         "NotCreatable",
+        "NotReplicated",
         "Service"
       ],
       "Superclass": "Instance",
@@ -18991,6 +18992,40 @@
         }
       }
     },
+    "MarkerCurve": {
+      "Name": "MarkerCurve",
+      "Tags": [],
+      "Superclass": "Instance",
+      "Properties": {
+        "Length": {
+          "Name": "Length",
+          "Scriptability": "Read",
+          "DataType": {
+            "Value": "Int32"
+          },
+          "Tags": [
+            "NotReplicated",
+            "ReadOnly"
+          ],
+          "Kind": {
+            "Canonical": {
+              "Serialization": "DoesNotSerialize"
+            }
+          }
+        }
+      },
+      "DefaultProperties": {
+        "AttributesSerialize": {
+          "BinaryString": ""
+        },
+        "SourceAssetId": {
+          "Int64": -1
+        },
+        "Tags": {
+          "BinaryString": ""
+        }
+      }
+    },
     "MarketplaceService": {
       "Name": "MarketplaceService",
       "Tags": [
@@ -19012,11 +19047,13 @@
       "Properties": {
         "Brick": {
           "Name": "Brick",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -19025,11 +19062,13 @@
         },
         "Cobblestone": {
           "Name": "Cobblestone",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -19038,11 +19077,13 @@
         },
         "Concrete": {
           "Name": "Concrete",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -19051,11 +19092,13 @@
         },
         "CorrodedMetal": {
           "Name": "CorrodedMetal",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -19064,11 +19107,13 @@
         },
         "DiamondPlate": {
           "Name": "DiamondPlate",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -19077,11 +19122,13 @@
         },
         "Fabric": {
           "Name": "Fabric",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -19090,11 +19137,13 @@
         },
         "Foil": {
           "Name": "Foil",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -19103,11 +19152,13 @@
         },
         "Granite": {
           "Name": "Granite",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -19116,11 +19167,13 @@
         },
         "Grass": {
           "Name": "Grass",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -19129,11 +19182,13 @@
         },
         "Ice": {
           "Name": "Ice",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -19142,11 +19197,13 @@
         },
         "Marble": {
           "Name": "Marble",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -19155,11 +19212,13 @@
         },
         "Metal": {
           "Name": "Metal",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -19168,11 +19227,13 @@
         },
         "Pebble": {
           "Name": "Pebble",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -19181,11 +19242,13 @@
         },
         "Plastic": {
           "Name": "Plastic",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -19194,11 +19257,13 @@
         },
         "Sand": {
           "Name": "Sand",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -19207,11 +19272,13 @@
         },
         "Slate": {
           "Name": "Slate",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -19220,11 +19287,13 @@
         },
         "SmoothPlastic": {
           "Name": "SmoothPlastic",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -19233,11 +19302,13 @@
         },
         "Wood": {
           "Name": "Wood",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -19246,11 +19317,13 @@
         },
         "WoodPlanks": {
           "Name": "WoodPlanks",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Ref"
           },
-          "Tags": [],
+          "Tags": [
+            "NotScriptable"
+          ],
           "Kind": {
             "Canonical": {
               "Serialization": "Serializes"
@@ -20025,23 +20098,6 @@
           "Scriptability": "None",
           "DataType": {
             "Value": "String"
-          },
-          "Tags": [
-            "Hidden",
-            "NotReplicated",
-            "ReadOnly"
-          ],
-          "Kind": {
-            "Canonical": {
-              "Serialization": "DoesNotSerialize"
-            }
-          }
-        },
-        "Valid": {
-          "Name": "Valid",
-          "Scriptability": "None",
-          "DataType": {
-            "Value": "Bool"
           },
           "Tags": [
             "Hidden",
@@ -23091,6 +23147,19 @@
               "Serialization": "Serializes"
             }
           }
+        },
+        "ModifierId": {
+          "Name": "ModifierId",
+          "Scriptability": "ReadWrite",
+          "DataType": {
+            "Value": "String"
+          },
+          "Tags": [],
+          "Kind": {
+            "Canonical": {
+              "Serialization": "Serializes"
+            }
+          }
         }
       },
       "DefaultProperties": {
@@ -23099,6 +23168,9 @@
         },
         "IsBidirectional": {
           "Bool": true
+        },
+        "ModifierId": {
+          "String": ""
         },
         "SourceAssetId": {
           "Int64": -1
@@ -27272,6 +27344,107 @@
         }
       }
     },
+    "RigidConstraint": {
+      "Name": "RigidConstraint",
+      "Tags": [
+        "NotBrowsable"
+      ],
+      "Superclass": "Constraint",
+      "Properties": {
+        "Broken": {
+          "Name": "Broken",
+          "Scriptability": "ReadWrite",
+          "DataType": {
+            "Value": "Bool"
+          },
+          "Tags": [
+            "NotBrowsable"
+          ],
+          "Kind": {
+            "Canonical": {
+              "Serialization": "Serializes"
+            }
+          }
+        },
+        "DestructionEnabled": {
+          "Name": "DestructionEnabled",
+          "Scriptability": "ReadWrite",
+          "DataType": {
+            "Value": "Bool"
+          },
+          "Tags": [
+            "NotBrowsable"
+          ],
+          "Kind": {
+            "Canonical": {
+              "Serialization": "Serializes"
+            }
+          }
+        },
+        "DestructionForce": {
+          "Name": "DestructionForce",
+          "Scriptability": "ReadWrite",
+          "DataType": {
+            "Value": "Float32"
+          },
+          "Tags": [
+            "NotBrowsable"
+          ],
+          "Kind": {
+            "Canonical": {
+              "Serialization": "Serializes"
+            }
+          }
+        },
+        "DestructionTorque": {
+          "Name": "DestructionTorque",
+          "Scriptability": "ReadWrite",
+          "DataType": {
+            "Value": "Float32"
+          },
+          "Tags": [
+            "NotBrowsable"
+          ],
+          "Kind": {
+            "Canonical": {
+              "Serialization": "Serializes"
+            }
+          }
+        }
+      },
+      "DefaultProperties": {
+        "AttributesSerialize": {
+          "BinaryString": ""
+        },
+        "Broken": {
+          "Bool": false
+        },
+        "Color": {
+          "Int32": 194
+        },
+        "DestructionEnabled": {
+          "Bool": false
+        },
+        "DestructionForce": {
+          "Float32": null
+        },
+        "DestructionTorque": {
+          "Float32": null
+        },
+        "Enabled": {
+          "Bool": true
+        },
+        "SourceAssetId": {
+          "Int64": -1
+        },
+        "Tags": {
+          "BinaryString": ""
+        },
+        "Visible": {
+          "Bool": false
+        }
+      }
+    },
     "RobloxPluginGuiService": {
       "Name": "RobloxPluginGuiService",
       "Tags": [
@@ -28336,6 +28509,17 @@
           }
         }
       },
+      "DefaultProperties": {}
+    },
+    "ScriptRegistrationService": {
+      "Name": "ScriptRegistrationService",
+      "Tags": [
+        "NotCreatable",
+        "NotReplicated",
+        "Service"
+      ],
+      "Superclass": "Instance",
+      "Properties": {},
       "DefaultProperties": {}
     },
     "ScriptService": {
@@ -33930,6 +34114,22 @@
             }
           }
         },
+        "Doc View Code Background Color": {
+          "Name": "Doc View Code Background Color",
+          "Scriptability": "None",
+          "DataType": {
+            "Value": "Color3"
+          },
+          "Tags": [
+            "Hidden",
+            "NotReplicated"
+          ],
+          "Kind": {
+            "Canonical": {
+              "Serialization": "DoesNotSerialize"
+            }
+          }
+        },
         "Drag Multiple Parts As Single Part": {
           "Name": "Drag Multiple Parts As Single Part",
           "Scriptability": "ReadWrite",
@@ -33946,6 +34146,19 @@
         "Enable Autocomplete": {
           "Name": "Enable Autocomplete",
           "Scriptability": "ReadWrite",
+          "DataType": {
+            "Value": "Bool"
+          },
+          "Tags": [],
+          "Kind": {
+            "Canonical": {
+              "Serialization": "Serializes"
+            }
+          }
+        },
+        "Enable Autocomplete Doc View": {
+          "Name": "Enable Autocomplete Doc View",
+          "Scriptability": "None",
           "DataType": {
             "Value": "Bool"
           },
@@ -34036,6 +34249,19 @@
         },
         "Enable Signature Help": {
           "Name": "Enable Signature Help",
+          "Scriptability": "None",
+          "DataType": {
+            "Value": "Bool"
+          },
+          "Tags": [],
+          "Kind": {
+            "Canonical": {
+              "Serialization": "Serializes"
+            }
+          }
+        },
+        "Enable Signature Help Doc View": {
+          "Name": "Enable Signature Help Doc View",
           "Scriptability": "None",
           "DataType": {
             "Value": "Bool"
@@ -43465,7 +43691,23 @@
         "Service"
       ],
       "Superclass": "Instance",
-      "Properties": {},
+      "Properties": {
+        "ScriptCollabEnabled": {
+          "Name": "ScriptCollabEnabled",
+          "Scriptability": "None",
+          "DataType": {
+            "Value": "Bool"
+          },
+          "Tags": [
+            "Hidden"
+          ],
+          "Kind": {
+            "Canonical": {
+              "Serialization": "DoesNotSerialize"
+            }
+          }
+        }
+      },
       "DefaultProperties": {}
     },
     "VideoFrame": {
@@ -44036,6 +44278,7 @@
     "VoiceChatService": {
       "Name": "VoiceChatService",
       "Tags": [
+        "Deprecated",
         "NotCreatable",
         "Service"
       ],
@@ -44410,7 +44653,9 @@
           ],
           "Kind": {
             "Canonical": {
-              "Serialization": "DoesNotSerialize"
+              "Serialization": {
+                "SerializesAs": "Part0Internal"
+              }
             }
           }
         },
@@ -44438,7 +44683,9 @@
           ],
           "Kind": {
             "Canonical": {
-              "Serialization": "DoesNotSerialize"
+              "Serialization": {
+                "SerializesAs": "Part1Internal"
+              }
             }
           }
         },
@@ -44521,7 +44768,7 @@
         },
         "CollisionGroups": {
           "Name": "CollisionGroups",
-          "Scriptability": "Custom",
+          "Scriptability": "None",
           "DataType": {
             "Value": "String"
           },
@@ -47889,6 +48136,7 @@
         "DebuggerCurrentLine": 26,
         "DebuggerErrorLine": 27,
         "Default": 0,
+        "DocViewCodeBackground": 38,
         "Error": 23,
         "FindSelectionBackground": 20,
         "Function": 11,
@@ -47932,48 +48180,49 @@
     "StudioStyleGuideColor": {
       "name": "StudioStyleGuideColor",
       "items": {
-        "AttributeCog": 115,
+        "AttributeCog": 116,
         "Border": 31,
         "BrightText": 39,
         "Button": 17,
-        "ButtonBorder": 87,
-        "ButtonText": 88,
+        "ButtonBorder": 88,
+        "ButtonText": 89,
         "CategoryItem": 24,
-        "ChatIncomingBgColor": 81,
-        "ChatIncomingTextColor": 82,
-        "ChatModeratedMessageColor": 85,
-        "ChatOutgoingBgColor": 83,
-        "ChatOutgoingTextColor": 84,
-        "CheckedFieldBackground": 90,
-        "CheckedFieldBorder": 91,
-        "CheckedFieldIndicator": 92,
+        "ChatIncomingBgColor": 82,
+        "ChatIncomingTextColor": 83,
+        "ChatModeratedMessageColor": 86,
+        "ChatOutgoingBgColor": 84,
+        "ChatOutgoingTextColor": 85,
+        "CheckedFieldBackground": 91,
+        "CheckedFieldBorder": 92,
+        "CheckedFieldIndicator": 93,
         "ColorPickerFrame": 29,
         "CurrentMarker": 30,
         "Dark": 34,
-        "DebuggerCurrentLine": 63,
-        "DebuggerErrorLine": 64,
-        "DialogButton": 96,
-        "DialogButtonBorder": 98,
-        "DialogButtonText": 97,
-        "DialogMainButton": 99,
-        "DialogMainButtonText": 100,
-        "DiffFilePathBackground": 79,
-        "DiffFilePathBorder": 80,
-        "DiffFilePathText": 65,
-        "DiffLineNum": 74,
-        "DiffLineNumAdditionBackground": 77,
-        "DiffLineNumDeletionBackground": 78,
-        "DiffLineNumNoChangeBackground": 76,
-        "DiffLineNumSeparatorBackground": 75,
-        "DiffTextAddition": 68,
-        "DiffTextAdditionBackground": 72,
-        "DiffTextDeletion": 69,
-        "DiffTextDeletionBackground": 73,
-        "DiffTextHunkInfo": 66,
-        "DiffTextNoChange": 67,
-        "DiffTextNoChangeBackground": 71,
-        "DiffTextSeparatorBackground": 70,
+        "DebuggerCurrentLine": 64,
+        "DebuggerErrorLine": 65,
+        "DialogButton": 97,
+        "DialogButtonBorder": 99,
+        "DialogButtonText": 98,
+        "DialogMainButton": 100,
+        "DialogMainButtonText": 101,
+        "DiffFilePathBackground": 80,
+        "DiffFilePathBorder": 81,
+        "DiffFilePathText": 66,
+        "DiffLineNum": 75,
+        "DiffLineNumAdditionBackground": 78,
+        "DiffLineNumDeletionBackground": 79,
+        "DiffLineNumNoChangeBackground": 77,
+        "DiffLineNumSeparatorBackground": 76,
+        "DiffTextAddition": 69,
+        "DiffTextAdditionBackground": 73,
+        "DiffTextDeletion": 70,
+        "DiffTextDeletionBackground": 74,
+        "DiffTextHunkInfo": 67,
+        "DiffTextNoChange": 68,
+        "DiffTextNoChangeBackground": 72,
+        "DiffTextSeparatorBackground": 71,
         "DimmedText": 40,
+        "DocViewCodeBackground": 63,
         "Dropdown": 2,
         "EmulatorBar": 27,
         "EmulatorDropDown": 28,
@@ -47986,12 +48235,12 @@
         "FilterButtonHover": 10,
         "GameSettingsTableItem": 25,
         "GameSettingsTooltip": 26,
-        "HeaderSection": 93,
-        "InfoBarWarningBackground": 101,
-        "InfoBarWarningText": 102,
+        "HeaderSection": 94,
+        "InfoBarWarningBackground": 102,
+        "InfoBarWarningText": 103,
         "InfoText": 44,
         "InputFieldBackground": 21,
-        "InputFieldBorder": 89,
+        "InputFieldBorder": 90,
         "Item": 22,
         "Light": 33,
         "LinkText": 41,
@@ -47999,46 +48248,46 @@
         "MainButton": 18,
         "MainText": 36,
         "Mid": 35,
-        "Midlight": 94,
+        "Midlight": 95,
         "Notification": 4,
         "RibbonButton": 19,
         "RibbonTab": 15,
         "RibbonTabTopBar": 16,
         "ScriptBackground": 47,
-        "ScriptBool": 107,
-        "ScriptBracket": 114,
+        "ScriptBool": 108,
+        "ScriptBracket": 115,
         "ScriptBuiltInFunction": 58,
         "ScriptComment": 56,
-        "ScriptEditorCurrentLine": 103,
+        "ScriptEditorCurrentLine": 104,
         "ScriptError": 60,
         "ScriptFindSelectionBackground": 51,
-        "ScriptFunction": 108,
-        "ScriptFunctionName": 112,
+        "ScriptFunction": 109,
+        "ScriptFunctionName": 113,
         "ScriptKeyword": 57,
-        "ScriptLocal": 109,
-        "ScriptLuauKeyword": 111,
+        "ScriptLocal": 110,
+        "ScriptLuauKeyword": 112,
         "ScriptMatchingWordSelectionBackground": 52,
-        "ScriptMethod": 104,
-        "ScriptNil": 106,
+        "ScriptMethod": 105,
+        "ScriptNil": 107,
         "ScriptNumber": 54,
         "ScriptOperator": 53,
-        "ScriptProperty": 105,
+        "ScriptProperty": 106,
         "ScriptRuler": 62,
         "ScriptSelectionBackground": 50,
         "ScriptSelectionText": 49,
-        "ScriptSelf": 110,
+        "ScriptSelf": 111,
         "ScriptSideWidget": 46,
         "ScriptString": 55,
         "ScriptText": 48,
-        "ScriptTodo": 113,
+        "ScriptTodo": 114,
         "ScriptWarning": 59,
         "ScriptWhitespace": 61,
         "ScrollBar": 5,
         "ScrollBarBackground": 6,
         "SensitiveText": 45,
-        "Separator": 86,
+        "Separator": 87,
         "Shadow": 32,
-        "StatusBar": 95,
+        "StatusBar": 96,
         "SubText": 37,
         "Tab": 8,
         "TabBar": 7,

--- a/src/cli/upload.rs
+++ b/src/cli/upload.rs
@@ -24,13 +24,13 @@ pub struct UploadCommand {
     #[structopt(long)]
     pub cookie: Option<String>,
 
-	/// Used for the new Open Cloud API. Still experimental.
-	#[structopt(long = "api_key")]
-	pub api_key: Option<String>,
+    /// Used for the new Open Cloud API. Still experimental.
+    #[structopt(long = "api_key")]
+    pub api_key: Option<String>,
 
-	/// Required when using the Open Cloud API.
-	#[structopt(long = "universe_id")]
-	pub universe_id: Option<u64>,
+    /// Required when using the Open Cloud API.
+    #[structopt(long = "universe_id")]
+    pub universe_id: Option<u64>,
 
     /// Asset ID to upload to.
     #[structopt(long = "asset_id")]
@@ -41,30 +41,30 @@ impl UploadCommand {
     pub fn run(self) -> Result<(), anyhow::Error> {
         let project_path = resolve_path(&self.project);
 
-		let use_open_cloud = self.api_key.is_some();
-        
-		// Validate differently depending on if we're trying to use open cloud or not.
-		// If there's a better way of doing this, please do so.
-		let api_key = if use_open_cloud { 
+        let use_open_cloud = self.api_key.is_some();
+
+        // Validate differently depending on if we're trying to use open cloud or not.
+        // If there's a better way of doing this, please do so.
+        let api_key = if use_open_cloud {
             self.api_key
                 .context("Rojo could not find your api key. Please pass one via --api_key")?
-		} else { 
-			"undefined".to_string()
-		};
-		let universe_id = if use_open_cloud { 
-			self.universe_id.context(
+        } else {
+            "undefined".to_string()
+        };
+        let universe_id = if use_open_cloud {
+            self.universe_id.context(
 				"A Universe id is required when using the Open Cloud API. Please pass one via --universe_id"
 			)?
-		} else { 
-			0
-		};
-		let cookie = if use_open_cloud { 
-			"undefined".to_string() 
-		} else { 
-			self.cookie.or_else(get_auth_cookie).context(
+        } else {
+            0
+        };
+        let cookie = if use_open_cloud {
+            "undefined".to_string()
+        } else {
+            self.cookie.or_else(get_auth_cookie).context(
                 "Rojo could not find your Roblox auth cookie. Please pass one via --cookie.",
-			)? 
-		};
+            )?
+        };
 
         let vfs = Vfs::new_default();
 
@@ -79,15 +79,15 @@ impl UploadCommand {
             _ => vec![root.referent()],
         };
 
-		let mut buffer = Vec::new();
+        let mut buffer = Vec::new();
 
         log::trace!("Encoding binary model");
         rbx_binary::to_writer(&mut buffer, tree.inner(), &encode_ids)?;
-		if use_open_cloud {
-			return do_upload_open_cloud(buffer, universe_id, self.asset_id, &api_key);
-		} else {
-			return do_upload(buffer, self.asset_id, &cookie);
-		}
+        if use_open_cloud {
+            return do_upload_open_cloud(buffer, universe_id, self.asset_id, &api_key);
+        } else {
+            return do_upload(buffer, self.asset_id, &cookie);
+        }
     }
 }
 
@@ -187,8 +187,8 @@ fn do_upload_open_cloud(
     log::debug!("Uploading to Roblox...");
     let mut response = build_request().send()?;
 
-	// Previously would've attempted to complete a CSRF challenge.
-	// That should not be required using this API.(hopefully)
+    // Previously would've attempted to complete a CSRF challenge.
+    // That should not be required using this API.(hopefully)
 
     let status = response.status();
     if !status.is_success() {

--- a/src/cli/upload.rs
+++ b/src/cli/upload.rs
@@ -45,15 +45,27 @@ impl UploadCommand {
         
 		// Validate differently depending on if we're trying to use open cloud or not.
 		// If there's a better way of doing this, please do so.
-		let api_key = if use_open_cloud { self.api_key.context(
-			"Rojo could not find your api key. Please pass one via --api_key"
-		)? } else { "undefined".to_string() };
-		let universe_id = if use_open_cloud { self.universe_id.context(
-			"A Universe id is required when using the Open Cloud API. Please pass one via --universe_id"
-		)? } else { 0 };
-		let cookie = if use_open_cloud { "undefined".to_string() } else { self.cookie.or_else(get_auth_cookie).context(
-			"Rojo could not find your Roblox auth cookie. Please pass one via --cookie."
-		)? };
+		let api_key = if use_open_cloud { 
+			self.api_key.context(
+				"Rojo could not find your api key. Please pass one via --api_key"
+			)?
+		} else { 
+			"undefined".to_string()
+		};
+		let universe_id = if use_open_cloud { 
+			self.universe_id.context(
+				"A Universe id is required when using the Open Cloud API. Please pass one via --universe_id"
+			)?
+		} else { 
+			0
+		};
+		let cookie = if use_open_cloud { 
+			"undefined".to_string() 
+		} else { 
+			self.cookie.or_else(get_auth_cookie).context(
+				"Rojo could not find your Roblox auth cookie. Please pass one via --cookie."
+			)? 
+		};
 
         let vfs = Vfs::new_default();
 

--- a/src/cli/upload.rs
+++ b/src/cli/upload.rs
@@ -46,9 +46,8 @@ impl UploadCommand {
 		// Validate differently depending on if we're trying to use open cloud or not.
 		// If there's a better way of doing this, please do so.
 		let api_key = if use_open_cloud { 
-			self.api_key.context(
-				"Rojo could not find your api key. Please pass one via --api_key"
-			)?
+            self.api_key
+                .context("Rojo could not find your api key. Please pass one via --api_key")?
 		} else { 
 			"undefined".to_string()
 		};
@@ -63,7 +62,7 @@ impl UploadCommand {
 			"undefined".to_string() 
 		} else { 
 			self.cookie.or_else(get_auth_cookie).context(
-				"Rojo could not find your Roblox auth cookie. Please pass one via --cookie."
+                "Rojo could not find your Roblox auth cookie. Please pass one via --cookie.",
 			)? 
 		};
 
@@ -163,11 +162,15 @@ fn do_upload(buffer: Vec<u8>, asset_id: u64, cookie: &str) -> anyhow::Result<()>
 /// Implementation of do_upload that supports the new open cloud api.
 /// I'm sure there's a better of doing this. Please correct it if so.
 /// see https://developer.roblox.com/en-us/articles/open-cloud
-fn do_upload_open_cloud(buffer: Vec<u8>, universe_id: u64, asset_id: u64, api_key: &str) -> anyhow::Result<()> {
+fn do_upload_open_cloud(
+    buffer: Vec<u8>,
+    universe_id: u64,
+    asset_id: u64,
+    api_key: &str,
+) -> anyhow::Result<()> {
     let url = format!(
         "https://apis.roblox.com/universes/v1/{}/places/{}/versions?versionType=Published",
-		universe_id,
-        asset_id
+        universe_id, asset_id
     );
 
     let client = reqwest::Client::new();

--- a/src/cli/upload.rs
+++ b/src/cli/upload.rs
@@ -178,7 +178,7 @@ fn do_upload_open_cloud(buffer: Vec<u8>, universe_id: u64, asset_id: u64, api_ke
             .header("x-api-key", api_key)
             .header(CONTENT_TYPE, "application/xml")
             .header(ACCEPT, "application/json")
-            .body(buffer.clone())
+            .body(buffer)
     };
 
     log::debug!("Uploading to Roblox...");


### PR DESCRIPTION
Closes #486 by providing a ``--api_key`` along with ``--universe_id`` in place of ``--cookie``. Universe ID is required in order to use the open cloud api.
So new upload commands will look like ``rojo upload --api_key <API_KEY> --asset_id <PLACE_ID> --universe_id <UNIVERSE_ID> [project file]``
Instead of ``rojo upload --cookie <COOKIE> --asset_id <PLACE_ID> [project file]``

This was made with an accumulative ~3 hours of experience with rust, so I'm sure things could be done better and I'm open to suggestions. Most notably lines 48-68.