### PR TITLE
Add two way instance added

### DIFF
--- a/plugin/src/App/init.lua
+++ b/plugin/src/App/init.lua
@@ -1,3 +1,6 @@
+local Players = game:GetService("Players")
+local ServerStorage = game:GetService("ServerStorage")
+
 local Rojo = script:FindFirstAncestor("Rojo")
 local Plugin = Rojo.Plugin
 local Packages = Rojo.Packages
@@ -92,7 +95,65 @@ function App:getHostAndPort()
 	return host, port
 end
 
+function App:claimSyncLock()
+	if #Players:GetPlayers() == 0 then
+		Log.trace("Skipping sync lock because this isn't in Team Create")
+		return true
+	end
+
+	local lock = ServerStorage:FindFirstChild("__Rojo_SessionLock")
+	if not lock then
+		lock = Instance.new("ObjectValue")
+		lock.Name = "__Rojo_SessionLock"
+		lock.Archivable = false
+		lock.Value = Players.LocalPlayer
+		lock.Parent = ServerStorage
+		Log.trace("Created and claimed sync lock")
+		return true
+	end
+
+	if lock.Value and lock.Value ~= Players.LocalPlayer and lock.Value.Parent then
+		Log.trace("Found existing sync lock owned by {}", lock.Value)
+		return false, lock.Value
+	end
+
+	lock.Value = Players.LocalPlayer
+	Log.trace("Claimed existing sync lock")
+	return true
+end
+
+function App:releaseSyncLock()
+	local lock = ServerStorage:FindFirstChild("__Rojo_SessionLock")
+	if not lock then
+		Log.trace("No sync lock found, assumed released")
+		return
+	end
+
+	if lock.Value == Players.LocalPlayer then
+		lock.Value = nil
+		Log.trace("Released sync lock")
+		return
+	end
+
+	Log.trace("Could not relase sync lock because it is owned by {}", lock.Value)
+end
+
 function App:startSession()
