### PR TITLE
Improve tooltip behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Improved sync info text on Connected page. ([#692])
 * Fix patch visualizer breaking when instances are removed during sync ([#713])
 * Patch visualizer now indicates what changes failed to apply. ([#717])
+* Improve tooltip behavior ([#723])
 
 [#668]: https://github.com/rojo-rbx/rojo/pull/668
 [#674]: https://github.com/rojo-rbx/rojo/pull/674
@@ -24,6 +25,7 @@
 [#692]: https://github.com/rojo-rbx/rojo/pull/692
 [#713]: https://github.com/rojo-rbx/rojo/pull/713
 [#717]: https://github.com/rojo-rbx/rojo/pull/717
+[#723]: https://github.com/rojo-rbx/rojo/pull/723
 
 
 ## [7.3.0] - April 22, 2023

--- a/plugin/src/App/Components/Tooltip.lua
+++ b/plugin/src/App/Components/Tooltip.lua
@@ -182,6 +182,17 @@ function Trigger:willUnmount()
 	end
 end
 
+function Trigger:didUpdate(prevProps)
+	if prevProps.text ~= self.props.text then
+		-- Any existing popup is now invalid
+		self.props.context.removeTip(self.id)
+		self.showingPopup = false
+
+		-- Let the new text propagate
+		self:managePopup()
+	end
+end
+
 function Trigger:isHovering()
 	local rbx = self.ref.current
 	if rbx then

--- a/plugin/src/App/Components/Tooltip.lua
+++ b/plugin/src/App/Components/Tooltip.lua
@@ -165,9 +165,11 @@ function Trigger:init()
 	self.id = HttpService:GenerateGUID(false)
 	self.ref = Roact.createRef()
 	self.mousePos = Vector2.zero
+	self.showingPopup = false
 
 	self.destroy = function()
 		self.props.context.removeTip(self.id)
+		self.showingPopup = false
 	end
 end
 
@@ -180,31 +182,66 @@ function Trigger:willUnmount()
 	end
 end
 
+function Trigger:isHovering()
+	local rbx = self.ref.current
+	if rbx then
+		local pos = rbx.AbsolutePosition
+		local size = rbx.AbsoluteSize
+		local mousePos = self.mousePos
+
+		return
+			mousePos.X >= pos.X and mousePos.X <= pos.X + size.X
+			and mousePos.Y >= pos.Y and mousePos.Y <= pos.Y + size.Y
+	end
+	return false
+end
+
+function Trigger:managePopup()
+	if self:isHovering() then
+		if self.showingPopup or self.showDelayThread then
+			-- Don't duplicate popups
+			return
+		end
+
+		self.showDelayThread = task.delay(DELAY, function()
+			self.props.context.addTip(self.id, {
+				Text = self.props.text,
+				Position = self.mousePos,
+				Trigger = self.ref,
+			})
+			self.showDelayThread = nil
+			self.showingPopup = true
+		end)
+	else
+		if self.showDelayThread then
+			task.cancel(self.showDelayThread)
+			self.showDelayThread = nil
+		end
+		self.props.context.removeTip(self.id)
+		self.showingPopup = false
+	end
+end
+
 function Trigger:render()
+	local function recalculate(rbx)
+		local widget = rbx:FindFirstAncestorOfClass("DockWidgetPluginGui")
+		if not widget then return end
+		self.mousePos = widget:GetRelativeMousePosition()
+
+		self:managePopup()
+	end
+
 	return e("Frame", {
 		Size = UDim2.fromScale(1, 1),
 		BackgroundTransparency = 1,
 		ZIndex = self.props.zIndex or 100,
 		[Roact.Ref] = self.ref,
 
-		[Roact.Event.MouseMoved] = function(_rbx, x, y)
-			self.mousePos = Vector2.new(x, y)
-		end,
-		[Roact.Event.MouseEnter] = function()
-			self.showDelayThread = task.delay(DELAY, function()
-				self.props.context.addTip(self.id, {
-					Text = self.props.text,
-					Position = self.mousePos,
-					Trigger = self.ref,
-				})
-			end)
-		end,
-		[Roact.Event.MouseLeave] = function()
-			if self.showDelayThread then
-				task.cancel(self.showDelayThread)
-			end
-			self.props.context.removeTip(self.id)
-		end,
+		[Roact.Change.AbsolutePosition] = recalculate,
+		[Roact.Change.AbsoluteSize] = recalculate,
+		[Roact.Event.MouseMoved] = recalculate,
+		[Roact.Event.MouseLeave] = recalculate,
+		[Roact.Event.MouseEnter] = recalculate,
 	})
 end
 


### PR DESCRIPTION
Tooltips only triggered based on mouse movement, but if the hover trigger moved out from under a stationary mouse then the tooltip remained. This was really irking me, so I redid the tooltip logic to solve this.


https://github.com/rojo-rbx/rojo/assets/40185666/433c748b-201a-4ed1-a460-383f05340d00


This doesn't technically support rotated triggers, but we have no need for that so I'm not going to over complicate the math when it won't provide benefit.