### PR TITLE
Post-Build/Post-Sync Boilerplate Add-on Capability

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -73,6 +73,17 @@ pub struct Project {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub serve_address: Option<IpAddr>,
 
+    /// If specified, sets the boilerplate text that rojo should add to
+    /// the beginning of scripts when parsing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub boilerplate_text: Option<String>,
+
+    /// A list of globs, relative to the folder the project file is in, that
+    /// match files that should be excluded when Rojo is applying boilerplate
+    /// text.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub glob_boilerplate_ignore_paths: Vec<Glob>,
+
     /// A list of globs, relative to the folder the project file is in, that
     /// match files that should be excluded if Rojo encounters them.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/src/snapshot_middleware/project.rs
+++ b/src/snapshot_middleware/project.rs
@@ -31,6 +31,15 @@ pub fn snapshot_project(
 
     context.add_path_ignore_rules(rules);
 
+    let boilerplate_rules = project.glob_boilerplate_ignore_paths.iter().map(|glob| PathIgnoreRule {
+        glob: glob.clone(),
+        base_path: project.folder_location().to_path_buf(),
+    });
+
+    context.add_boilerplate_ignore_rules(boilerplate_rules);
+
+    context.set_boilerplate_text(project.boilerplate_text);
+
     match snapshot_project_node(&context, path, &project.name, &project.tree, vfs, None)? {
         Some(found_snapshot) => {
             let mut snapshot = found_snapshot;


### PR DESCRIPTION
Adding post-build & post-sync boilerplate capabilities has the potential to unlock a wide array of new functionalities.

### Example Use-Case:
A developer is utilizing (Non-Roblox) Lua's path string version of require like so:
```lua
local module = require("src/client/module")
-- Roblox no likey :(
```
By implementing post-build and post-sync boilerplate capabilities, this developer's code can be automatically prepended during the build/sync process with their own boilerplate, transforming their code into a format that is compatible with the Roblox platform:
```lua
local require = require(game:GetService("ReplicatedStorage"):WaitForChild("Framework"))
local module = require("src/client/module")
-- Hooray! :D
```

### Example "default.project.json" File:
```json
{
  "boilerplateText": "local require = require(game:GetService('ReplicatedStorage'):WaitForChild('Framework'))",
  "globBoilerplateIgnorePaths": ["**/*.client.lua", "**/*.server.lua"],
}
```