### PR TITLE
Change gitmodules from ssh to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "plugin/Packages/Roact"]
 	path = plugin/Packages/Roact
-	url = https://github.com/roblox/roact
+	url = https://github.com/roblox/roact.git
 [submodule "plugin/Packages/Flipper"]
 	path = plugin/Packages/Flipper
-	url = https://github.com/reselim/flipper
+	url = https://github.com/reselim/flipper.git
 [submodule "plugin/Packages/Promise"]
 	path = plugin/Packages/Promise
-	url = https://github.com/evaera/roblox-lua-promise
+	url = https://github.com/evaera/roblox-lua-promise.git
 [submodule "plugin/Packages/t"]
 	path = plugin/Packages/t
-	url = https://github.com/osyrisrblx/t
+	url = https://github.com/osyrisrblx/t.git
 [submodule "plugin/Packages/TestEZ"]
 	path = plugin/Packages/TestEZ
-	url = https://github.com/roblox/testez
+	url = https://github.com/roblox/testez.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "plugin/Packages/Roact"]
 	path = plugin/Packages/Roact
-	url = git@github.com:roblox/roact
+	url = https://github.com/roblox/roact
 [submodule "plugin/Packages/Flipper"]
 	path = plugin/Packages/Flipper
-	url = git@github.com:reselim/flipper
+	url = https://github.com/reselim/flipper
 [submodule "plugin/Packages/Promise"]
 	path = plugin/Packages/Promise
-	url = git@github.com:evaera/roblox-lua-promise
+	url = https://github.com/evaera/roblox-lua-promise
 [submodule "plugin/Packages/t"]
 	path = plugin/Packages/t
-	url = git@github.com:osyrisrblx/t
+	url = https://github.com/osyrisrblx/t
 [submodule "plugin/Packages/TestEZ"]
 	path = plugin/Packages/TestEZ
-	url = git@github.com:roblox/testez
+	url = https://github.com/roblox/testez


### PR DESCRIPTION
Why if you want to use ssh you need todo more setup aka add a ssh key into github while with https you don't have to do the extra work aka makes rojo easier to contribute to.