### PR TITLE
Defer application of `init.meta.json` until after init Lua files.

### DIFF
--- a/rojo-test/build-test-snapshots/end_to_end__tests__build__issue_546.snap
+++ b/rojo-test/build-test-snapshots/end_to_end__tests__build__issue_546.snap
@@ -1,0 +1,14 @@
+---
+source: tests/tests/build.rs
+assertion_line: 98
+expression: contents
+---
+<roblox version="4">
+  <Item class="LocalScript" referent="0">
+    <Properties>
+      <string name="Name">issue_546</string>
+      <bool name="Disabled">true</bool>
+      <string name="Source">print("Hello, world!")</string>
+    </Properties>
+  </Item>
+</roblox>

--- a/rojo-test/build-tests/issue_546/README.md
+++ b/rojo-test/build-tests/issue_546/README.md
@@ -1,0 +1,2 @@
+# Issue #546 (https://github.com/rojo-rbx/rojo/issues/546)
+Regression from Rojo 6.2.0 to Rojo 7.0.0. Meta files named as init.meta.json should apply after init.client.lua and other init files.

--- a/rojo-test/build-tests/issue_546/default.project.json
+++ b/rojo-test/build-tests/issue_546/default.project.json
@@ -1,0 +1,6 @@
+{
+  "name": "issue_546",
+  "tree": {
+    "$path": "hello"
+  }
+}

--- a/rojo-test/build-tests/issue_546/hello/init.client.lua
+++ b/rojo-test/build-tests/issue_546/hello/init.client.lua
@@ -1,0 +1,1 @@
+print("Hello, world!")

--- a/rojo-test/build-tests/issue_546/hello/init.meta.json
+++ b/rojo-test/build-tests/issue_546/hello/init.meta.json
@@ -1,0 +1,5 @@
+{
+  "properties": {
+    "Disabled": true
+  }
+}

--- a/src/snapshot_middleware/dir.rs
+++ b/src/snapshot_middleware/dir.rs
@@ -11,6 +11,40 @@ pub fn snapshot_dir(
     vfs: &Vfs,
     path: &Path,
 ) -> anyhow::Result<Option<InstanceSnapshot>> {
+    let mut snapshot = match snapshot_dir_no_meta(context, vfs, path)? {
+        Some(snapshot) => snapshot,
+        None => return Ok(None),
+    };
+
+    if let Some(mut meta) = dir_meta(vfs, path)? {
+        meta.apply_all(&mut snapshot)?;
+    }
+
+    Ok(Some(snapshot))
+}
+
+/// Retrieves the meta file that should be applied for this directory, if it
+/// exists.
+pub fn dir_meta(vfs: &Vfs, path: &Path) -> anyhow::Result<Option<DirectoryMetadata>> {
+    let meta_path = path.join("init.meta.json");
+
+    if let Some(meta_contents) = vfs.read(&meta_path).with_not_found()? {
+        let metadata = DirectoryMetadata::from_slice(&meta_contents, meta_path)?;
+        Ok(Some(metadata))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Snapshot a directory without applying meta files; useful for if the
+/// directory's ClassName will change before metadata should be applied. For
+/// example, this can happen if the directory contains an `init.client.lua`
+/// file.
+pub fn snapshot_dir_no_meta(
+    context: &InstanceContext,
+    vfs: &Vfs,
+    path: &Path,
+) -> anyhow::Result<Option<InstanceSnapshot>> {
     let passes_filter_rules = |child: &DirEntry| {
         context
             .path_ignore_rules
@@ -52,7 +86,7 @@ pub fn snapshot_dir(
         path.join("init.client.lua"),
     ];
 
-    let mut snapshot = InstanceSnapshot::new()
+    let snapshot = InstanceSnapshot::new()
         .name(instance_name)
         .class_name("Folder")
         .children(snapshot_children)
@@ -62,11 +96,6 @@ pub fn snapshot_dir(
                 .relevant_paths(relevant_paths)
                 .context(context),
         );
-
-    if let Some(meta_contents) = vfs.read(&meta_path).with_not_found()? {
-        let mut metadata = DirectoryMetadata::from_slice(&meta_contents, meta_path)?;
-        metadata.apply_all(&mut snapshot)?;
-    }
 
     Ok(Some(snapshot))
 }

--- a/src/snapshot_middleware/lua.rs
+++ b/src/snapshot_middleware/lua.rs
@@ -6,7 +6,11 @@ use memofs::{IoResultExt, Vfs};
 
 use crate::snapshot::{InstanceContext, InstanceMetadata, InstanceSnapshot};
 
-use super::{dir::snapshot_dir, meta_file::AdjacentMetadata, util::match_trailing};
+use super::{
+    dir::{dir_meta, snapshot_dir_no_meta},
+    meta_file::AdjacentMetadata,
+    util::match_trailing,
+};
 
 /// Core routine for turning Lua files into snapshots.
 pub fn snapshot_lua(
@@ -66,7 +70,7 @@ pub fn snapshot_lua_init(
     init_path: &Path,
 ) -> anyhow::Result<Option<InstanceSnapshot>> {
     let folder_path = init_path.parent().unwrap();
-    let dir_snapshot = snapshot_dir(context, vfs, folder_path)?.unwrap();
+    let dir_snapshot = snapshot_dir_no_meta(context, vfs, folder_path)?.unwrap();
 
     if dir_snapshot.class_name != "Folder" {
         anyhow::bail!(
@@ -85,6 +89,10 @@ pub fn snapshot_lua_init(
     init_snapshot.name = dir_snapshot.name;
     init_snapshot.children = dir_snapshot.children;
     init_snapshot.metadata = dir_snapshot.metadata;
+
+    if let Some(mut meta) = dir_meta(vfs, folder_path)? {
+        meta.apply_all(&mut init_snapshot)?;
+    }
 
     Ok(Some(init_snapshot))
 }

--- a/tests/tests/build.rs
+++ b/tests/tests/build.rs
@@ -36,11 +36,13 @@ gen_build_tests! {
     init_meta_class_name,
     init_meta_properties,
     init_with_children,
+    issue_546,
     json_as_lua,
     json_model_in_folder,
     json_model_legacy_name,
     module_in_folder,
     module_init,
+    optional,
     project_composed_default,
     project_composed_file,
     project_root_name,
@@ -53,7 +55,6 @@ gen_build_tests! {
     txt,
     txt_in_folder,
     unresolved_values,
-    optional,
     weldconstraint,
 }
 


### PR DESCRIPTION
Fixes #546.