### PR TITLE
Fix typo in .gitignore

### DIFF
--- a/assets/default-place-project/gitignore.txt
+++ b/assets/default-place-project/gitignore.txt
@@ -1,5 +1,5 @@
 # Project place file
-/{project_name}.rbxlx
+/{project_name}.rbxl
 
 # Roblox Studio lock files
 /*.rbxlx.lock


### PR DESCRIPTION
Fix a typo in .gitignore which caused it to exclude the Roblox Place file.