### PR TITLE
Change linux release runner to use `ubuntu-18.04`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         # -x86_64 to each release.
         include:
           - host: linux
-            os: ubuntu-latest
+            os: ubuntu-18.04
             target: x86_64-unknown-linux-gnu
             label: linux
 


### PR DESCRIPTION
ubuntu-latest uses Ubuntu 20.04, this causes issues with glibc as older versions of ubuntu/other distros use an older version.

This is fixed by building the release binary on `ubuntu-18.04`, which uses a version of glibc more widely available.

Ref: https://github.com/JohnnyMorganz/StyLua/pull/444
https://github.com/JohnnyMorganz/StyLua/pull/445