### PR TITLE
Bugfix: PluginAction spam causing errors

### DIFF
--- a/plugin/src/App/StatusPages/NotConnected.lua
+++ b/plugin/src/App/StatusPages/NotConnected.lua
@@ -14,8 +14,6 @@ local PORT_WIDTH = 74
 local DIVIDER_WIDTH = 1
 local HOST_OFFSET = 12
 
-local lastHost, lastPort
-
 local e = Roact.createElement
 
 local function AddressEntry(props)
@@ -26,7 +24,7 @@ local function AddressEntry(props)
 			layoutOrder = props.layoutOrder,
 		}, {
 			Host = e("TextBox", {
-				Text = lastHost or "",
+				Text = props.hostText or "",
 				Font = Enum.Font.Code,
 				TextSize = 18,
 				TextColor3 = theme.AddressEntry.TextColor,
@@ -45,7 +43,7 @@ local function AddressEntry(props)
 			}),
 
 			Port = e("TextBox", {
-				Text = lastPort or "",
+				Text = props.portText or "",
 				Font = Enum.Font.Code,
 				TextSize = 18,
 				TextColor3 = theme.AddressEntry.TextColor,
@@ -90,6 +88,8 @@ function NotConnectedPage:render()
 		}),
 
 		AddressEntry = e(AddressEntry, {
+			hostText = self.props.hostText,
+			portText = self.props.portText,
 			hostRef = self.props.hostRef,
 			portRef = self.props.portRef,
 			transparency = self.props.transparency,

--- a/plugin/src/App/StatusPages/NotConnected.lua
+++ b/plugin/src/App/StatusPages/NotConnected.lua
@@ -24,7 +24,7 @@ local function AddressEntry(props)
 			layoutOrder = props.layoutOrder,
 		}, {
 			Host = e("TextBox", {
-				Text = props.hostText or "",
+				Text = props.host or "",
 				Font = Enum.Font.Code,
 				TextSize = 18,
 				TextColor3 = theme.AddressEntry.TextColor,
@@ -32,6 +32,7 @@ local function AddressEntry(props)
 				TextTransparency = props.transparency,
 				PlaceholderText = Config.defaultHost,
 				PlaceholderColor3 = theme.AddressEntry.PlaceholderColor,
+				ClearTextOnFocus = false,
 
 				Size = UDim2.new(1, -(HOST_OFFSET + DIVIDER_WIDTH + PORT_WIDTH), 1, 0),
 				Position = UDim2.new(0, HOST_OFFSET, 0, 0),
@@ -39,17 +40,22 @@ local function AddressEntry(props)
 				ClipsDescendants = true,
 				BackgroundTransparency = 1,
 
-				[Roact.Ref] = props.hostRef,
+				[Roact.Change.Text] = function(object)
+					if props.onHostChange ~= nil then
+						props.onHostChange(object.Text)
+					end
+				end
 			}),
 
 			Port = e("TextBox", {
-				Text = props.portText or "",
+				Text = props.port or "",
 				Font = Enum.Font.Code,
 				TextSize = 18,
 				TextColor3 = theme.AddressEntry.TextColor,
 				TextTransparency = props.transparency,
 				PlaceholderText = Config.defaultPort,
 				PlaceholderColor3 = theme.AddressEntry.PlaceholderColor,
+				ClearTextOnFocus = false,
 
 				Size = UDim2.new(0, PORT_WIDTH, 1, 0),
 				Position = UDim2.new(1, 0, 0, 0),
@@ -58,12 +64,14 @@ local function AddressEntry(props)
 				ClipsDescendants = true,
 				BackgroundTransparency = 1,
 
-				[Roact.Ref] = props.portRef,
-
 				[Roact.Change.Text] = function(object)
 					local text = object.Text
 					text = text:gsub("%D", "")
 					object.Text = text
+
+					if props.onPortChange ~= nil then
+						props.onPortChange(text)
+					end
 				end,
 			}, {
 				Divider = e("Frame", {
@@ -88,10 +96,10 @@ function NotConnectedPage:render()
 		}),
 
 		AddressEntry = e(AddressEntry, {
-			hostText = self.props.hostText,
-			portText = self.props.portText,
-			hostRef = self.props.hostRef,
-			portRef = self.props.portRef,
+			host = self.props.host,
+			port = self.props.port,
+			onHostChange = self.props.onHostChange,
+			onPortChange = self.props.onPortChange,
 			transparency = self.props.transparency,
 			layoutOrder = 2,
 		}),

--- a/plugin/src/App/init.lua
+++ b/plugin/src/App/init.lua
@@ -38,11 +38,8 @@ local App = Roact.Component:extend("App")
 function App:init()
 	preloadAssets()
 
-	self.hostText = ""
-	self.portText = ""
-
-	self.hostRef = Roact.createRef()
-	self.portRef = Roact.createRef()
+	self.host, self.setHost = Roact.createBinding("")
+	self.port, self.setPort = Roact.createBinding("")
 
 	self:setState({
 		appStatus = AppStatus.NotConnected,
@@ -51,16 +48,18 @@ function App:init()
 	})
 end
 
-function App:startSession()
-	if self.hostRef.current then
-		self.hostText = self.hostRef.current.Text
-	end
-	if self.portRef.current then
-		self.portText = self.portRef.current.Text
-	end
+function App:getHostAndPort()
+	local host = self.host:getValue()
+	local port = self.port:getValue()
 
-	local host = if #self.hostText > 0 then self.hostText else Config.defaultHost
-	local port = if #self.portText > 0 then self.portText else Config.defaultPort
+	local host = if #host > 0 then host else Config.defaultHost
+	local port = if #port > 0 then port else Config.defaultPort
+
+	return host, port
+end
+
+function App:startSession()
+	local host, port = self:getHostAndPort()
 
 	local sessionOptions = {
 		openScriptsExternally = self.props.settings:get("openScriptsExternally"),
@@ -184,10 +183,10 @@ function App:render()
 					end,
 				}, {
 					NotConnectedPage = createPageElement(AppStatus.NotConnected, {
-						hostText = self.hostText,
-						portText = self.portText,
-						hostRef = self.hostRef,
-						portRef = self.portRef,
+						host = self.host,
+						onHostChange = self.setHost,
+						port = self.port,
+						onPortChange = self.setPort,
 
 						onConnect = function()
 							self:startSession()

--- a/plugin/src/App/init.lua
+++ b/plugin/src/App/init.lua
@@ -237,10 +237,10 @@ function App:render()
 					icon = Assets.Images.PluginButton,
 					bindable = true,
 					onTriggered = function()
-						if self.serveSession then
-							self:endSession()
-						else
+						if self.serveSession == nil or self.serveSession:getStatus() == ServeSession.Status.NotStarted then
 							self:startSession()
+						elseif self.serveSession ~= nil and self.serveSession:getStatus() == ServeSession.Status.Connected then
+							self:endSession()
 						end
 					end,
 				}),
@@ -252,11 +252,9 @@ function App:render()
 					icon = Assets.Images.PluginButton,
 					bindable = true,
 					onTriggered = function()
-						if self.serveSession then
-							return
+						if self.serveSession == nil or self.serveSession:getStatus() == ServeSession.Status.NotStarted then
+							self:startSession()
 						end
-
-						self:startSession()
 					end,
 				}),
 
@@ -267,11 +265,9 @@ function App:render()
 					icon = Assets.Images.PluginButton,
 					bindable = true,
 					onTriggered = function()
-						if not self.serveSession then
-							return
+						if self.serveSession ~= nil and self.serveSession:getStatus() == ServeSession.Status.Connected then
+							self:endSession()
 						end
-
-						self:endSession()
 					end,
 				}),
 

--- a/plugin/src/App/init.lua
+++ b/plugin/src/App/init.lua
@@ -38,6 +38,9 @@ local App = Roact.Component:extend("App")
 function App:init()
 	preloadAssets()
 
+	self.hostText = ""
+	self.portText = ""
+
 	self.hostRef = Roact.createRef()
 	self.portRef = Roact.createRef()
 
@@ -49,11 +52,16 @@ function App:init()
 end
 
 function App:startSession()
-	local hostText = self.hostRef.current.Text
-	local portText = self.portRef.current.Text
+	if self.hostRef.current then
+		self.hostText = self.hostRef.current.Text
+	end
+	if self.portRef.current then
+		self.portText = self.portRef.current.Text
+	end
 
-	local host = if #hostText > 0 then hostText else Config.defaultHost
-	local port = if #portText > 0 then portText else Config.defaultPort
+	local host = if #self.hostText > 0 then self.hostText else Config.defaultHost
+	local port = if #self.portText > 0 then self.portText else Config.defaultPort
+
 	local sessionOptions = {
 		openScriptsExternally = self.props.settings:get("openScriptsExternally"),
 		twoWaySync = self.props.settings:get("twoWaySync"),
@@ -176,6 +184,8 @@ function App:render()
 					end,
 				}, {
 					NotConnectedPage = createPageElement(AppStatus.NotConnected, {
+						hostText = self.hostText,
+						portText = self.portText,
 						hostRef = self.hostRef,
 						portRef = self.portRef,
 

--- a/plugin/src/ServeSession.lua
+++ b/plugin/src/ServeSession.lua
@@ -113,6 +113,10 @@ function ServeSession:__fmtDebug(output)
 	output:write("}")
 end
 
+function ServeSession:getStatus()
+	return self.__status
+end
+
 function ServeSession:onStatusChanged(callback)
 	self.__statusChangedCallback = callback
 end


### PR DESCRIPTION
Fixes the following issues that I missed in #537:
- [x] Actions checked session's existence rather than session's status, causing issues with actions during connecting status and other non-valid states
- [x] Actions during pages other than NotConnected would nil index fail because the hostRef/portRef weren't being rendered
- [x] In the refactor of the connect function, accidentally lost the host/port text being retained between page renders

My sincere apologies!