### PR TITLE
Add ability to specify address in default.project.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Rojo Changelog
 
 ## Unreleased Changes
+* Added support for specifying an address to be used by default in the .project.json file ([#447])
 * Fixed Rojo's interactions with properties enabled by FFlags that are not yet enabled. ([#493])
 * Improved output in Roblox Studio plugin when bad property data is encountered.
 * Reintroduced support for CFrame shorthand syntax in Rojo project and `.meta.json` files, matching Rojo 6. ([#430])
 * Connection settings are now remembered when reconnecting in Roblox Studio. ([#500])
 * Updated reflection database to Roblox v503.
 
+[#447]: https://github.com/rojo-rbx/rojo/issues/447
 [#430]: https://github.com/rojo-rbx/rojo/issues/430
 [#493]: https://github.com/rojo-rbx/rojo/pull/493
 [#500]: https://github.com/rojo-rbx/rojo/pull/500

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -42,9 +42,9 @@ impl ServeCommand {
         let session = Arc::new(ServeSession::new(vfs, &project_path)?);
 
         let ip = self
-			.address
-			.or_else(|| session.serve_address())
-			.unwrap_or(DEFAULT_BIND_ADDRESS.into());
+            .address
+            .or_else(|| session.serve_address())
+            .unwrap_or(DEFAULT_BIND_ADDRESS.into());
 
         let port = self
             .port

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -41,7 +41,10 @@ impl ServeCommand {
 
         let session = Arc::new(ServeSession::new(vfs, &project_path)?);
 
-        let ip = self.address.unwrap_or(DEFAULT_BIND_ADDRESS.into());
+        let ip = self
+			.address
+			.or_else(|| session.serve_address())
+			.unwrap_or(DEFAULT_BIND_ADDRESS.into());
 
         let port = self
             .port

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fs, io,
-	net::IpAddr,
+    net::IpAddr,
     path::{Path, PathBuf},
 };
 
@@ -68,10 +68,10 @@ pub struct Project {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub game_id: Option<u64>,
 
-	/// If specified, this address will be used in place of the default address
-	/// As long as --address is unprovided.
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub serve_address: Option<IpAddr>,
+    /// If specified, this address will be used in place of the default address
+    /// As long as --address is unprovided.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub serve_address: Option<IpAddr>,
 
     /// A list of globs, relative to the folder the project file is in, that
     /// match files that should be excluded if Rojo encounters them.

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fs, io,
+	net::IpAddr,
     path::{Path, PathBuf},
 };
 
@@ -66,6 +67,11 @@ pub struct Project {
     /// Rojo server from Roblox Studio.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub game_id: Option<u64>,
+
+	/// If specified, this address will be used in place of the default address
+	/// As long as --address is unprovided.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub serve_address: Option<IpAddr>,
 
     /// A list of globs, relative to the folder the project file is in, that
     /// match files that should be excluded if Rojo encounters them.

--- a/src/serve_session.rs
+++ b/src/serve_session.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Cow,
     collections::HashSet,
     io,
-	net::IpAddr,
+    net::IpAddr,
     path::{Path, PathBuf},
     sync::{Arc, Mutex, MutexGuard},
     time::Instant,
@@ -214,9 +214,9 @@ impl ServeSession {
         self.root_project.serve_place_ids.as_ref()
     }
 
-	pub fn serve_address(&self) -> Option<IpAddr> {
-		self.root_project.serve_address
-	}
+    pub fn serve_address(&self) -> Option<IpAddr> {
+        self.root_project.serve_address
+    }
 }
 
 #[derive(Debug, Error)]

--- a/src/serve_session.rs
+++ b/src/serve_session.rs
@@ -2,6 +2,7 @@ use std::{
     borrow::Cow,
     collections::HashSet,
     io,
+	net::IpAddr,
     path::{Path, PathBuf},
     sync::{Arc, Mutex, MutexGuard},
     time::Instant,
@@ -212,6 +213,10 @@ impl ServeSession {
     pub fn serve_place_ids(&self) -> Option<&HashSet<u64>> {
         self.root_project.serve_place_ids.as_ref()
     }
+
+	pub fn serve_address(&self) -> Option<IpAddr> {
+		self.root_project.serve_address
+	}
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
Close #447. Gives support for specifying the default address in the .project.json file.
Running rojo serve with the ``--address`` flag will still use the passed address rather than the address specified in .project.json.

Example entry:
```json
{
  "name": "serve-address-example",
  "serveAddress": "127.0.0.1",
  "tree": {
    "$className": "DataModel"
  }
}
```