### PR TITLE
Update rbx_binary to 0.6.5, fixes #557

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,12 +1639,13 @@ dependencies = [
 
 [[package]]
 name = "rbx_binary"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f424adb7a0a24ab4bd153be141035f1404ae40affed902fd2721b42cca7f86"
+checksum = "28fe644ede286801c9bd59527b332d69449c6e9eaefa2277a0e776252097bc90"
 dependencies = [
  "log",
  "lz4",
+ "profiling",
  "rbx_dom_weak",
  "rbx_reflection",
  "rbx_reflection_database",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ memofs = { version = "0.2.0", path = "crates/memofs" }
 # rbx_reflection_database = { path = "../rbx-dom/rbx_reflection_database" }
 # rbx_xml = { path = "../rbx-dom/rbx_xml" }
 
-rbx_binary = "0.6.4"
+rbx_binary = "0.6.5"
 rbx_dom_weak = "2.4.0"
 rbx_reflection = "4.2.0"
 rbx_reflection_database = "0.2.2"


### PR DESCRIPTION
Fixes #557. I can't seem to get the `cargo test` command passing on either the base or this commit. I suspect that issue is related to my local development setup, and if CI is green it should be fine. I also have tested the debug build in my workflow and am no longer seeing the same errors that I was in that issue. 