### PR TITLE
Change Notification sound to generic sound

### DIFF
--- a/plugin/src/Assets.lua
+++ b/plugin/src/Assets.lua
@@ -46,7 +46,7 @@ local Assets = {
 		},
 	},
 	Sounds = {
-		Notification = "rbxassetid://9716079936",
+		Notification = "rbxassetid://8747340426",
 	},
 	StartSession = "",
 	SessionActive = "",

--- a/plugin/src/Assets.lua
+++ b/plugin/src/Assets.lua
@@ -46,7 +46,7 @@ local Assets = {
 		},
 	},
 	Sounds = {
-		Notification = "rbxassetid://8747340426",
+		Notification = "rbxassetid://203785492",
 	},
 	StartSession = "",
 	SessionActive = "",


### PR DESCRIPTION
The notification sound for the plugin notifications causes the game to summon an error due to no experience permissions with no way to grant permission. This is due to the new audio policy update.