### PR TITLE
Add `--watch` to sourcemap generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Rojo Changelog
 
 ## Unreleased Changes
+* Added `--watch` flag to `rojo sourcemap` ([#602])
+
+[#602]: https://github.com/rojo-rbx/rojo/pull/602
 
 ## [7.2.1] - July 8, 2022
 * Fixed notification sound by changing it to a generic sound. ([#566])

--- a/src/cli/sourcemap.rs
+++ b/src/cli/sourcemap.rs
@@ -102,10 +102,10 @@ fn filter_nothing(_instance: &InstanceWithMeta) -> bool {
 }
 
 fn filter_non_scripts(instance: &InstanceWithMeta) -> bool {
-    match instance.class_name() {
-        "Script" | "LocalScript" | "ModuleScript" => true,
-        _ => false,
-    }
+    matches!(
+        instance.class_name(),
+        "Script" | "LocalScript" | "ModuleScript"
+    )
 }
 
 fn recurse_create_node(
@@ -118,7 +118,7 @@ fn recurse_create_node(
 
     let mut children = Vec::new();
     for &child_id in instance.children() {
-        if let Some(child_node) = recurse_create_node(tree, child_id, &project_dir, filter) {
+        if let Some(child_node) = recurse_create_node(tree, child_id, project_dir, filter) {
             children.push(child_node);
         }
     }

--- a/src/cli/sourcemap.rs
+++ b/src/cli/sourcemap.rs
@@ -1,5 +1,6 @@
 use std::{
     io::{BufWriter, Write},
+    mem::forget,
     path::{Path, PathBuf},
 };
 
@@ -87,6 +88,10 @@ impl SourcemapCommand {
                 write_sourcemap(&session, self.output.as_deref(), filter)?;
             }
         }
+
+        // Avoid dropping ServeSession: it's potentially VERY expensive to drop
+        // and we're about to exit anyways.
+        forget(session);
 
         Ok(())
     }


### PR DESCRIPTION
Adds support for `--watch` on sourcemap generation, to automatically regenerate sourcemap on changes.

I went ahead and did some drive-by fixes for some clippy warnings too. Also added a call to `forget` similar to how `rojo build` does it. Let me know if you want this reverted and in a separate PR though

