### PR TITLE
Add protection against syncing non place projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased Changes
 * Significantly improved performance of `rojo sourcemap`. ([#668])
+* Added protection against syncing a model to a place. ([#691])
 
 [#668]: https://github.com/rojo-rbx/rojo/pull/668
+[#691]: https://github.com/rojo-rbx/rojo/pull/691
 
 ## [7.3.0] - April 22, 2023
 * Added `$attributes` to project format. ([#574])

--- a/plugin/src/ServeSession.lua
+++ b/plugin/src/ServeSession.lua
@@ -232,6 +232,18 @@ function ServeSession:__initialSync(serverInfo)
 				Log.error("Could not compute a diff to catch up to the Rojo server: {:#?}", catchUpPatch)
 			end
 
+			for _, update in catchUpPatch.updated do
+				if
+					update.id == self.__instanceMap.fromInstances[game]
+					and update.changedClassName ~= nil
+				then
+					-- Non-place projects will try to update the classname of game from DataModel to
+					-- something like Folder, ModuleScript, etc. This would fail, so we exit with a clear
+					-- message instead of crashing.
+					return Promise.reject("Cannot sync a non-place project!")
+				end
+			end
+
 			Log.trace("Computed hydration patch: {:#?}", debugPatch(catchUpPatch))
 
 			local userDecision = "Accept"

--- a/plugin/src/ServeSession.lua
+++ b/plugin/src/ServeSession.lua
@@ -240,7 +240,11 @@ function ServeSession:__initialSync(serverInfo)
 					-- Non-place projects will try to update the classname of game from DataModel to
 					-- something like Folder, ModuleScript, etc. This would fail, so we exit with a clear
 					-- message instead of crashing.
-					return Promise.reject("Cannot sync a non-place project!")
+					return Promise.reject(
+						"Cannot sync a model as a place."
+						.. "\nEnsure Rojo is serving a project file that has a DataModel at the root of its tree and try again."
+						.. "\nSee project file docs: https://rojo.space/docs/v7/project-format/"
+					)
 				end
 			end
 


### PR DESCRIPTION
Closes #113.

Does what it says on the tin. When you try to sync a non-place project, it gives a clear message instead of crashing.

![image](https://github.com/rojo-rbx/rojo/assets/40185666/c6a7d05d-2032-45ba-8ab2-b29660f72a7b)
