### PR TITLE
Implement sourcemap CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## Unreleased Changes
 * Added support for specifying an address to be used by default in the .project.json file ([#447])
 * Added support for the new Open Cloud API when uploading. ([#486])
+* Added `sourcemap` command for generating sourcemaps to feed into other tools. ([#530])
 
 [#447]: https://github.com/rojo-rbx/rojo/issues/447
 [#486]: https://github.com/rojo-rbx/rojo/issues/486
+[#530]: https://github.com/rojo-rbx/rojo/pull/530
 
 ## [7.0.0] - December 10, 2021
 * Fixed Rojo's interactions with properties enabled by FFlags that are not yet enabled. ([#493])

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,7 @@ mod fmt_project;
 mod init;
 mod plugin;
 mod serve;
+mod sourcemap;
 mod upload;
 
 use std::{borrow::Cow, env, path::Path, str::FromStr};
@@ -19,6 +20,7 @@ pub use self::fmt_project::FmtProjectCommand;
 pub use self::init::{InitCommand, InitKind};
 pub use self::plugin::{PluginCommand, PluginSubcommand};
 pub use self::serve::ServeCommand;
+pub use self::sourcemap::SourcemapCommand;
 pub use self::upload::UploadCommand;
 
 /// Command line options that Rojo accepts, defined using the structopt crate.
@@ -40,6 +42,7 @@ impl Options {
             Subcommand::Serve(subcommand) => subcommand.run(self.global),
             Subcommand::Build(subcommand) => subcommand.run(),
             Subcommand::Upload(subcommand) => subcommand.run(),
+            Subcommand::Sourcemap(subcommand) => subcommand.run(),
             Subcommand::FmtProject(subcommand) => subcommand.run(),
             Subcommand::Doc(subcommand) => subcommand.run(),
             Subcommand::Plugin(subcommand) => subcommand.run(),
@@ -112,6 +115,7 @@ pub enum Subcommand {
     Serve(ServeCommand),
     Build(BuildCommand),
     Upload(UploadCommand),
+    Sourcemap(SourcemapCommand),
     FmtProject(FmtProjectCommand),
     Doc(DocCommand),
     Plugin(PluginCommand),

--- a/src/cli/sourcemap.rs
+++ b/src/cli/sourcemap.rs
@@ -33,7 +33,7 @@ struct SourcemapNode {
     children: Option<Vec<SourcemapNode>>,
 }
 
-/// Generates a model or place file from the Rojo project.
+/// Generates a sourcemap file from the Rojo project.
 #[derive(Debug, StructOpt)]
 pub struct SourcemapCommand {
     /// Path to the project to serve. Defaults to the current directory.

--- a/src/cli/sourcemap.rs
+++ b/src/cli/sourcemap.rs
@@ -36,7 +36,7 @@ struct SourcemapNode {
 /// Generates a sourcemap file from the Rojo project.
 #[derive(Debug, StructOpt)]
 pub struct SourcemapCommand {
-    /// Path to the project to serve. Defaults to the current directory.
+    /// Path to the project to use for the sourcemap. Defaults to the current directory.
     #[structopt(default_value = "")]
     pub project: PathBuf,
 

--- a/src/cli/sourcemap.rs
+++ b/src/cli/sourcemap.rs
@@ -1,20 +1,17 @@
 use std::{
-    sync::MutexGuard,
-    io::{BufWriter, Write, stdout},
-    path::PathBuf
+    io::{BufWriter, Write},
+    path::{Path, PathBuf},
 };
 
-use memofs::Vfs;
 use fs_err::File;
+use memofs::Vfs;
+use rbx_dom_weak::types::Ref;
 use serde::Serialize;
 use structopt::StructOpt;
 
 use crate::{
     serve_session::ServeSession,
-    snapshot::{
-        RojoTree,
-        InstanceWithMeta
-    }
+    snapshot::{InstanceWithMeta, RojoTree},
 };
 
 use super::resolve_path;
@@ -27,20 +24,24 @@ const PATH_STRIP_FAILED_ERR: &str = "Failed to create relative paths for project
 struct SourcemapNode {
     name: String,
     class_name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    file_paths: Option<Vec<PathBuf>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    children: Option<Vec<SourcemapNode>>,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    file_paths: Vec<PathBuf>,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    children: Vec<SourcemapNode>,
 }
 
 /// Generates a sourcemap file from the Rojo project.
 #[derive(Debug, StructOpt)]
 pub struct SourcemapCommand {
-    /// Path to the project to use for the sourcemap. Defaults to the current directory.
+    /// Path to the project to use for the sourcemap. Defaults to the current
+    /// directory.
     #[structopt(default_value = "")]
     pub project: PathBuf,
 
-    /// Where to output the sourcemap. Omit this to use stdout instead of writing to a file.
+    /// Where to output the sourcemap. Omit this to use stdout instead of
+    /// writing to a file.
     ///
     /// Should end in .json.
     #[structopt(long, short)]
@@ -62,89 +63,77 @@ impl SourcemapCommand {
         let vfs = Vfs::new_default();
 
         let session = ServeSession::new(vfs, &project_path)?;
-
         let tree = session.tree();
 
-        let root_node = recurse_create_node(
-            &tree,
-            &tree.get_instance(tree.get_root_id()).unwrap(),
-            &project_dir,
-            &self.include_non_scripts
-        );
+        let filter = if self.include_non_scripts {
+            filter_nothing
+        } else {
+            filter_non_scripts
+        };
+
+        let root_node = recurse_create_node(&tree, tree.get_root_id(), &project_dir, filter);
 
         if let Some(output_path) = self.output {
             let mut file = BufWriter::new(File::create(&output_path)?);
             serde_json::to_writer(&mut file, &root_node)?;
             file.flush()?;
 
-            let filename = &output_path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .unwrap_or("<invalid utf-8>");
-            println!("Created sourcemap at {}", filename);
+            println!("Created sourcemap at {}", output_path.display());
         } else {
-            let str = serde_json::to_string(&root_node)?;
-            stdout().write(str.as_bytes())?;
+            let output = serde_json::to_string(&root_node)?;
+            println!("{}", output);
         }
 
         Ok(())
     }
 }
 
+fn filter_nothing(_instance: &InstanceWithMeta) -> bool {
+    true
+}
+
+fn filter_non_scripts(instance: &InstanceWithMeta) -> bool {
+    match instance.class_name() {
+        "Script" | "LocalScript" | "ModuleScript" => true,
+        _ => false,
+    }
+}
+
 fn recurse_create_node(
-    tree: &MutexGuard<RojoTree>,
-    instance: &InstanceWithMeta,
-    project_dir: &PathBuf,
-    include_non_scripts: &bool
+    tree: &RojoTree,
+    referent: Ref,
+    project_dir: &Path,
+    filter: fn(&InstanceWithMeta) -> bool,
 ) -> Option<SourcemapNode> {
+    let instance = tree.get_instance(referent).expect("instance did not exist");
 
-    let mut node_children = Vec::new();
-    for child_id in instance.children() {
-        if let Some(child_instance) = tree.get_instance(child_id.to_owned()) {
-            if let Some(child_node) = recurse_create_node(
-                tree,
-                &child_instance,
-                &project_dir,
-                &include_non_scripts
-            ) {
-                node_children.push(child_node);
-            }
+    let mut children = Vec::new();
+    for &child_id in instance.children() {
+        if let Some(child_node) = recurse_create_node(tree, child_id, &project_dir, filter) {
+            children.push(child_node);
         }
     }
 
-    // If we only want to include scripts, make sure this instance is a script,
-    // or that is has children, meaning it then potentiallly has script descendants
-    // This works and does not create unnecessary empty non-script nodes
-    // because we create children recursively *before* performing this check
-    if !include_non_scripts && node_children.len() == 0 {
-        let is_script = match instance.class_name() {
-            "Script" | "LocalScript" | "ModuleScript" => true,
-            _ => false
-        };
-        if !is_script {
-            return None
-        }
+    // If this object has no children and doesn't pass the filter, it doesn't
+    // contain any information we're looking for.
+    if children.is_empty() && !filter(&instance) {
+        return None;
     }
 
-    // 1. Filter out directories and paths that dont exist
-    // 2. Remove the root directory (parent of project directory)
-    // from the path to transform into project-relative paths
-    let existing_paths = instance.metadata().relevant_paths.iter()
-        .filter(|path| path.is_file() && path.exists())
+    let file_paths = instance
+        .metadata()
+        .relevant_paths
+        .iter()
+        // Not all paths listed as relevant are guaranteed to exist.
+        .filter(|path| path.is_file())
         .map(|path| path.strip_prefix(project_dir).expect(PATH_STRIP_FAILED_ERR))
         .map(|path| path.to_path_buf())
-        .collect::<Vec<PathBuf>>();
+        .collect();
 
     Some(SourcemapNode {
         name: instance.name().to_string(),
         class_name: instance.class_name().to_string(),
-        file_paths: match existing_paths.len() {
-            0 => None,
-            _ => Some(existing_paths)
-        },
-        children: match node_children.len() {
-            0 => None,
-            _ => Some(node_children)
-        },
+        file_paths,
+        children,
     })
 }

--- a/src/cli/sourcemap.rs
+++ b/src/cli/sourcemap.rs
@@ -1,0 +1,150 @@
+use std::{
+    sync::MutexGuard,
+    io::{BufWriter, Write, stdout},
+    path::PathBuf
+};
+
+use memofs::Vfs;
+use fs_err::File;
+use serde::Serialize;
+use structopt::StructOpt;
+
+use crate::{
+    serve_session::ServeSession,
+    snapshot::{
+        RojoTree,
+        InstanceWithMeta
+    }
+};
+
+use super::resolve_path;
+
+const PATH_STRIP_FAILED_ERR: &str = "Failed to create relative paths for project file!";
+
+/// Representation of a node in the generated sourcemap tree.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SourcemapNode {
+    name: String,
+    class_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    file_paths: Option<Vec<PathBuf>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    children: Option<Vec<SourcemapNode>>,
+}
+
+/// Generates a model or place file from the Rojo project.
+#[derive(Debug, StructOpt)]
+pub struct SourcemapCommand {
+    /// Path to the project to serve. Defaults to the current directory.
+    #[structopt(default_value = "")]
+    pub project: PathBuf,
+
+    /// Where to output the sourcemap. Omit this to use stdout instead of writing to a file.
+    ///
+    /// Should end in .json.
+    #[structopt(long, short)]
+    pub output: Option<PathBuf>,
+
+    /// If non-script files should be included or not. Defaults to false.
+    #[structopt(long)]
+    pub include_non_scripts: bool,
+}
+
+impl SourcemapCommand {
+    pub fn run(self) -> anyhow::Result<()> {
+        let project_path = resolve_path(&self.project);
+
+        let mut project_dir = project_path.to_path_buf();
+        project_dir.pop();
+
+        log::trace!("Constructing in-memory filesystem");
+        let vfs = Vfs::new_default();
+
+        let session = ServeSession::new(vfs, &project_path)?;
+
+        let tree = session.tree();
+
+        let root_node = recurse_create_node(
+            &tree,
+            &tree.get_instance(tree.get_root_id()).unwrap(),
+            &project_dir,
+            &self.include_non_scripts
+        );
+
+        if let Some(output_path) = self.output {
+            let mut file = BufWriter::new(File::create(&output_path)?);
+            serde_json::to_writer(&mut file, &root_node)?;
+            file.flush()?;
+
+            let filename = &output_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("<invalid utf-8>");
+            println!("Created sourcemap at {}", filename);
+        } else {
+            let str = serde_json::to_string(&root_node)?;
+            stdout().write(str.as_bytes())?;
+        }
+
+        Ok(())
+    }
+}
+
+fn recurse_create_node(
+    tree: &MutexGuard<RojoTree>,
+    instance: &InstanceWithMeta,
+    project_dir: &PathBuf,
+    include_non_scripts: &bool
+) -> Option<SourcemapNode> {
+
+    let mut node_children = Vec::new();
+    for child_id in instance.children() {
+        if let Some(child_instance) = tree.get_instance(child_id.to_owned()) {
+            if let Some(child_node) = recurse_create_node(
+                tree,
+                &child_instance,
+                &project_dir,
+                &include_non_scripts
+            ) {
+                node_children.push(child_node);
+            }
+        }
+    }
+
+    // If we only want to include scripts, make sure this instance is a script,
+    // or that is has children, meaning it then potentiallly has script descendants
+    // This works and does not create unnecessary empty non-script nodes
+    // because we create children recursively *before* performing this check
+    if !include_non_scripts && node_children.len() == 0 {
+        let is_script = match instance.class_name() {
+            "Script" | "LocalScript" | "ModuleScript" => true,
+            _ => false
+        };
+        if !is_script {
+            return None
+        }
+    }
+
+    // 1. Filter out directories and paths that dont exist
+    // 2. Remove the root directory (parent of project directory)
+    // from the path to transform into project-relative paths
+    let existing_paths = instance.metadata().relevant_paths.iter()
+        .filter(|path| path.is_file() && path.exists())
+        .map(|path| path.strip_prefix(project_dir).expect(PATH_STRIP_FAILED_ERR))
+        .map(|path| path.to_path_buf())
+        .collect::<Vec<PathBuf>>();
+
+    Some(SourcemapNode {
+        name: instance.name().to_string(),
+        class_name: instance.class_name().to_string(),
+        file_paths: match existing_paths.len() {
+            0 => None,
+            _ => Some(existing_paths)
+        },
+        children: match node_children.len() {
+            0 => None,
+            _ => Some(node_children)
+        },
+    })
+}


### PR DESCRIPTION
### PR summary

This PR implements a new `sourcemap` command which produces an instance tree in JSON format in the following shape:

```json5
{
  // Equivalent to instance.Name in Roblox
  "name": "...",
  // Equivalent to instance.ClassName in Roblox
  "className": "...",
  // Array of existing file paths that contributed to the creation of this instance
  "filePaths": ["src/path/init.lua", "src/path/init.meta.json"],
  // Array of children with the same structure
  "children": []
}
```

This enables new & interesting use cases, as well as consistency in other tools/apps when using Rojo.
* Tools like [luau-analyze-rojo](https://github.com/JohnnyMorganz/luau-analyze-rojo) and [Roblox LSP](https://github.com/NightrainsRbx/RobloxLsp) should no longer need to do their own parsing of file structures and suffixes to get the same instance structure that Rojo provides
* Stack traces produced in Roblox can now be linked back to their original file paths, potentially enabling much simpler debugging workflows as well as additional features for services such as [Sentry](https://sentry.io/)

--------

### Initial implementation / design details

The command takes a project file as input or defaults to `default.project.json` just like other CLI commands.

The json data will either be written to a file specified by the `--output` parameter, similar to the `build` command, or if omitted will use `stdout` so that other tools do not have to write to and read a file as a proxy.

A flag `--include-non-scripts` determines if **all** instances should be included in the sourcemap, or just scripts. This can greatly reduce sourcemap size if the Rojo project is fully managed. If the flag is not provided, only scripts will be included in the source map. ***NOTE:** Might need a better name or default here?*