### PR TITLE
working generations for folders

### DIFF
--- a/src/snapshot/generation_map.rs
+++ b/src/snapshot/generation_map.rs
@@ -1,0 +1,50 @@
+use std::{collections::HashMap, path::PathBuf};
+
+#[derive(Debug)]
+pub struct GenerationMap {
+    known: HashMap<PathBuf, bool>,
+    updatable: PathBuf,
+    new: HashMap<PathBuf, bool>,
+    bypass: bool,
+}
+impl GenerationMap {
+    pub fn new() -> GenerationMap {
+        Self {
+            known: HashMap::new(),
+            updatable: PathBuf::new(),
+            new: HashMap::new(),
+
+            //Is for project files to bypass
+            bypass: false,
+        }
+    }
+
+    pub fn next_generation(&mut self, path: PathBuf) {
+        self.bypass = false;
+        for (k, _) in self.new.iter() {
+            self.known.insert(k.clone(), true);
+        }
+        self.new = HashMap::new();
+        self.updatable = path
+    }
+    pub fn bypass(&mut self) {
+        self.bypass = true
+    }
+    pub fn should_ignore_chilren(&mut self, path: PathBuf) -> bool {
+        let option = self.known.get(&path);
+        match option {
+            Some(_) => {
+                if self.updatable != path {
+                    if self.bypass {
+                        return false;
+                    }
+                    return true;
+                }
+            }
+            None => {
+                self.new.insert(path, true);
+            }
+        }
+        false
+    }
+}

--- a/src/snapshot/instance_snapshot.rs
+++ b/src/snapshot/instance_snapshot.rs
@@ -37,6 +37,8 @@ pub struct InstanceSnapshot {
     ///
     /// Order is relevant for Roblox instances!
     pub children: Vec<InstanceSnapshot>,
+
+    pub ignore_children: bool,
 }
 
 impl InstanceSnapshot {
@@ -48,6 +50,7 @@ impl InstanceSnapshot {
             class_name: Cow::Borrowed("DEFAULT"),
             properties: HashMap::new(),
             children: Vec::new(),
+            ignore_children: false,
         }
     }
 
@@ -84,6 +87,12 @@ impl InstanceSnapshot {
     pub fn children(self, children: impl Into<Vec<Self>>) -> Self {
         Self {
             children: children.into(),
+            ..self
+        }
+    }
+    pub fn ignore_children(self, ignore_children: bool) -> Self {
+        Self {
+            ignore_children,
             ..self
         }
     }
@@ -126,6 +135,7 @@ impl InstanceSnapshot {
             class_name: Cow::Owned(instance.class),
             properties: instance.properties,
             children,
+            ignore_children: false,
         }
     }
 }

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -48,6 +48,7 @@
 
 #![allow(dead_code)]
 
+mod generation_map;
 mod instance_snapshot;
 mod metadata;
 mod patch;
@@ -55,6 +56,7 @@ mod patch_apply;
 mod patch_compute;
 mod tree;
 
+pub use generation_map::*;
 pub use instance_snapshot::InstanceSnapshot;
 pub use metadata::*;
 pub use patch::*;

--- a/src/snapshot/patch_apply.rs
+++ b/src/snapshot/patch_apply.rs
@@ -239,6 +239,7 @@ mod test {
             properties: hashmap! {
                 "Baz".to_owned() => Variant::Int32(5),
             },
+            ignore_children: false,
             children: Vec::new(),
         };
 

--- a/src/snapshot/patch_compute.rs
+++ b/src/snapshot/patch_compute.rs
@@ -256,6 +256,7 @@ mod test {
             metadata: Default::default(),
             name: Cow::Borrowed("foo"),
             class_name: Cow::Borrowed("foo"),
+            ignore_children: false,
             children: Vec::new(),
         };
 
@@ -300,6 +301,7 @@ mod test {
                 metadata: Default::default(),
                 name: Cow::Borrowed("child"),
                 class_name: Cow::Borrowed("child"),
+                ignore_children: false,
                 children: Vec::new(),
             }],
 
@@ -307,6 +309,7 @@ mod test {
             properties: HashMap::new(),
             name: Cow::Borrowed("foo"),
             class_name: Cow::Borrowed("foo"),
+            ignore_children: false,
         };
 
         let patch_set = compute_patch_set(Some(snapshot), &tree, root_id);
@@ -322,6 +325,7 @@ mod test {
                     },
                     name: Cow::Borrowed("child"),
                     class_name: Cow::Borrowed("child"),
