### PR TITLE
fix release action with aftman

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,6 @@ jobs:
           profile: minimal
 
       - name: Setup Aftman
-        # when https://github.com/ok-nick/setup-aftman/pull/1 is accepted switch back to ok-nick version
         uses: Bok-nick/setup-aftman@v0.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,10 +112,13 @@ jobs:
           override: true
           profile: minimal
 
-      - name: Setup Foreman
-        uses: Roblox/setup-foreman@v1
+      - name: Setup Aftman
+        # when https://github.com/ok-nick/setup-aftman/pull/1 is accepted switch back to ok-nick version
+        uses: Boegie19/setup-aftman@v1.1.0-windows-fix.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          trust-check: false
+          version: 'v0.2.6'
 
       - name: Install packages
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Setup Aftman
         # when https://github.com/ok-nick/setup-aftman/pull/1 is accepted switch back to ok-nick version
-        uses: Boegie19/setup-aftman@v1.1.0-windows-fix.2
+        uses: Bok-nick/setup-aftman@v0.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           trust-check: false
@@ -125,6 +125,7 @@ jobs:
           cd plugin
           wally install
           cd ..
+        shell: bash
 
       - name: Build Release
         run: cargo build --release --locked --verbose

--- a/aftman.toml
+++ b/aftman.toml
@@ -1,0 +1,2 @@
+[tools]
+wally = "UpliftGames/wally@0.3.1"


### PR DESCRIPTION
replaced forman with afterman for builds
to fix the issues with foreman not building specific builds.
I still use foreman for the creation of the plugin

node:
In some of my test the Build (aarch64-apple-darwin) failed since I exceeded the api limit Idk if this issue would reappear for you as well but if I rerun it it then works.

error:
Aftman error: Unexpected GitHub API response: {"message":"API rate limit exceeded for 199.7.166.17. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}