### PR TITLE
New release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1
@@ -40,6 +42,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ name: CI
 on:
   push:
     branches:
-    - main
+    - master
 
   pull_request:
     branches:
-    - main
+    - master
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,65 +2,148 @@ name: Release
 
 on:
   push:
-    tags: ["*"]
+    tags: ["v*"]
 
 jobs:
-  windows:
-    runs-on: windows-latest
-
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: true
-
-    - name: Build release binary
-      run: cargo build --verbose --locked --release
-
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: rojo-win64
-        path: target/release/rojo.exe
-
-  macos:
-    runs-on: macos-latest
-
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: true
-
-    - name: Install Rust
-      run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-
-    - name: Build release binary
-      run: |
-        source $HOME/.cargo/env
-        cargo build --verbose --locked --release
-      env:
-        OPENSSL_STATIC: 1
-
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: rojo-macos
-        path: target/release/rojo
-
-  linux:
+  create-release:
+    name: Create Release
     runs-on: ubuntu-latest
-
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: true
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: true
+          prerelease: false
 
-    - name: Build
-      run: cargo build --locked --verbose --release
-      env:
-        OPENSSL_STATIC: 1
+  build-plugin:
+    needs: ["create-release"]
+    name: Build Roblox Studio Plugin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: rojo-linux
-        path: target/release/rojo
+      - name: Setup Foreman
+        uses: Roblox/setup-foreman@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Plugin
+        run: rojo build plugin --output Rojo.rbxm
+
+      - name: Upload Plugin to Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: Rojo.rbxm
+          asset_name: Rojo.rbxm
+          asset_content_type: application/octet-stream
+
+      - name: Upload Plugin to Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Rojo.rbxm
+          path: Rojo.rbxm
+
+  build:
+    needs: ["create-release"]
+    strategy:
+      fail-fast: false
+      matrix:
+        # https://doc.rust-lang.org/rustc/platform-support.html
+        #
+        # FIXME: After the Rojo VS Code extension updates, add architecture
+        # names to each of these releases. We'll rename win64 to windows and add
+        # -x86_64 to each release.
+        include:
+          - host: linux
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            label: linux
+
+          - host: windows
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            label: win64
+
+          - host: macos
+            os: macos-latest
+            target: x86_64-apple-darwin
+            label: macos
+
+          - host: macos
+            os: macos-latest
+            target: aarch64-apple-darwin
+            label: macos-aarch64
+
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    env:
+      BIN: rojo
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get Version from Tag
+        shell: bash
+        # https://github.community/t/how-to-get-just-the-tag-name/16241/7#M1027
+        run: |
+          echo "PROJECT_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+          echo "Version is: ${{ env.PROJECT_VERSION }}"
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+          profile: minimal
+
+      - name: Build Release
+        run: cargo build --release --locked --verbose
+        env:
+          # Build into a known directory so we can find our build artifact more
+          # easily.
+          CARGO_TARGET_DIR: output
+
+          # On platforms that use OpenSSL, ensure it is statically linked to
+          # make binaries more portable.
+          OPENSSL_STATIC: 1
+
+      - name: Create Release Archive
+        shell: bash
+        run: |
+          mkdir staging
+
+          if [ "${{ matrix.host }}" = "windows" ]; then
+            cp "output/release/$BIN.exe" staging/
+            cd staging
+            7z a ../release.zip *
+          else
+            cp "output/release/$BIN" staging/
+            cd staging
+            zip ../release.zip *
+          fi
+
+      - name: Upload Archive to Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: release.zip
+          asset_name: ${{ env.BIN }}-${{ env.PROJECT_VERSION }}-${{ matrix.label }}.zip
+          asset_content_type: application/octet-stream
+
+      - name: Upload Archive to Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.BIN }}-${{ env.PROJECT_VERSION }}-${{ matrix.label }}.zip
+          path: release.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,8 @@ jobs:
       BIN: rojo
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Get Version from Tag
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Setup Foreman
         uses: Roblox/setup-foreman@v1


### PR DESCRIPTION
This PR ports the release workflow from Aftman, with a couple tweaks to keep the existing VS Code Rojo extension working.

This is how we will create releases for Rojo in the future.

Artifacts from the last release workflow, which are uploaded manually:
![chrome_9i3fhkPmcm](https://user-images.githubusercontent.com/654598/170388789-317c429e-da61-4f0b-abb8-3a6d923dabdd.png)

Artifacts from the new release workflow, which are uploaded completely automatically:
![chrome_VqFu03bKXy](https://user-images.githubusercontent.com/654598/170388814-723301d8-4803-4846-84bb-e3b889fd15e5.png)
