### PR TITLE
Fix errors after session already ended

### DIFF
--- a/plugin/src/ServeSession.lua
+++ b/plugin/src/ServeSession.lua
@@ -137,7 +137,9 @@ function ServeSession:start()
 				end)
 		end)
 		:catch(function(err)
-			self:__stopInternal(err)
+			if self.__status ~= Status.Disconnected then
+				self:__stopInternal(err)
+			end
 		end)
 end
 


### PR DESCRIPTION
Fixes issue #579.

To debug, I put a traceback into `__stopInternal` and performed the repro steps from issue #579. I saw where the call came from, and then added an if statement there (the API promise) to prevent it from firing stop after the session is already stopped.
After this change, performing the repro steps leads to no errors or warnings as expected.