+                    ignore_children: false,
                     children: Vec::new(),
                 },
             }],

--- a/src/snapshot/patch_compute.rs
+++ b/src/snapshot/patch_compute.rs
@@ -88,7 +88,9 @@ fn compute_patch_set_internal(
         .expect("Instance did not exist in tree");
 
     compute_property_patches(&mut snapshot, &instance, patch_set);
-    compute_children_patches(context, &mut snapshot, tree, id, patch_set);
+    if !snapshot.ignore_children {
+        compute_children_patches(context, &mut snapshot, tree, id, patch_set);
+    }
 }
 
 fn compute_property_patches(

--- a/src/snapshot/tests/compute.rs
+++ b/src/snapshot/tests/compute.rs
@@ -20,6 +20,7 @@ fn set_name_and_class_name() {
         name: Cow::Borrowed("Some Folder"),
         class_name: Cow::Borrowed("Folder"),
         properties: Default::default(),
+        ignore_children: false,
         children: Vec::new(),
     };
 
@@ -44,6 +45,7 @@ fn set_property() {
         properties: hashmap! {
             "PropertyName".to_owned() => "Hello, world!".into(),
         },
+        ignore_children: false,
         children: Vec::new(),
     };
 
@@ -75,6 +77,7 @@ fn remove_property() {
         name: Cow::Borrowed("ROOT"),
         class_name: Cow::Borrowed("ROOT"),
         properties: Default::default(),
+        ignore_children: false,
         children: Vec::new(),
     };
 
@@ -96,6 +99,7 @@ fn add_child() {
         metadata: Default::default(),
         name: Cow::Borrowed("ROOT"),
         class_name: Cow::Borrowed("ROOT"),
+        ignore_children:  false,
         properties: Default::default(),
         children: vec![InstanceSnapshot {
             snapshot_id: None,
@@ -103,6 +107,7 @@ fn add_child() {
             name: Cow::Borrowed("New"),
             class_name: Cow::Borrowed("Folder"),
             properties: Default::default(),
+            ignore_children: false,
             children: Vec::new(),
         }],
     };
@@ -136,6 +141,7 @@ fn remove_child() {
         name: Cow::Borrowed("ROOT"),
         class_name: Cow::Borrowed("ROOT"),
         properties: Default::default(),
+        ignore_children: false,
         children: Vec::new(),
     };
 

--- a/src/snapshot/tests/compute.rs
+++ b/src/snapshot/tests/compute.rs
@@ -99,7 +99,7 @@ fn add_child() {
         metadata: Default::default(),
         name: Cow::Borrowed("ROOT"),
         class_name: Cow::Borrowed("ROOT"),
-        ignore_children:  false,
+        ignore_children: false,
         properties: Default::default(),
         children: vec![InstanceSnapshot {
             snapshot_id: None,

--- a/src/snapshot/tests/snapshots/librojo__snapshot__tests__compute__add_child.snap
+++ b/src/snapshot/tests/snapshots/librojo__snapshot__tests__compute__add_child.snap
@@ -15,4 +15,6 @@ added_instances:
       class_name: Folder
       properties: {}
       children: []
+      ignore_children: false
 updated_instances: []
+

--- a/src/snapshot_middleware/csv.rs
+++ b/src/snapshot_middleware/csv.rs
@@ -5,7 +5,7 @@ use maplit::hashmap;
 use memofs::{IoResultExt, Vfs};
 use serde::Serialize;
 
-use crate::snapshot::{InstanceContext, InstanceMetadata, InstanceSnapshot};
+use crate::snapshot::{GenerationMap, InstanceContext, InstanceMetadata, InstanceSnapshot};
 
 use super::{
     dir::{dir_meta, snapshot_dir_no_meta},
@@ -59,9 +59,10 @@ pub fn snapshot_csv_init(
     context: &InstanceContext,
     vfs: &Vfs,
     init_path: &Path,
+    generation_map: &mut GenerationMap,
 ) -> anyhow::Result<Option<InstanceSnapshot>> {
     let folder_path = init_path.parent().unwrap();
-    let dir_snapshot = snapshot_dir_no_meta(context, vfs, folder_path)?.unwrap();
+    let dir_snapshot = snapshot_dir_no_meta(context, vfs, folder_path, generation_map)?.unwrap();
 
     if dir_snapshot.class_name != "Folder" {
         anyhow::bail!(

--- a/src/snapshot_middleware/dir.rs
+++ b/src/snapshot_middleware/dir.rs
@@ -126,7 +126,7 @@ mod test {
         let mut vfs = Vfs::new(imfs);
 
         let instance_snapshot =
-            snapshot_dir(&InstanceContext::default(), &mut vfs, Path::new("/foo"))
+            snapshot_dir(&InstanceContext::default(), &mut vfs, Path::new("/foo"), &mut GenerationMap::new())
                 .unwrap()
                 .unwrap();
 
@@ -147,7 +147,7 @@ mod test {
         let mut vfs = Vfs::new(imfs);
 
         let instance_snapshot =
-            snapshot_dir(&InstanceContext::default(), &mut vfs, Path::new("/foo"))
+            snapshot_dir(&InstanceContext::default(), &mut vfs, Path::new("/foo"), &mut GenerationMap::new())
                 .unwrap()
                 .unwrap();
 

--- a/src/snapshot_middleware/dir.rs
+++ b/src/snapshot_middleware/dir.rs
@@ -125,10 +125,14 @@ mod test {
 
         let mut vfs = Vfs::new(imfs);
 
-        let instance_snapshot =
-            snapshot_dir(&InstanceContext::default(), &mut vfs, Path::new("/foo"), &mut GenerationMap::new())
-                .unwrap()
-                .unwrap();
+        let instance_snapshot = snapshot_dir(
+            &InstanceContext::default(),
+            &mut vfs,
+            Path::new("/foo"),
+            &mut GenerationMap::new(),
+        )
+        .unwrap()
+        .unwrap();
 
         insta::assert_yaml_snapshot!(instance_snapshot);
     }
@@ -146,10 +150,14 @@ mod test {
 
         let mut vfs = Vfs::new(imfs);
 
-        let instance_snapshot =
-            snapshot_dir(&InstanceContext::default(), &mut vfs, Path::new("/foo"), &mut GenerationMap::new())
-                .unwrap()
-                .unwrap();
+        let instance_snapshot = snapshot_dir(
+            &InstanceContext::default(),
+            &mut vfs,
+            Path::new("/foo"),
+            &mut GenerationMap::new(),
+        )
+        .unwrap()
+        .unwrap();
 
         insta::assert_yaml_snapshot!(instance_snapshot);
     }

--- a/src/snapshot_middleware/json_model.rs
+++ b/src/snapshot_middleware/json_model.rs
@@ -118,6 +118,7 @@ impl JsonModel {
             class_name: Cow::Owned(class_name),
             properties,
             children,
+            ignore_children: false,
         })
     }
 }

--- a/src/snapshot_middleware/json_model.rs
+++ b/src/snapshot_middleware/json_model.rs
@@ -117,8 +117,8 @@ impl JsonModel {
             name: Cow::Owned(name),
             class_name: Cow::Owned(class_name),
             properties,
-            children,
             ignore_children: false,
+            children,
         })
     }
 }

--- a/src/snapshot_middleware/lua.rs
+++ b/src/snapshot_middleware/lua.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use maplit::hashmap;
 use memofs::{IoResultExt, Vfs};
 
-use crate::snapshot::{InstanceContext, InstanceMetadata, InstanceSnapshot};
+use crate::snapshot::{GenerationMap, InstanceContext, InstanceMetadata, InstanceSnapshot};
 
 use super::{
     dir::{dir_meta, snapshot_dir_no_meta},
@@ -74,9 +74,10 @@ pub fn snapshot_lua_init(
     context: &InstanceContext,
     vfs: &Vfs,
     init_path: &Path,
+    generation_map: &mut GenerationMap,
 ) -> anyhow::Result<Option<InstanceSnapshot>> {
     let folder_path = init_path.parent().unwrap();
-    let dir_snapshot = snapshot_dir_no_meta(context, vfs, folder_path)?.unwrap();
+    let dir_snapshot = snapshot_dir_no_meta(context, vfs, folder_path, generation_map)?.unwrap();
 
     if dir_snapshot.class_name != "Folder" {
         anyhow::bail!(

--- a/src/snapshot_middleware/project.rs
+++ b/src/snapshot_middleware/project.rs
@@ -350,10 +350,14 @@ mod test {
 
         let mut vfs = Vfs::new(imfs);
 
-        let instance_snapshot =
-            snapshot_project(&InstanceContext::default(), &mut vfs, Path::new("/foo"),&mut GenerationMap::new())
-                .expect("snapshot error")
-                .expect("snapshot returned no instances");
+        let instance_snapshot = snapshot_project(
+            &InstanceContext::default(),
+            &mut vfs,
+            Path::new("/foo"),
+            &mut GenerationMap::new(),
+        )
+        .expect("snapshot error")
+        .expect("snapshot returned no instances");
 
         insta::assert_yaml_snapshot!(instance_snapshot);
     }
@@ -460,7 +464,7 @@ mod test {
             &InstanceContext::default(),
             &mut vfs,
             Path::new("/foo.project.json"),
-            &mut GenerationMap::new()
+            &mut GenerationMap::new(),
         )
         .expect("snapshot error")
         .expect("snapshot returned no instances");

--- a/src/snapshot_middleware/project.rs
+++ b/src/snapshot_middleware/project.rs
@@ -287,9 +287,9 @@ pub fn snapshot_project_node(
         name,
         class_name,
         properties,
+        ignore_children: false,
         children,
         metadata,
-        ignore_children: false,
     }))
 }
 
@@ -351,7 +351,7 @@ mod test {
         let mut vfs = Vfs::new(imfs);
 
         let instance_snapshot =
-            snapshot_project(&InstanceContext::default(), &mut vfs, Path::new("/foo"))
+            snapshot_project(&InstanceContext::default(), &mut vfs, Path::new("/foo"),&mut GenerationMap::new())
                 .expect("snapshot error")
                 .expect("snapshot returned no instances");
 
@@ -384,6 +384,7 @@ mod test {
             &InstanceContext::default(),
             &mut vfs,
             Path::new("/foo/hello.project.json"),
+            &mut GenerationMap::new(),
         )
         .expect("snapshot error")
         .expect("snapshot returned no instances");
@@ -422,6 +423,7 @@ mod test {
             &InstanceContext::default(),
             &mut vfs,
             Path::new("/foo.project.json"),
+            &mut GenerationMap::new(),
         )
         .expect("snapshot error")
         .expect("snapshot returned no instances");
@@ -458,6 +460,7 @@ mod test {
             &InstanceContext::default(),
             &mut vfs,
             Path::new("/foo.project.json"),
+            &mut GenerationMap::new()
         )
         .expect("snapshot error")
         .expect("snapshot returned no instances");
@@ -495,6 +498,7 @@ mod test {
             &InstanceContext::default(),
             &mut vfs,
             Path::new("/foo.project.json"),
+            &mut GenerationMap::new(),
         )
         .expect("snapshot error")
         .expect("snapshot returned no instances");
@@ -529,6 +533,7 @@ mod test {
             &InstanceContext::default(),
             &mut vfs,
             Path::new("/foo/default.project.json"),
+            &mut GenerationMap::new(),
         )
         .expect("snapshot error")
         .expect("snapshot returned no instances");
@@ -570,6 +575,7 @@ mod test {
             &InstanceContext::default(),
             &mut vfs,
             Path::new("/foo/default.project.json"),
+            &mut GenerationMap::new(),
         )
         .expect("snapshot error")
         .expect("snapshot returned no instances");
@@ -615,6 +621,7 @@ mod test {
             &InstanceContext::default(),
             &mut vfs,
             Path::new("/foo/default.project.json"),
+            &mut GenerationMap::new(),
         )
         .expect("snapshot error")
         .expect("snapshot returned no instances");
@@ -665,6 +672,7 @@ mod test {
             &InstanceContext::default(),
             &mut vfs,
             Path::new("/foo/default.project.json"),
+            &mut GenerationMap::new(),
         )
         .expect("snapshot error")
         .expect("snapshot returned no instances");

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__csv__test__csv_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__csv__test__csv_from_vfs.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/csv.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -18,4 +17,5 @@ properties:
   Contents:
     String: "[{\"key\":\"Ack\",\"example\":\"An exclamation of despair\",\"source\":\"Ack!\",\"values\":{\"es\":\"¡Ay!\"}}]"
 children: []
+ignore_children: false
 

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__csv__test__csv_with_meta.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__csv__test__csv_with_meta.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/csv.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -18,4 +17,5 @@ properties:
   Contents:
     String: "[{\"key\":\"Ack\",\"example\":\"An exclamation of despair\",\"source\":\"Ack!\",\"values\":{\"es\":\"¡Ay!\"}}]"
 children: []
+ignore_children: false
 

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__dir__test__empty_folder.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__dir__test__empty_folder.snap
@@ -1,6 +1,5 @@
 ---
 source: src/snapshot_middleware/dir.rs
-assertion_line: 127
 expression: instance_snapshot
 ---
 snapshot_id: ~
@@ -23,4 +22,5 @@ name: foo
 class_name: Folder
 properties: {}
 children: []
+ignore_children: false
 

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__dir__test__folder_in_folder.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__dir__test__folder_in_folder.snap
@@ -1,6 +1,5 @@
 ---
 source: src/snapshot_middleware/dir.rs
-assertion_line: 148
 expression: instance_snapshot
 ---
 snapshot_id: ~
@@ -43,4 +42,6 @@ children:
     class_name: Folder
     properties: {}
     children: []
+    ignore_children: false
+ignore_children: false
 

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__json__test__instance_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__json__test__instance_from_vfs.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/json.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -18,4 +17,5 @@ properties:
   Source:
     String: "return {\n\t[\"1invalidident\"] = \"nice\",\n\tarray = {1, 2, 3},\n\t[\"false\"] = false,\n\tfloat = 1234.5452,\n\tint = 1234,\n\tnull = nil,\n\tobject = {\n\t\thello = \"world\",\n\t},\n\t[\"true\"] = true,\n}"
 children: []
+ignore_children: false
 

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__json_model__test__model_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__json_model__test__model_from_vfs.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/json_model.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -26,4 +25,6 @@ children:
     class_name: StringValue
     properties: {}
     children: []
+    ignore_children: false
+ignore_children: false
 

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__json_model__test__model_from_vfs_legacy.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__json_model__test__model_from_vfs_legacy.snap
@@ -1,6 +1,5 @@
 ---
 source: src/snapshot_middleware/json_model.rs
-assertion_line: 186
 expression: instance_snapshot
 ---
 snapshot_id: ~
@@ -26,4 +25,6 @@ children:
     class_name: StringValue
     properties: {}
     children: []
+    ignore_children: false
+ignore_children: false
 

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__client_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__client_from_vfs.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/lua.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -18,4 +17,5 @@ properties:
   Source:
     String: Hello there!
 children: []
+ignore_children: false
 

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__module_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__module_from_vfs.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/lua.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -18,4 +17,5 @@ properties:
   Source:
     String: Hello there!
 children: []
+ignore_children: false
 

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__module_with_meta.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__module_with_meta.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/lua.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -18,4 +17,5 @@ properties:
   Source:
     String: Hello there!
 children: []
+ignore_children: false
 

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__script_disabled.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__script_disabled.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/lua.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -20,4 +19,5 @@ properties:
   Source:
     String: Hello there!
 children: []
+ignore_children: false
 

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__script_with_meta.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__script_with_meta.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/lua.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -18,4 +17,5 @@ properties:
   Source:
     String: Hello there!
 children: []
+ignore_children: false
 

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__server_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__server_from_vfs.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/lua.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -18,4 +17,5 @@ properties:
   Source:
     String: Hello there!
 children: []
+ignore_children: false
 

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_from_direct_file.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_from_direct_file.snap
@@ -14,3 +14,5 @@ name: direct-project
 class_name: Model
 properties: {}
 children: []
+ignore_children: false
+

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_path_property_overrides.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_path_property_overrides.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/project.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -18,4 +17,5 @@ properties:
   Value:
     String: Changed
 children: []
+ignore_children: false
 

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_children.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_children.snap
@@ -29,3 +29,6 @@ children:
     class_name: Model
     properties: {}
     children: []
+    ignore_children: false
+ignore_children: false
+

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_path_to_project.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_path_to_project.snap
@@ -15,3 +15,5 @@ name: path-project
 class_name: Model
 properties: {}
 children: []
+ignore_children: false
+

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_path_to_project_with_children.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_path_to_project_with_children.snap
@@ -30,3 +30,6 @@ children:
     class_name: Model
     properties: {}
     children: []
+    ignore_children: false
+ignore_children: false
+

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_path_to_txt.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_path_to_txt.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/project.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -19,4 +18,5 @@ properties:
   Value:
     String: "Hello, world!"
 children: []
+ignore_children: false
 

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_resolved_properties.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_resolved_properties.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/project.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -17,4 +16,5 @@ properties:
   Value:
     String: "Hello, world!"
 children: []
+ignore_children: false
 

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_unresolved_properties.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_unresolved_properties.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/project.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -17,4 +16,5 @@ properties:
   Value:
     String: Hi!
 children: []
+ignore_children: false
 

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__txt__test__instance_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__txt__test__instance_from_vfs.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/txt.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -18,4 +17,5 @@ properties:
   Value:
     String: Hello there!
 children: []
+ignore_children: false
 


### PR DESCRIPTION
working generations for folders 

throws generations out of the window as soon as a second project is in the updated folder for all the paths being added by the project file.

- [x] fix tests