+	local claimedLock, priorOwner = self:claimSyncLock()
+	if not claimedLock then
+		local msg = string.format("Could not sync because user '%s' is already syncing", tostring(priorOwner))
+
+		Log.warn(msg)
+		self:addNotification(msg, 10)
+		self:setState({
+			appStatus = AppStatus.Error,
+			errorMessage = msg,
+			toolbarIcon = Assets.Images.PluginButtonWarning,
+		})
+
+		return
+	end
+
 	local host, port = self:getHostAndPort()
 
 	local sessionOptions = {
@@ -155,6 +216,7 @@ function App:startSession()
 			self:addNotification(string.format("Connected to session '%s' at %s.", details, address), 5)
 		elseif status == ServeSession.Status.Disconnected then
 			self.serveSession = nil
+			self:releaseSyncLock()
 
 			-- Details being present indicates that this
 			-- disconnection was from an error.

--- a/plugin/src/ChangeBatcher/createPatchSet.lua
+++ b/plugin/src/ChangeBatcher/createPatchSet.lua
@@ -11,14 +11,14 @@ local Log = require(Packages.Log)
 local PatchSet = require(script.Parent.Parent.PatchSet)
 
 local encodePatchUpdate = require(script.Parent.encodePatchUpdate)
-
+local encodePatchCreate = require(script.Parent.encodePatchCreate)
 return function(instanceMap, propertyChanges)
 	local patch = PatchSet.newEmpty()
 
 	for instance, properties in pairs(propertyChanges) do
 		local instanceId = instanceMap.fromInstances[instance]
 
-		if instanceId == nil then
+		if instanceId == nil and properties.Create == nil  then
 			Log.warn("Ignoring change for instance {:?} as it is unknown to Rojo", instance)
 			continue
 		end
@@ -29,6 +29,11 @@ return function(instanceMap, propertyChanges)
 			else
 				Log.warn("Cannot sync non-nil Parent property changes yet")
 			end
+		elseif properties.Create then
+			local parentId = instanceMap.fromInstances[instance.Parent]
+			local update = encodePatchCreate(instanceMap,instance, parentId)
+
+			table.insert(patch.added, update)
 		else
 			local update = encodePatchUpdate(instance, instanceId, properties)
 			table.insert(patch.updated, update)

--- a/plugin/src/ChangeBatcher/encodePatchCreate.lua
+++ b/plugin/src/ChangeBatcher/encodePatchCreate.lua
@@ -1,0 +1,47 @@
+local HttpService = game:GetService("HttpService")
+
+
+local Packages = script.Parent.Parent.Parent.Packages
+local RbxDom = require(Packages.RbxDom)
+
+local  function createInstanceSnapshot(instanceMap,instance) 
+
+	local id = HttpService:GenerateGUID(false)
+
+	instanceMap.createdInstances[id] = instance
+
+	local children = {}
+	for i,child in ipairs(instance:GetChildren()) do
+		table.insert(children,createInstanceSnapshot(instanceMap,child))
+	end
+
+	local properties = RbxDom.findAllNoneDefaultPropertiesEncoded(instance)
+	properties.Name = nil
+	properties.ClassName = nil
+
+	local attributes = nil
+	if #properties.Attributes ~= 0 then
+		attributes = properties.Attributes
+	end
+
+	properties.Attributes = nil
+	if #properties == 0 then
+		properties = nil
+	end
+	
+	return {
+		Name = instance.Name,
+		ClassName = instance.ClassName,
+		Children = children,
+		Properties = properties,
+		attributes = attributes,
+		DebugId = id
+	}
+end
+
+return function(instanceMap,instance,parentId)
+	return {
+		id = parentId,
+		instance = createInstanceSnapshot(instanceMap,instance),
+	}
+end

--- a/plugin/src/ChangeBatcher/encodePatchCreate.lua
+++ b/plugin/src/ChangeBatcher/encodePatchCreate.lua
@@ -15,28 +15,30 @@ local  function createInstanceSnapshot(instanceMap,instance)
 		table.insert(children,createInstanceSnapshot(instanceMap,child))
 	end
 
-	local properties = RbxDom.findAllNoneDefaultPropertiesEncoded(instance)
-	properties.Name = nil
-	properties.ClassName = nil
+	local success, properties = RbxDom.findAllNoneDefaultPropertiesEncoded(instance)
+	if success
+		properties.Name = nil
+		properties.ClassName = nil
 
-	local attributes = nil
-	if #properties.Attributes ~= 0 then
-		attributes = properties.Attributes
-	end
+		local attributes = nil
+		if #properties.Attributes ~= 0 then
+			attributes = properties.Attributes
+		end
 
-	properties.Attributes = nil
-	if #properties == 0 then
-		properties = nil
+		properties.Attributes = nil
+		if #properties == 0 then
+			properties = nil
+		end
+		
+		return {
+			Name = instance.Name,
+			ClassName = instance.ClassName,
+			Children = children,
+			Properties = properties,
+			attributes = attributes,
+			DebugId = id
+		}
 	end
-	
-	return {
-		Name = instance.Name,
-		ClassName = instance.ClassName,
-		Children = children,
-		Properties = properties,
-		attributes = attributes,
-		DebugId = id
-	}
 end
 
 return function(instanceMap,instance,parentId)

--- a/plugin/src/ChangeBatcher/encodePatchCreate.lua
+++ b/plugin/src/ChangeBatcher/encodePatchCreate.lua
@@ -16,10 +16,10 @@ local  function createInstanceSnapshot(instanceMap,instance)
 	end
 
 	local success, properties = RbxDom.findAllNoneDefaultPropertiesEncoded(instance)
-	if success
+	if success then
 		properties.Name = nil
 		properties.ClassName = nil
-
+		
 		local attributes = nil
 		if #properties.Attributes ~= 0 then
 			attributes = properties.Attributes
@@ -39,6 +39,7 @@ local  function createInstanceSnapshot(instanceMap,instance)
 			DebugId = id
 		}
 	end
+	return nil
 end
 
 return function(instanceMap,instance,parentId)

--- a/plugin/src/Reconciler/diff.lua
+++ b/plugin/src/Reconciler/diff.lua
@@ -115,6 +115,12 @@ local function diff(instanceMap, virtualInstances, rootId)
 			local childId = instanceMap.fromInstances[childInstance]
 
 			if childId == nil then
+				if childInstance.Archivable == false then
+					-- We don't remove instances that aren't going to be saved anyway,
+					-- such as the Rojo session lock value.
+					continue
+				end
+
 				-- This is an existing instance not present in the virtual DOM.
 				-- We can mark it for deletion unless the user has asked us not
 				-- to delete unknown stuff.

