### PR TITLE
Fix sourcemap command not stripping paths correctly

### DIFF
--- a/src/cli/sourcemap.rs
+++ b/src/cli/sourcemap.rs
@@ -57,7 +57,9 @@ impl SourcemapCommand {
         let project_path = resolve_path(&self.project);
 
         let mut project_dir = project_path.to_path_buf();
-        project_dir.pop();
+        if project_dir.is_file() {
+            project_dir.pop();
+        }
 
         log::trace!("Constructing in-memory filesystem");
         let vfs = Vfs::new_default();

--- a/src/cli/sourcemap.rs
+++ b/src/cli/sourcemap.rs
@@ -56,11 +56,6 @@ impl SourcemapCommand {
     pub fn run(self) -> anyhow::Result<()> {
         let project_path = resolve_path(&self.project);
 
-        let mut project_dir = project_path.to_path_buf();
-        if project_dir.is_file() {
-            project_dir.pop();
-        }
-
         log::trace!("Constructing in-memory filesystem");
         let vfs = Vfs::new_default();
 
@@ -73,7 +68,7 @@ impl SourcemapCommand {
             filter_non_scripts
         };
 
-        let root_node = recurse_create_node(&tree, tree.get_root_id(), &project_dir, filter);
+        let root_node = recurse_create_node(&tree, tree.get_root_id(), session.root_dir(), filter);
 
         if let Some(output_path) = self.output {
             let mut file = BufWriter::new(File::create(&output_path)?);

--- a/src/serve_session.rs
+++ b/src/serve_session.rs
@@ -216,6 +216,10 @@ impl ServeSession {
     pub fn serve_address(&self) -> Option<IpAddr> {
         self.root_project.serve_address
     }
+
+    pub fn root_dir(&self) -> &Path {
+        self.root_project.folder_location()
+    }
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
Simple fix to handle `rojo sourcemap` when a project file is not given correctly. Previous behavior was removing one level of directories too much inside the sourcemap if the project file path was not given.