### PR TITLE
fix empty applied patch sets

### DIFF
--- a/src/change_processor.rs
+++ b/src/change_processor.rs
@@ -171,7 +171,6 @@ impl JobThreadContext {
                 || applied_patch.updated.is_empty() == false
         });
 
-        
         if applied_patches.is_empty() == false {
             // Notify anyone listening to the message queue about the changes we
             // just made.


### PR DESCRIPTION
half of the fix for #577 
this fix will make it so that empty patch sets no longer get send as an event.
this should fix multiple empty patch sends being send.