### PR TITLE
Handle strings and instances in patch removes for visualizer

### DIFF
--- a/plugin/src/App/Components/PatchVisualizer/init.lua
+++ b/plugin/src/App/Components/PatchVisualizer/init.lua
@@ -7,6 +7,7 @@ local Packages = Rojo.Packages
 local Roact = require(Packages.Roact)
 local Log = require(Packages.Log)
 
+local Types = require(Plugin.Types)
 local PatchSet = require(Plugin.PatchSet)
 local decodeValue = require(Plugin.Reconciler.decodeValue)
 local getProperty = require(Plugin.Reconciler.getProperty)
@@ -240,7 +241,14 @@ function PatchVisualizer:buildTree(patch, instanceMap)
 		})
 	end
 
-	for _, instance in patch.removed do
+	for _, idOrInstance in patch.removed do
+		local instance = if Types.RbxId(idOrInstance) then instanceMap.fromIds[idOrInstance] else idOrInstance
+		if not instance then
+			-- If we're viewing a past patch, the instance is already removed
+			-- and we therefore cannot get the tree for it anymore
+			continue
+		end
+
 		-- Gather ancestors from existing DOM
 		-- (note that they may have no ID if they're being removed as unknown)
 		local ancestry = {}


### PR DESCRIPTION
When an object is deleted in a patch, it is either represented with an ID or an Instance. On initial sync, removals are instances since the map does not contain those instances. Later removals of managed objects use an ID. The patch visualizer only handled instances, so this fixes that.

Closes #710.