### PR TITLE
Make error messages copyable

### DIFF
--- a/plugin/src/App/StatusPages/Error.lua
+++ b/plugin/src/App/StatusPages/Error.lua
@@ -57,8 +57,9 @@ function Error:render()
 			end,
 		}, {
 			ErrorMessage = Theme.with(function(theme)
-				return e("TextLabel", {
+				return e("TextBox", {
 					Text = self.props.errorMessage,
+					TextEditable = false,
 					Font = Enum.Font.Code,
 					TextSize = 16,
 					TextColor3 = theme.ErrorColor,
@@ -66,10 +67,14 @@ function Error:render()
 					TextYAlignment = Enum.TextYAlignment.Top,
 					TextTransparency = self.props.transparency,
 					TextWrapped = true,
-
-					Size = UDim2.new(1, 0, 1, 0),
-
+					ClearTextOnFocus = false,
 					BackgroundTransparency = 1,
+					Size = UDim2.new(1, 0, 1, 0),
+					[Roact.Change.CursorPosition] = function(rbx)
+						if rbx.CursorPosition == -1 then return end
+						rbx.SelectionStart = 0
+						rbx.CursorPosition = #rbx.Text+1
+					end,
 				})
 			end),
 

--- a/plugin/src/App/StatusPages/Error.lua
+++ b/plugin/src/App/StatusPages/Error.lua
@@ -58,6 +58,13 @@ function Error:render()
 		}, {
 			ErrorMessage = Theme.with(function(theme)
 				return e("TextBox", {
+					[Roact.Event.InputBegan] = function(rbx, input)
+						if input.UserInputType ~= Enum.UserInputType.MouseButton1 then return end
+						rbx.SelectionStart = 0
+						rbx.CursorPosition = #rbx.Text+1
+					end,
+
+
 					Text = self.props.errorMessage,
 					TextEditable = false,
 					Font = Enum.Font.Code,
@@ -70,11 +77,6 @@ function Error:render()
 					ClearTextOnFocus = false,
 					BackgroundTransparency = 1,
 					Size = UDim2.new(1, 0, 1, 0),
-					[Roact.Change.CursorPosition] = function(rbx)
-						if rbx.CursorPosition == -1 then return end
-						rbx.SelectionStart = 0
-						rbx.CursorPosition = #rbx.Text+1
-					end,
 				})
 			end),
 


### PR DESCRIPTION
It was requested that error messages be copyable for easier support and debugging. Being able to double click the message, hit Ctrl+C, and then Google it is much nicer than having to retype it up by hand. Also allows you to drag to select just part of it.
This is a very small and easy change, and there's no downside to it.

![error](https://user-images.githubusercontent.com/40185666/183269799-37148dc9-f62b-41e1-89b8-525e387d10f8.gif)