--- a/plugin/src/Reconciler/reify.lua
+++ b/plugin/src/Reconciler/reify.lua
@@ -50,14 +50,20 @@ function reifyInner(instanceMap, virtualInstances, id, parentInstance, unapplied
 		invariant("Cannot reify an instance not present in virtualInstances\nID: {}", id)
 	end
 
-	-- Instance.new can fail if we're passing in something that can't be
-	-- created, like a service, something enabled with a feature flag, or
-	-- something that requires higher security than we have.
-	local ok, instance = pcall(Instance.new, virtualInstance.ClassName)
+	local ok, instance
+	
+	if virtualInstance.Metadata and virtualInstance.Metadata.debugId and instanceMap.createdInstances[virtualInstance.Metadata.debugId] then
+		instance = instanceMap.createdInstances[virtualInstance.Metadata.debugId] 
+	else
+		-- Instance.new can fail if we're passing in something that can't be
+		-- created, like a service, something enabled with a feature flag, or
+		-- something that requires higher security than we have.
+		ok, instance = pcall(Instance.new, virtualInstance.ClassName)
 
-	if not ok then
-		addAllToPatch(unappliedPatch, virtualInstances, id)
-		return
+		if not ok then
+			addAllToPatch(unappliedPatch, virtualInstances, id)
+			return
+		end
 	end
 
 	-- TODO: Can this fail? Previous versions of Rojo guarded against this, but

--- a/plugin/src/Reconciler/reify.lua
+++ b/plugin/src/Reconciler/reify.lua
@@ -54,6 +54,7 @@ function reifyInner(instanceMap, virtualInstances, id, parentInstance, unapplied
 	
 	if virtualInstance.Metadata and virtualInstance.Metadata.debugId and instanceMap.createdInstances[virtualInstance.Metadata.debugId] then
 		instance = instanceMap.createdInstances[virtualInstance.Metadata.debugId] 
+		instanceMap.createdInstances[virtualInstance.Metadata.debugId] = nil
 	else
 		-- Instance.new can fail if we're passing in something that can't be
 		-- created, like a service, something enabled with a feature flag, or

--- a/plugin/src/Types.lua
+++ b/plugin/src/Types.lua
@@ -9,6 +9,7 @@ local ApiValue = t.keys(t.string)
 
 local ApiInstanceMetadata = t.interface({
 	ignoreUnknownInstances = t.optional(t.boolean),
+	debugId =  t.optional(t.string)
 })
 
 local ApiInstance = t.interface({

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__add_folder_all-2.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__add_folder_all-2.snap
@@ -9,6 +9,7 @@ instances:
     ClassName: Folder
     Id: id-2
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: add_folder
     Parent: "00000000000000000000000000000000"
@@ -18,9 +19,11 @@ instances:
     ClassName: Folder
     Id: id-3
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: my-new-folder
     Parent: id-2
     Properties: {}
 messageCursor: 1
 sessionId: id-1
+

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__add_folder_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__add_folder_all.snap
@@ -8,9 +8,11 @@ instances:
     ClassName: Folder
     Id: id-2
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: add_folder
     Parent: "00000000000000000000000000000000"
     Properties: {}
 messageCursor: 0
 sessionId: id-1
+

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__add_folder_subscribe.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__add_folder_subscribe.snap
@@ -10,6 +10,7 @@ messages:
         ClassName: Folder
         Id: id-3
         Metadata:
+          debugId: ~
           ignoreUnknownInstances: false
         Name: my-new-folder
         Parent: id-2
@@ -17,3 +18,4 @@ messages:
     removed: []
     updated: []
 sessionId: id-1
+

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__edit_init_all-2.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__edit_init_all-2.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/tests/serve.rs
 expression: "read_response.intern_and_redact(&mut redactions, root_id)"
-
 ---
 instances:
   id-2:
@@ -9,6 +8,7 @@ instances:
     ClassName: ModuleScript
     Id: id-2
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: edit_init
     Parent: "00000000000000000000000000000000"

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__edit_init_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__edit_init_all.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/tests/serve.rs
 expression: "read_response.intern_and_redact(&mut redactions, root_id)"
-
 ---
 instances:
   id-2:
@@ -9,6 +8,7 @@ instances:
     ClassName: ModuleScript
     Id: id-2
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: edit_init
     Parent: "00000000000000000000000000000000"

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_all.snap
@@ -8,9 +8,11 @@ instances:
     ClassName: Folder
     Id: id-2
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: true
     Name: empty
     Parent: "00000000000000000000000000000000"
     Properties: {}
 messageCursor: 0
 sessionId: id-1
+

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_json_model_all-2.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_json_model_all-2.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/tests/serve.rs
 expression: "read_response.intern_and_redact(&mut redactions, root_id)"
-
 ---
 instances:
   id-2:
@@ -10,6 +9,7 @@ instances:
     ClassName: Folder
     Id: id-2
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: empty_folder
     Parent: "00000000000000000000000000000000"
@@ -19,6 +19,7 @@ instances:
     ClassName: Model
     Id: id-3
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: test
     Parent: id-2

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_json_model_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_json_model_all.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/tests/serve.rs
 expression: "read_response.intern_and_redact(&mut redactions, root_id)"
-
 ---
 instances:
   id-2:
@@ -9,6 +8,7 @@ instances:
     ClassName: Folder
     Id: id-2
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: empty_folder
     Parent: "00000000000000000000000000000000"

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_json_model_subscribe.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_json_model_subscribe.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/tests/serve.rs
 expression: "subscribe_response.intern_and_redact(&mut redactions, ())"
-
 ---
 messageCursor: 1
 messages:
@@ -11,6 +10,7 @@ messages:
         ClassName: Model
         Id: id-3
         Metadata:
+          debugId: ~
           ignoreUnknownInstances: false
         Name: test
         Parent: id-2

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__move_folder_of_stuff_all-2.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__move_folder_of_stuff_all-2.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/tests/serve.rs
 expression: "read_response.intern_and_redact(&mut redactions, root_id)"
-
 ---
 instances:
   id-10:
@@ -9,6 +8,7 @@ instances:
     ClassName: StringValue
     Id: id-10
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: "6"
     Parent: id-3
@@ -20,6 +20,7 @@ instances:
     ClassName: StringValue
     Id: id-11
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: "7"
     Parent: id-3
@@ -31,6 +32,7 @@ instances:
     ClassName: StringValue
     Id: id-12
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: "8"
     Parent: id-3
@@ -42,6 +44,7 @@ instances:
     ClassName: StringValue
     Id: id-13
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: "9"
     Parent: id-3
@@ -54,6 +57,7 @@ instances:
     ClassName: Folder
     Id: id-2
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: move_folder_of_stuff
     Parent: "00000000000000000000000000000000"
@@ -73,6 +77,7 @@ instances:
     ClassName: Folder
     Id: id-3
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: new-stuff
     Parent: id-2
@@ -82,6 +87,7 @@ instances:
     ClassName: StringValue
     Id: id-4
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: "0"
     Parent: id-3
@@ -93,6 +99,7 @@ instances:
     ClassName: StringValue
     Id: id-5
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: "1"
     Parent: id-3
@@ -104,6 +111,7 @@ instances:
     ClassName: StringValue
     Id: id-6
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: "2"
     Parent: id-3
@@ -115,6 +123,7 @@ instances:
     ClassName: StringValue
     Id: id-7
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: "3"
     Parent: id-3
@@ -126,6 +135,7 @@ instances:
     ClassName: StringValue
     Id: id-8
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: "4"
     Parent: id-3
@@ -137,6 +147,7 @@ instances:
     ClassName: StringValue
     Id: id-9
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: "5"
     Parent: id-3

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__move_folder_of_stuff_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__move_folder_of_stuff_all.snap
@@ -8,9 +8,11 @@ instances:
     ClassName: Folder
     Id: id-2
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: move_folder_of_stuff
     Parent: "00000000000000000000000000000000"
     Properties: {}
 messageCursor: 0
 sessionId: id-1
+

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__move_folder_of_stuff_subscribe.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__move_folder_of_stuff_subscribe.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/tests/serve.rs
 expression: "subscribe_response.intern_and_redact(&mut redactions, ())"
-
 ---
 messageCursor: 1
 messages:
@@ -11,6 +10,7 @@ messages:
         ClassName: StringValue
         Id: id-10
         Metadata:
+          debugId: ~
           ignoreUnknownInstances: false
         Name: "6"
         Parent: id-3
@@ -22,6 +22,7 @@ messages:
         ClassName: StringValue
         Id: id-11
         Metadata:
+          debugId: ~
           ignoreUnknownInstances: false
         Name: "7"
         Parent: id-3
@@ -33,6 +34,7 @@ messages:
         ClassName: StringValue
         Id: id-12
         Metadata:
+          debugId: ~
           ignoreUnknownInstances: false
         Name: "8"
         Parent: id-3
@@ -44,6 +46,7 @@ messages:
         ClassName: StringValue
         Id: id-13
         Metadata:
+          debugId: ~
           ignoreUnknownInstances: false
         Name: "9"
         Parent: id-3
@@ -65,6 +68,7 @@ messages:
         ClassName: Folder
         Id: id-3
         Metadata:
+          debugId: ~
           ignoreUnknownInstances: false
         Name: new-stuff
         Parent: id-2
@@ -74,6 +78,7 @@ messages:
         ClassName: StringValue
         Id: id-4
         Metadata:
+          debugId: ~
           ignoreUnknownInstances: false
         Name: "0"
         Parent: id-3
@@ -85,6 +90,7 @@ messages:
         ClassName: StringValue
         Id: id-5
         Metadata:
+          debugId: ~
           ignoreUnknownInstances: false
         Name: "1"
         Parent: id-3
@@ -96,6 +102,7 @@ messages:
         ClassName: StringValue
         Id: id-6
         Metadata:
+          debugId: ~
           ignoreUnknownInstances: false
         Name: "2"
         Parent: id-3
@@ -107,6 +114,7 @@ messages:
         ClassName: StringValue
         Id: id-7
         Metadata:
+          debugId: ~
           ignoreUnknownInstances: false
         Name: "3"
         Parent: id-3
@@ -118,6 +126,7 @@ messages:
         ClassName: StringValue
         Id: id-8
         Metadata:
+          debugId: ~
           ignoreUnknownInstances: false
         Name: "4"
         Parent: id-3
@@ -129,6 +138,7 @@ messages:
         ClassName: StringValue
         Id: id-9
         Metadata:
+          debugId: ~
           ignoreUnknownInstances: false
         Name: "5"
         Parent: id-3

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__remove_file_all-2.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__remove_file_all-2.snap
@@ -8,9 +8,11 @@ instances:
     ClassName: Folder
     Id: id-2
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: remove_file
     Parent: "00000000000000000000000000000000"
     Properties: {}
 messageCursor: 1
 sessionId: id-1
+

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__remove_file_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__remove_file_all.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/tests/serve.rs
 expression: "read_response.intern_and_redact(&mut redactions, root_id)"
-
 ---
 instances:
   id-2:
@@ -10,6 +9,7 @@ instances:
     ClassName: Folder
     Id: id-2
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: remove_file
     Parent: "00000000000000000000000000000000"
@@ -19,6 +19,7 @@ instances:
     ClassName: StringValue
     Id: id-3
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: hello
     Parent: id-2

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__scripts_all-2.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__scripts_all-2.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/tests/serve.rs
 expression: "read_response.intern_and_redact(&mut redactions, root_id)"
-
 ---
 instances:
   id-2:
@@ -11,6 +10,7 @@ instances:
     ClassName: Folder
     Id: id-2
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: scripts
     Parent: "00000000000000000000000000000000"
@@ -20,6 +20,7 @@ instances:
     ClassName: Script
     Id: id-3
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: bar
     Parent: id-2
@@ -31,6 +32,7 @@ instances:
     ClassName: ModuleScript
     Id: id-4
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: foo
     Parent: id-2

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__scripts_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__scripts_all.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/tests/serve.rs
 expression: "read_response.intern_and_redact(&mut redactions, root_id)"
-
 ---
 instances:
   id-2:
@@ -11,6 +10,7 @@ instances:
     ClassName: Folder
     Id: id-2
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: scripts
     Parent: "00000000000000000000000000000000"
@@ -20,6 +20,7 @@ instances:
     ClassName: Script
     Id: id-3
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: bar
     Parent: id-2
@@ -31,6 +32,7 @@ instances:
     ClassName: ModuleScript
     Id: id-4
     Metadata:
+      debugId: ~
       ignoreUnknownInstances: false
     Name: foo
     Parent: id-2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 pub mod cli;
 
 #[cfg(test)]
-mod tree_view;
+pub mod tree_view;
 
 mod auth_cookie;
 mod change_processor;

--- a/src/snapshot/metadata.rs
+++ b/src/snapshot/metadata.rs
@@ -52,6 +52,9 @@ pub struct InstanceMetadata {
     /// that instance's instigating source is snapshotted directly, the same
     /// context will be passed into it.
     pub context: InstanceContext,
+
+    ///Should only be used by the game generating instances
+    pub debug_id: Option<String>,
 }
 
 impl InstanceMetadata {
@@ -61,6 +64,7 @@ impl InstanceMetadata {
             instigating_source: None,
             relevant_paths: Vec::new(),
             context: InstanceContext::default(),
+            debug_id: None,
         }
     }
 
@@ -88,6 +92,12 @@ impl InstanceMetadata {
     pub fn context(self, context: &InstanceContext) -> Self {
         Self {
             context: context.clone(),
+            ..self
+        }
+    }
+    pub fn debug_id(self, debug_id: Option<String>) -> Self {
+        Self {
+            debug_id: debug_id,
             ..self
         }
     }

--- a/src/snapshot/tests/snapshots/librojo__snapshot__tests__apply__add_property.snap
+++ b/src/snapshot/tests/snapshots/librojo__snapshot__tests__apply__add_property.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot/tests/apply.rs
 expression: tree_view
-
 ---
 id: id-1
 name: ROOT
@@ -13,5 +12,6 @@ metadata:
   ignore_unknown_instances: false
   relevant_paths: []
   context: {}
+  debug_id: ~
 children: []
 

--- a/src/snapshot/tests/snapshots/librojo__snapshot__tests__apply__remove_property_after_patch.snap
+++ b/src/snapshot/tests/snapshots/librojo__snapshot__tests__apply__remove_property_after_patch.snap
@@ -10,4 +10,6 @@ metadata:
   ignore_unknown_instances: false
   relevant_paths: []
   context: {}
+  debug_id: ~
 children: []
+

--- a/src/snapshot/tests/snapshots/librojo__snapshot__tests__apply__remove_property_initial.snap
+++ b/src/snapshot/tests/snapshots/librojo__snapshot__tests__apply__remove_property_initial.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot/tests/apply.rs
 expression: tree_view
-
 ---
 id: id-1
 name: ROOT
@@ -13,5 +12,6 @@ metadata:
   ignore_unknown_instances: false
   relevant_paths: []
   context: {}
+  debug_id: ~
 children: []
 

--- a/src/snapshot/tests/snapshots/librojo__snapshot__tests__apply__set_name_and_class_name.snap
+++ b/src/snapshot/tests/snapshots/librojo__snapshot__tests__apply__set_name_and_class_name.snap
@@ -10,4 +10,6 @@ metadata:
   ignore_unknown_instances: false
   relevant_paths: []
   context: {}
+  debug_id: ~
 children: []
+

--- a/src/snapshot/tests/snapshots/librojo__snapshot__tests__compute__add_child.snap
+++ b/src/snapshot/tests/snapshots/librojo__snapshot__tests__compute__add_child.snap
@@ -11,8 +11,10 @@ added_instances:
         ignore_unknown_instances: false
         relevant_paths: []
         context: {}
+        debug_id: ~
       name: New
       class_name: Folder
       properties: {}
       children: []
 updated_instances: []
+

--- a/src/snapshot_middleware/mod.rs
+++ b/src/snapshot_middleware/mod.rs
@@ -8,7 +8,7 @@
 mod csv;
 mod dir;
 mod json;
-mod json_model;
+pub mod json_model;
 mod lua;
 mod meta_file;
 mod project;

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__csv__test__csv_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__csv__test__csv_from_vfs.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/csv.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -12,6 +11,7 @@ metadata:
     - /foo.csv
     - /foo.meta.json
   context: {}
+  debug_id: ~
 name: foo
 class_name: LocalizationTable
 properties:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__csv__test__csv_with_meta.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__csv__test__csv_with_meta.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/csv.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -12,6 +11,7 @@ metadata:
     - /foo.csv
     - /foo.meta.json
   context: {}
+  debug_id: ~
 name: foo
 class_name: LocalizationTable
 properties:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__dir__test__empty_folder.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__dir__test__empty_folder.snap
@@ -1,6 +1,5 @@
 ---
 source: src/snapshot_middleware/dir.rs
-assertion_line: 127
 expression: instance_snapshot
 ---
 snapshot_id: ~
@@ -19,6 +18,7 @@ metadata:
     - /foo/init.client.luau
     - /foo/init.csv
   context: {}
+  debug_id: ~
 name: foo
 class_name: Folder
 properties: {}

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__dir__test__folder_in_folder.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__dir__test__folder_in_folder.snap
@@ -1,6 +1,5 @@
 ---
 source: src/snapshot_middleware/dir.rs
-assertion_line: 148
 expression: instance_snapshot
 ---
 snapshot_id: ~
@@ -19,6 +18,7 @@ metadata:
     - /foo/init.client.luau
     - /foo/init.csv
   context: {}
+  debug_id: ~
 name: foo
 class_name: Folder
 properties: {}
@@ -39,6 +39,7 @@ children:
         - /foo/Child/init.client.luau
         - /foo/Child/init.csv
       context: {}
+      debug_id: ~
     name: Child
     class_name: Folder
     properties: {}

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__json__test__instance_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__json__test__instance_from_vfs.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/json.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -12,6 +11,7 @@ metadata:
     - /foo.json
     - /foo.meta.json
   context: {}
+  debug_id: ~
 name: foo
 class_name: ModuleScript
 properties:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__json_model__test__model_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__json_model__test__model_from_vfs.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/json_model.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -11,6 +10,7 @@ metadata:
   relevant_paths:
     - /foo.model.json
   context: {}
+  debug_id: ~
 name: foo
 class_name: IntValue
 properties:
@@ -22,6 +22,7 @@ children:
       ignore_unknown_instances: false
       relevant_paths: []
       context: {}
+      debug_id: ~
     name: The Child
     class_name: StringValue
     properties: {}

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__json_model__test__model_from_vfs_legacy.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__json_model__test__model_from_vfs_legacy.snap
@@ -1,6 +1,5 @@
 ---
 source: src/snapshot_middleware/json_model.rs
-assertion_line: 186
 expression: instance_snapshot
 ---
 snapshot_id: ~
@@ -11,6 +10,7 @@ metadata:
   relevant_paths:
     - /foo.model.json
   context: {}
+  debug_id: ~
 name: foo
 class_name: IntValue
 properties:
@@ -22,6 +22,7 @@ children:
       ignore_unknown_instances: false
       relevant_paths: []
       context: {}
+      debug_id: ~
     name: The Child
     class_name: StringValue
     properties: {}

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__client_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__client_from_vfs.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/lua.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -12,6 +11,7 @@ metadata:
     - /foo.client.lua
     - /foo.meta.json
   context: {}
+  debug_id: ~
 name: foo
 class_name: LocalScript
 properties:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__module_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__module_from_vfs.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/lua.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -12,6 +11,7 @@ metadata:
     - /foo.lua
     - /foo.meta.json
   context: {}
+  debug_id: ~
 name: foo
 class_name: ModuleScript
 properties:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__module_with_meta.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__module_with_meta.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/lua.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -12,6 +11,7 @@ metadata:
     - /foo.lua
     - /foo.meta.json
   context: {}
+  debug_id: ~
 name: foo
 class_name: ModuleScript
 properties:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__script_disabled.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__script_disabled.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/lua.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -12,6 +11,7 @@ metadata:
     - /bar.server.lua
     - /bar.meta.json
   context: {}
+  debug_id: ~
 name: bar
 class_name: Script
 properties:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__script_with_meta.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__script_with_meta.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/lua.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -12,6 +11,7 @@ metadata:
     - /foo.server.lua
     - /foo.meta.json
   context: {}
+  debug_id: ~
 name: foo
 class_name: Script
 properties:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__server_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__server_from_vfs.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/lua.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -12,6 +11,7 @@ metadata:
     - /foo.server.lua
     - /foo.meta.json
   context: {}
+  debug_id: ~
 name: foo
 class_name: Script
 properties:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_from_direct_file.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_from_direct_file.snap
@@ -10,7 +10,9 @@ metadata:
   relevant_paths:
     - /foo/hello.project.json
   context: {}
+  debug_id: ~
 name: direct-project
 class_name: Model
 properties: {}
 children: []
+

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_path_property_overrides.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_path_property_overrides.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/project.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -12,6 +11,7 @@ metadata:
     - /foo/other.project.json
     - /foo/default.project.json
   context: {}
+  debug_id: ~
 name: path-property-override
 class_name: StringValue
 properties:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_children.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_children.snap
@@ -10,6 +10,7 @@ metadata:
   relevant_paths:
     - /foo.project.json
   context: {}
+  debug_id: ~
 name: children
 class_name: Folder
 properties: {}
@@ -25,7 +26,9 @@ children:
           - Folder
       relevant_paths: []
       context: {}
+      debug_id: ~
     name: Child
     class_name: Model
     properties: {}
     children: []
+

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_path_to_project.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_path_to_project.snap
@@ -11,7 +11,9 @@ metadata:
     - /foo/other.project.json
     - /foo/default.project.json
   context: {}
+  debug_id: ~
 name: path-project
 class_name: Model
 properties: {}
 children: []
+

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_path_to_project_with_children.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_path_to_project_with_children.snap
@@ -11,6 +11,7 @@ metadata:
     - /foo/other.project.json
     - /foo/default.project.json
   context: {}
+  debug_id: ~
 name: path-child-project
 class_name: Folder
 properties: {}
@@ -26,7 +27,9 @@ children:
           - Folder
       relevant_paths: []
       context: {}
+      debug_id: ~
     name: SomeChild
     class_name: Model
     properties: {}
     children: []
+

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_path_to_txt.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_path_to_txt.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/project.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -13,6 +12,7 @@ metadata:
     - /foo/other.meta.json
     - /foo/default.project.json
   context: {}
+  debug_id: ~
 name: path-project
 class_name: StringValue
 properties:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_resolved_properties.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_resolved_properties.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/project.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -11,6 +10,7 @@ metadata:
   relevant_paths:
     - /foo.project.json
   context: {}
+  debug_id: ~
 name: resolved-properties
 class_name: StringValue
 properties:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_unresolved_properties.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_unresolved_properties.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/project.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -11,6 +10,7 @@ metadata:
   relevant_paths:
     - /foo.project.json
   context: {}
+  debug_id: ~
 name: unresolved-properties
 class_name: StringValue
 properties:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__txt__test__instance_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__txt__test__instance_from_vfs.snap
@@ -1,7 +1,6 @@
 ---
 source: src/snapshot_middleware/txt.rs
 expression: instance_snapshot
-
 ---
 snapshot_id: ~
 metadata:
@@ -12,6 +11,7 @@ metadata:
     - /foo.txt
     - /foo.meta.json
   context: {}
+  debug_id: ~
 name: foo
 class_name: StringValue
 properties:

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -8,7 +8,7 @@ use rbx_dom_weak::types::Ref;
 
 use crate::{
     serve_session::ServeSession,
-    snapshot::{InstanceWithMeta, PatchSet, PatchUpdate},
+    snapshot::{InstanceWithMeta, PatchAdd, PatchSet, PatchUpdate},
     web::{
         interface::{
             ErrorResponse, Instance, OpenResponse, ReadResponse, ServerInfoResponse,
@@ -150,10 +150,19 @@ impl ApiService {
             })
             .collect();
 
+        let added_instances = request
+            .added
+            .into_iter()
+            .map(|update| PatchAdd {
+                parent_id: update.id,
+                instance: update.instance.into_snapshot().unwrap(),
+            })
+            .collect();
+
         tree_mutation_sender
             .send(PatchSet {
-                removed_instances: Vec::new(),
-                added_instances: Vec::new(),
+                removed_instances: request.removed,
+                added_instances,
                 updated_instances,
             })
             .unwrap();

--- a/src/web/interface.rs
+++ b/src/web/interface.rs
@@ -15,6 +15,7 @@ use crate::{
     snapshot::{
         AppliedPatchSet, InstanceMetadata as RojoInstanceMetadata, InstanceWithMeta, RojoTree,
     },
+    snapshot_middleware::json_model::JsonModel,
 };
 
 /// Server version to report over the API, not exposed outside this crate.
@@ -97,12 +98,14 @@ pub struct InstanceUpdate {
 #[serde(rename_all = "camelCase")]
 pub struct InstanceMetadata {
     pub ignore_unknown_instances: bool,
+    pub debug_id: Option<String>,
 }
 
 impl InstanceMetadata {
     pub(crate) fn from_rojo_metadata(meta: &RojoInstanceMetadata) -> Self {
         Self {
             ignore_unknown_instances: meta.ignore_unknown_instances,
+            debug_id: meta.debug_id.clone(),
         }
     }
 }
@@ -182,10 +185,17 @@ pub struct WriteRequest {
     pub removed: Vec<Ref>,
 
     #[serde(default)]
-    pub added: HashMap<Ref, ()>,
+    pub added: Vec<WritePatchAdded>,
+
     pub updated: Vec<InstanceUpdate>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WritePatchAdded {
+    pub id: Ref,
+    pub instance: JsonModel,
+}
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WriteResponse {


### PR DESCRIPTION
requires both
https://github.com/rojo-rbx/rbx-dom/pull/233
https://github.com/rojo-rbx/rbx-dom/pull/232
to be accepted and to be pulled into rojo to work.

this PR adds instance added events to rojo so that we can later 2 way sync model.json. rbxm and rbxmx files.
because of that this pr also adds ids created instances and adds that idea in the metadata.