### PR TITLE
Support explicitly specifying http or https protocol in plugin

### DIFF
--- a/plugin/src/App/init.lua
+++ b/plugin/src/App/init.lua
@@ -203,8 +203,8 @@ function App:startSession()
 	}
 
 	local baseUrl = if string.find(host, "^https?://")
-		then string.format("%s:%d", host, port)
-		else string.format("http://%s:%d", host, port)
+		then string.format("%s:%s", host, port)
+		else string.format("http://%s:%s", host, port)
 	local apiContext = ApiContext.new(baseUrl)
 
 	local serveSession = ServeSession.new({

--- a/plugin/src/App/init.lua
+++ b/plugin/src/App/init.lua
@@ -202,7 +202,9 @@ function App:startSession()
 		twoWaySync = Settings:get("twoWaySync"),
 	}
 
-	local baseUrl = ("http://%s:%s"):format(host, port)
+	local baseUrl = if string.find(host, "^https?://")
+		then string.format("%s:%d", host, port)
+		else string.format("http://%s:%d", host, port)
 	local apiContext = ApiContext.new(baseUrl)
 
 	local serveSession = ServeSession.new({


### PR DESCRIPTION
When you put in the URL `https://example.com`, it would try to send a request to `http://https://example.com` instead, which would cause an "InvalidUrl" error. This fixes the error by only implicitly adding `http://` if a protocol is not otherwise specified.
This change is necessary for a project I'm working on that serves a Rojo project over https (via an SSL termination proxy) in order to prevent man in the middle attacks.