### PR TITLE
Fix security permission error

### DIFF
--- a/plugin/src/Reconciler/diff.lua
+++ b/plugin/src/Reconciler/diff.lua
@@ -115,9 +115,13 @@ local function diff(instanceMap, virtualInstances, rootId)
 			local childId = instanceMap.fromInstances[childInstance]
 
 			if childId == nil then
-				if childInstance.Archivable == false then
+				-- pcall to avoid security permission errors
+				local success, skip = pcall(function()
 					-- We don't remove instances that aren't going to be saved anyway,
 					-- such as the Rojo session lock value.
+					return childInstance.Archivable == false
+				end)
+				if success and skip then
 					continue
 				end
 


### PR DESCRIPTION
```
The current identity (5) cannot Class security check (lacking permission 6)
PluginDebugService.user_Rojo.rbxm.Rojo.Plugin.Reconciler.diff:118 function diffInternal
```

Apparently some Instances don't like it when you read a property. Wrapping our check in a pcall resolves this.