### PR TITLE
Fix disconnected session activity

### DIFF
--- a/plugin/src/ServeSession.lua
+++ b/plugin/src/ServeSession.lua
@@ -285,6 +285,8 @@ end
 function ServeSession:__mainSyncLoop()
 	return self.__apiContext:retrieveMessages()
 		:andThen(function(messages)
+			Log.trace("Serve session {} retrieved {} messages", tostring(self), #messages)
+
 			for _, message in ipairs(messages) do
 				local unappliedPatch = self.__reconciler:applyPatch(message)
 


### PR DESCRIPTION
When a session is disconnected, the apiContext long-polling for messages continues until resolved/rejected. This means that even after a session is disconnected, a message can be received and handled.

This leads to bad behavior, as the session was already cleaned up and the message cannot be handled correctly. The instance map was cleaned up upon disconnect, so it will warn about unapplied changes to unknown instances. (Like #512)

It's very easy to repro:
Connect a session, disconnect it, then save a change.

https://github.com/rojo-rbx/rojo/assets/40185666/846a7269-7043-4727-9f9c-b3ac55a18a3a

-----------

This PR fixes that neatly by tracking all active requests in a map, and cancelling their promises when we disconnect.