### PR TITLE
Skip confirming patches that only contain a datamodel name change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased Changes
 * Significantly improved performance of `rojo sourcemap`. ([#668])
+* Skip confirming patches that contain only a datamodel name change. ([#688])
 
 [#668]: https://github.com/rojo-rbx/rojo/pull/668
+[#688]: https://github.com/rojo-rbx/rojo/pull/688
 
 ## [7.3.0] - April 22, 2023
 * Added `$attributes` to project format. ([#574])

--- a/plugin/src/App/init.lua
+++ b/plugin/src/App/init.lua
@@ -297,24 +297,17 @@ function App:startSession()
 
 		-- The datamodel name gets overwritten by Studio, making confirmation of it intrusive
 		-- and unnecessary. This special case allows it to be accepted without confirmation.
-
 		if
 			PatchSet.hasAdditions(patch) == false
 			and PatchSet.hasRemoves(patch) == false
-			and PatchSet.hasUpdates(patch) == true
+			and PatchSet.containsOnlyInstance(patch, instanceMap, game)
 		then
-			local onlyDatamodelNameChange = true
-			for _, update in patch.updated do
-				if
-					instanceMap.fromIds[update.id] ~= game -- Something other than the datamodel is changing
-					or next(update.changedProperties) ~= nil -- Something other than the name is changing
-				then
-					onlyDatamodelNameChange = false
-					break
-				end
-			end
-
-			if onlyDatamodelNameChange then
+			local datamodelUpdates = PatchSet.getUpdateForInstance(patch, instanceMap, game)
+			if
+				datamodelUpdates ~= nil
+				and next(datamodelUpdates.changedProperties) == nil
+				and datamodelUpdates.changedClassName == nil
+			then
 				Log.trace("Accepting patch without confirmation because it only contains a datamodel name change")
 				return "Accept"
 			end

--- a/plugin/src/PatchSet.lua
+++ b/plugin/src/PatchSet.lua
@@ -92,6 +92,112 @@ function PatchSet.hasUpdates(patchSet)
 end
 
 --[[
+	Tells whether the given PatchSet contains changes to the given instance id
+]]
+function PatchSet.containsId(patchSet, instanceMap, id)
+	for addedId in patchSet.added do
+		if addedId == id then
+			return true
+		end
+	end
+
+	for _, idOrInstance in patchSet.removed do
+		local removedId = if type(idOrInstance) == "string" then idOrInstance else instanceMap.fromInstances[idOrInstance]
+		if removedId == id then
+			return true
+		end
+	end
+
+	for _, update in patchSet.updated do
+		if update.id == id then
+			return true
+		end
+	end
+
+	return false
+end
+
+--[[
+	Tells whether the given PatchSet contains changes to the given instance
+]]
+function PatchSet.containsInstance(patchSet, instanceMap, instance)
+	local id = instanceMap.fromInstances[instance]
+	if id == nil then
+		return false
+	end
+
+	return PatchSet.containsId(patchSet, instanceMap, id)
+end
+
+--[[
+	Tells whether the given PatchSet contains changes to nothing but the given instance id
+]]
+function PatchSet.containsOnlyId(patchSet, instanceMap, id)
+	if not PatchSet.containsId(patchSet, instanceMap, id) then
+		-- Patch doesn't contain the id at all
+		return false
+	end
+
+	for addedId in patchSet.added do
+		if addedId ~= id then
+			return false
+		end
+	end
+
+	for _, idOrInstance in patchSet.removed do
+		local removedId = if type(idOrInstance) == "string" then idOrInstance else instanceMap.fromInstances[idOrInstance]
+		if removedId ~= id then
+			return false
+		end
+	end
+
+	for _, update in patchSet.updated do
+		if update.id ~= id then
+			return false
+		end
+	end
+
+	return true
+end
+
+--[[
+	Tells whether the given PatchSet contains changes to nothing but the given instance
+]]
+function PatchSet.containsOnlyInstance(patchSet, instanceMap, instance)
+	local id = instanceMap.fromInstances[instance]
+	if id == nil then
+		return false
+	end
+
+	return PatchSet.containsOnlyId(patchSet, instanceMap, id)
+end
+
+--[[
+	Returns the update to the given instance id, or nil if there aren't any
+]]
+function PatchSet.getUpdateForId(patchSet, id)
+	for _, update in patchSet.updated do
+		if update.id == id then
+			return update
+		end
+	end
+
+	return nil
+end
+
+--[[
+	Returns the update to the given instance, or nil if there aren't any
+]]
+function PatchSet.getUpdateForInstance(patchSet, instanceMap, instance)
+	local id = instanceMap.fromInstances[instance]
+	if id == nil then
+		return nil
+	end
+
+	return PatchSet.getUpdateForId(patchSet, id)
+end
+
+--[[
 	Tells whether the given PatchSets are equal.
 ]]
 function PatchSet.isEqual(patchA, patchB)

--- a/plugin/src/PatchSet.lua
+++ b/plugin/src/PatchSet.lua
@@ -116,7 +116,8 @@ function PatchSet.containsId(patchSet, instanceMap, id)
 end
 
 --[[
-	Tells whether the given PatchSet contains changes to the given instance
+	Tells whether the given PatchSet contains changes to the given instance. 
+	If the given InstanceMap does not contain the instance, this function always returns false.
 ]]
 function PatchSet.containsInstance(patchSet, instanceMap, instance)
 	local id = instanceMap.fromInstances[instance]

--- a/plugin/src/PatchSet.lua
+++ b/plugin/src/PatchSet.lua
@@ -186,7 +186,8 @@ function PatchSet.getUpdateForId(patchSet, id)
 end
 
 --[[
-	Returns the update to the given instance, or nil if there aren't any
+	Returns the update to the given instance, or nil if there aren't any.
+	If the given InstanceMap does not contain the instance, this function always returns nil.
 ]]
 function PatchSet.getUpdateForInstance(patchSet, instanceMap, instance)
 	local id = instanceMap.fromInstances[instance]

--- a/plugin/src/PatchSet.lua
+++ b/plugin/src/PatchSet.lua
@@ -160,7 +160,8 @@ function PatchSet.containsOnlyId(patchSet, instanceMap, id)
 end
 
 --[[
-	Tells whether the given PatchSet contains changes to nothing but the given instance
+	Tells whether the given PatchSet contains changes to nothing but the given instance.
+	If the given InstanceMap does not contain the instance, this function always returns false.
 ]]
 function PatchSet.containsOnlyInstance(patchSet, instanceMap, instance)
 	local id = instanceMap.fromInstances[instance]

--- a/plugin/src/PatchSet.lua
+++ b/plugin/src/PatchSet.lua
@@ -100,7 +100,7 @@ function PatchSet.containsId(patchSet, instanceMap, id)
 	end
 
 	for _, idOrInstance in patchSet.removed do
-		local removedId = if type(idOrInstance) == "string" then idOrInstance else instanceMap.fromInstances[idOrInstance]
+		local removedId = if Types.RbxId(idOrInstance) then idOrInstance else instanceMap.fromInstances[idOrInstance]
 		if removedId == id then
 			return true
 		end
@@ -144,7 +144,7 @@ function PatchSet.containsOnlyId(patchSet, instanceMap, id)
 	end
 
 	for _, idOrInstance in patchSet.removed do
-		local removedId = if type(idOrInstance) == "string" then idOrInstance else instanceMap.fromInstances[idOrInstance]
+		local removedId = if Types.RbxId(idOrInstance) then idOrInstance else instanceMap.fromInstances[idOrInstance]
 		if removedId ~= id then
 			return false
 		end
@@ -257,7 +257,7 @@ function PatchSet.humanSummary(instanceMap, patchSet)
 	for _, idOrInstance in ipairs(patchSet.removed) do
 		local instance, id
 
-		if type(idOrInstance) == "string" then
+		if Types.RbxId(idOrInstance) then
 			id = idOrInstance
 			instance = instanceMap.fromIds[id]
 		else

--- a/plugin/src/PatchSet.lua
+++ b/plugin/src/PatchSet.lua
@@ -95,10 +95,8 @@ end
 	Tells whether the given PatchSet contains changes to the given instance id
 ]]
 function PatchSet.containsId(patchSet, instanceMap, id)
-	for addedId in patchSet.added do
-		if addedId == id then
-			return true
-		end
+	if patchSet.added[id] ~= nil then
+		return true
 	end
 
 	for _, idOrInstance in patchSet.removed do


### PR DESCRIPTION
Closes #672.

Skips the user confirmation if the patch contains only a datamodel name change.

I decided to build generic PatchSet utility functions in case we need to use similar logic in the future, in addition to maintaining clear division of duties. The app code shouldn't be too dependent upon patch internal structure when we can avoid it.