### PR TITLE
Rework patch visualizer with many fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Patch visualizer now indicates what changes failed to apply. ([#717])
 * Add buttons for navigation on the Connected page ([#722])
 * Improve tooltip behavior ([#723])
+* Rework patch visualizer with many fixes and improvements ([#726])
 
 [#668]: https://github.com/rojo-rbx/rojo/pull/668
 [#674]: https://github.com/rojo-rbx/rojo/pull/674
@@ -28,6 +29,7 @@
 [#717]: https://github.com/rojo-rbx/rojo/pull/717
 [#722]: https://github.com/rojo-rbx/rojo/pull/722
 [#723]: https://github.com/rojo-rbx/rojo/pull/723
+[#726]: https://github.com/rojo-rbx/rojo/pull/726
 
 ## [7.3.0] - April 22, 2023
 * Added `$attributes` to project format. ([#574])

--- a/plugin/src/App/Components/PatchVisualizer/ChangeList.lua
+++ b/plugin/src/App/Components/PatchVisualizer/ChangeList.lua
@@ -8,6 +8,8 @@ local Theme = require(Plugin.App.Theme)
 local ScrollingFrame = require(Plugin.App.Components.ScrollingFrame)
 local DisplayValue = require(script.Parent.DisplayValue)
 
+local EMPTY_TABLE = {}
+
 local e = Roact.createElement
 
 local ChangeList = Roact.Component:extend("ChangeList")
@@ -20,7 +22,6 @@ function ChangeList:render()
 	return Theme.with(function(theme)
 		local props = self.props
 		local changes = props.changes
-		local columnVisibility = props.columnVisibility
 
 		-- Color alternating rows for readability
 		local rowTransparency = props.transparency:map(function(t)
@@ -47,7 +48,6 @@ function ChangeList:render()
 				VerticalAlignment = Enum.VerticalAlignment.Center,
 			}),
 			A = e("TextLabel", {
-				Visible = columnVisibility[1],
 				Text = tostring(changes[1][1]),
 				BackgroundTransparency = 1,
 				Font = Enum.Font.GothamBold,
@@ -60,7 +60,6 @@ function ChangeList:render()
 				LayoutOrder = 1,
 			}),
 			B = e("TextLabel", {
-				Visible = columnVisibility[2],
 				Text = tostring(changes[1][2]),
 				BackgroundTransparency = 1,
 				Font = Enum.Font.GothamBold,
@@ -73,7 +72,6 @@ function ChangeList:render()
 				LayoutOrder = 2,
 			}),
 			C = e("TextLabel", {
-				Visible = columnVisibility[3],
 				Text = tostring(changes[1][3]),
 				BackgroundTransparency = 1,
 				Font = Enum.Font.GothamBold,
@@ -92,7 +90,7 @@ function ChangeList:render()
 				continue -- Skip headers, already handled above
 			end
 
-			local metadata = values[4]
+			local metadata = values[4] or EMPTY_TABLE
 			local isWarning = metadata.isWarning
 
 			rows[row] = e("Frame", {
@@ -110,7 +108,6 @@ function ChangeList:render()
 					VerticalAlignment = Enum.VerticalAlignment.Center,
 				}),
 				A = e("TextLabel", {
-					Visible = columnVisibility[1],
 					Text = (if isWarning then "⚠ " else "") .. tostring(values[1]),
 					BackgroundTransparency = 1,
 					Font = Enum.Font.GothamMedium,
@@ -125,7 +122,6 @@ function ChangeList:render()
 				B = e(
 					"Frame",
 					{
-						Visible = columnVisibility[2],
 						BackgroundTransparency = 1,
 						Size = UDim2.new(0.35, 0, 1, 0),
 						LayoutOrder = 2,
@@ -139,7 +135,6 @@ function ChangeList:render()
 				C = e(
 					"Frame",
 					{
-						Visible = columnVisibility[3],
 						BackgroundTransparency = 1,
 						Size = UDim2.new(0.35, 0, 1, 0),
 						LayoutOrder = 3,

--- a/plugin/src/App/Components/PatchVisualizer/DomLabel.lua
+++ b/plugin/src/App/Components/PatchVisualizer/DomLabel.lua
@@ -70,6 +70,22 @@ function DomLabel:init()
 	end)
 end
 
+function DomLabel:didUpdate(prevProps)
+	if
+		prevProps.instance ~= self.props.instance
+		or prevProps.patchType ~= self.props.patchType
+		or prevProps.name ~= self.props.name
+		or prevProps.changeList ~= self.props.changeList
+	then
+		-- Close the expansion when the domlabel is changed to a different thing
+		self.expanded = false
+		self.motor:setGoal(Flipper.Spring.new(30, {
+			frequency = 5,
+			dampingRatio = 1,
+		}))
+	end
+end
+
 function DomLabel:render()
 	local props = self.props
 
@@ -129,7 +145,7 @@ function DomLabel:render()
 						if props.changeList then
 							self.expanded = not self.expanded
 							local goalHeight = 30
-								+ (if self.expanded then math.clamp(#self.props.changeList * 30, 30, 30 * 6) else 0)
+								+ (if self.expanded then math.clamp(#props.changeList * 30, 30, 30 * 6) else 0)
 							self.motor:setGoal(Flipper.Spring.new(goalHeight, {
 								frequency = 5,
 								dampingRatio = 1,

--- a/plugin/src/App/Components/PatchVisualizer/DomLabel.lua
+++ b/plugin/src/App/Components/PatchVisualizer/DomLabel.lua
@@ -34,7 +34,6 @@ function Expansion:render()
 		ChangeList = e(ChangeList, {
 			changes = props.changeList,
 			transparency = props.transparency,
-			columnVisibility = props.columnVisibility,
 		}),
 	})
 end
@@ -155,7 +154,6 @@ function DomLabel:render()
 					indent = indent,
 					transparency = props.transparency,
 					changeList = props.changeList,
-					columnVisibility = props.columnVisibility,
 				})
 				else nil,
 			DiffIcon = if props.patchType

--- a/plugin/src/App/Components/PatchVisualizer/init.lua
+++ b/plugin/src/App/Components/PatchVisualizer/init.lua
@@ -28,7 +28,7 @@ function PatchVisualizer:willUnmount()
 end
 
 function PatchVisualizer:shouldUpdate(nextProps)
-	if self.props.tree ~= nextProps.tree then
+	if self.props.patchTree ~= nextProps.patchTree then
 		return true
 	end
 
@@ -41,18 +41,18 @@ function PatchVisualizer:shouldUpdate(nextProps)
 end
 
 function PatchVisualizer:render()
-	local tree = self.props.tree
-	if tree == nil and self.props.patch ~= nil then
-		tree = PatchTree.build(self.props.patch, self.props.instanceMap, self.props.changeListHeaders or { "Property", "Current", "Incoming" })
+	local patchTree = self.props.patchTree
+	if patchTree == nil and self.props.patch ~= nil then
+		patchTree = PatchTree.build(self.props.patch, self.props.instanceMap, self.props.changeListHeaders or { "Property", "Current", "Incoming" })
 		if self.props.unappliedPatch then
-			tree = PatchTree.updateMetadata(tree, self.props.patch, self.props.instanceMap, self.props.unappliedPatch)
+			patchTree = PatchTree.updateMetadata(patchTree, self.props.patch, self.props.instanceMap, self.props.unappliedPatch)
 		end
 	end
 
 	-- Recusively draw tree
 	local scrollElements, elementHeights = {}, {}
 
-	if tree then
+	if patchTree then
 		local function drawNode(node, depth)
 			local elementHeight, setElementHeight = Roact.createBinding(30)
 			table.insert(elementHeights, elementHeight)
@@ -75,7 +75,7 @@ function PatchVisualizer:render()
 			)
 		end
 
-		tree:forEach(function(node, depth)
+		patchTree:forEach(function(node, depth)
 			drawNode(node, depth)
 		end)
 	end

--- a/plugin/src/App/Components/PatchVisualizer/init.lua
+++ b/plugin/src/App/Components/PatchVisualizer/init.lua
@@ -5,149 +5,14 @@ local Plugin = Rojo.Plugin
 local Packages = Rojo.Packages
 
 local Roact = require(Packages.Roact)
-local Log = require(Packages.Log)
 
-local Types = require(Plugin.Types)
+local PatchTree = require(Plugin.PatchTree)
 local PatchSet = require(Plugin.PatchSet)
-local decodeValue = require(Plugin.Reconciler.decodeValue)
-local getProperty = require(Plugin.Reconciler.getProperty)
 
 local BorderedContainer = require(Plugin.App.Components.BorderedContainer)
 local VirtualScroller = require(Plugin.App.Components.VirtualScroller)
 
 local e = Roact.createElement
-
-local function alphabeticalNext(t, state)
-	-- Equivalent of the next function, but returns the keys in the alphabetic
-	-- order of node names. We use a temporary ordered key table that is stored in the
-	-- table being iterated.
-
-	local key = nil
-	if state == nil then
-		-- First iteration, generate the index
-		local orderedIndex, i = table.create(5), 0
-		for k in t do
-			i += 1
-			orderedIndex[i] = k
-		end
-		table.sort(orderedIndex, function(a, b)
-			local nodeA, nodeB = t[a], t[b]
-			return (nodeA.name or "") < (nodeB.name or "")
-		end)
-
-		t.__orderedIndex = orderedIndex
-		key = orderedIndex[1]
-	else
-		-- Fetch the next value
-		for i, orderedState in t.__orderedIndex do
-			if orderedState == state then
-				key = t.__orderedIndex[i + 1]
-				break
-			end
-		end
-	end
-
-	if key then
-		return key, t[key]
-	end
-
-	-- No more value to return, cleanup
-	t.__orderedIndex = nil
-	return
-end
-
-local function alphabeticalPairs(t)
-	-- Equivalent of the pairs() iterator, but sorted
-	return alphabeticalNext, t, nil
-end
-
-local function Tree()
-	local tree = {
-		idToNode = {},
-		ROOT = {
-			className = "DataModel",
-			name = "ROOT",
-			children = {},
-		},
-	}
-	-- Add ROOT to idToNode or it won't be found by getNode since that searches *within* ROOT
-	tree.idToNode["ROOT"] = tree.ROOT
-
-	function tree:getNode(id, target)
-		if self.idToNode[id] then
-			return self.idToNode[id]
-		end
-
-		for nodeId, node in target or tree.ROOT.children do
-			if nodeId == id then
-				self.idToNode[id] = node
-				return node
-			end
-			local descendant = self:getNode(id, node.children)
-			if descendant then
-				return descendant
-			end
-		end
-
-		return nil
-	end
-
-	function tree:addNode(parent, props)
-		parent = parent or "ROOT"
-
-		local node = self:getNode(props.id)
-		if node then
-			for k, v in props do
-				node[k] = v
-			end
-			return node
-		end
-
-		node = table.clone(props)
-		node.children = {}
-
-		local parentNode = self:getNode(parent)
-		if not parentNode then
-			Log.warn("Failed to create node since parent doesnt exist: {}, {}", parent, props)
-			return
-		end
-
-		parentNode.children[node.id] = node
-		self.idToNode[node.id] = node
-
-		return node
-	end
-
-	function tree:buildAncestryNodes(ancestry, patch, instanceMap)
-		-- Build nodes for ancestry by going up the tree
-		local previousId = "ROOT"
-		for _, ancestorId in ancestry do
-			local value = instanceMap.fromIds[ancestorId] or patch.added[ancestorId]
-			if not value then
-				Log.warn("Failed to find ancestor object for " .. ancestorId)
-				continue
-			end
-			self:addNode(previousId, {
-				id = ancestorId,
-				className = value.ClassName,
-				name = value.Name,
-				instance = if typeof(value) == "Instance" then value else nil,
-			})
-			previousId = ancestorId
-		end
-	end
-
-	return tree
-end
-
-local function findUnappliedPropsForId(unappliedPatch, id)
-	for _, change in unappliedPatch.updated do
-		if change.id == id then
-			return change.changedProperties or {}
-		end
-	end
-	return {}
-end
 
 local DomLabel = require(script.DomLabel)
 
@@ -164,253 +29,56 @@ function PatchVisualizer:willUnmount()
 end
 
 function PatchVisualizer:shouldUpdate(nextProps)
+	if self.props.tree ~= nextProps.tree then
+		return true
+	end
+
 	local currentPatch, nextPatch = self.props.patch, nextProps.patch
-
-	return not PatchSet.isEqual(currentPatch, nextPatch)
-end
-
-function PatchVisualizer:buildTree(patch, unappliedPatch, instanceMap)
-	local tree = Tree()
-
-	for _, change in patch.updated do
-		local instance = instanceMap.fromIds[change.id]
-		if not instance then
-			continue
-		end
-
-		-- Gather ancestors from existing DOM
-		local ancestry = {}
-		local parentObject = instance.Parent
-		local parentId = instanceMap.fromInstances[parentObject]
-		while parentObject do
-			table.insert(ancestry, 1, parentId)
-			parentObject = parentObject.Parent
-			parentId = instanceMap.fromInstances[parentObject]
-		end
-
-		tree:buildAncestryNodes(ancestry, patch, instanceMap)
-
-		-- Gather detail text
-		local changeList, hint = nil, nil
-		if next(change.changedProperties) or change.changedName then
-			local unappliedChanges = findUnappliedPropsForId(unappliedPatch, change.id)
-
-			changeList = {}
-
-			local hintBuffer, i = {}, 0
-			local function addProp(prop: string, current: any?, incoming: any?, metadata: any?)
-				i += 1
-				hintBuffer[i] = prop
-				changeList[i] = { prop, current, incoming, metadata }
-			end
-
-			-- Gather the changes
-
-			if change.changedName then
-				addProp("Name", instance.Name, change.changedName)
-			end
-
-			for prop, incoming in change.changedProperties do
-				local incomingSuccess, incomingValue = decodeValue(incoming, instanceMap)
-				local currentSuccess, currentValue = getProperty(instance, prop)
-
-				addProp(
-					prop,
-					if currentSuccess then currentValue else "[Error]",
-					if incomingSuccess then incomingValue else next(incoming),
-					{
-						isWarning = unappliedChanges[prop] ~= nil
-					}
-				)
-			end
-
-			-- Finalize detail values
-
-			-- Trim hint to top 3
-			table.sort(hintBuffer)
-			if #hintBuffer > 3 then
-				hintBuffer = {
-					hintBuffer[1],
-					hintBuffer[2],
-					hintBuffer[3],
-					i - 3 .. " more",
-				}
-			end
-			hint = table.concat(hintBuffer, ", ")
-
-			-- Sort changes and add header
-			table.sort(changeList, function(a, b)
-				return a[1] < b[1]
-			end)
-			table.insert(changeList, 1, { "Property", "Current", "Incoming" })
-		end
-
-		-- Add this node to tree
-		tree:addNode(instanceMap.fromInstances[instance.Parent], {
-			id = change.id,
-			patchType = "Edit",
-			className = instance.ClassName,
-			name = instance.Name,
-			instance = instance,
-			hint = hint,
-			changeList = changeList,
-		})
+	if currentPatch ~= nil or nextPatch ~= nil then
+		return not PatchSet.isEqual(currentPatch, nextPatch)
 	end
 
-	for _, idOrInstance in patch.removed do
-		local instance = if Types.RbxId(idOrInstance) then instanceMap.fromIds[idOrInstance] else idOrInstance
-		if not instance then
-			-- If we're viewing a past patch, the instance is already removed
-			-- and we therefore cannot get the tree for it anymore
-			continue
-		end
-
-		-- Gather ancestors from existing DOM
-		-- (note that they may have no ID if they're being removed as unknown)
-		local ancestry = {}
-		local parentObject = instance.Parent
-		local parentId = instanceMap.fromInstances[parentObject] or HttpService:GenerateGUID(false)
-		while parentObject do
-			instanceMap:insert(parentId, parentObject)
-			table.insert(ancestry, 1, parentId)
-			parentObject = parentObject.Parent
-			parentId = instanceMap.fromInstances[parentObject] or HttpService:GenerateGUID(false)
-		end
-
-		tree:buildAncestryNodes(ancestry, patch, instanceMap)
-
-		-- Add this node to tree
-		local nodeId = instanceMap.fromInstances[instance] or HttpService:GenerateGUID(false)
-		instanceMap:insert(nodeId, instance)
-		tree:addNode(instanceMap.fromInstances[instance.Parent], {
-			id = nodeId,
-			patchType = "Remove",
-			className = instance.ClassName,
-			name = instance.Name,
-			instance = instance,
-		})
-	end
-
-	for id, change in patch.added do
-		-- Gather ancestors from existing DOM or future additions
-		local ancestry = {}
-		local parentId = change.Parent
-		local parentData = patch.added[parentId]
-		local parentObject = instanceMap.fromIds[parentId]
-		while parentId do
-			table.insert(ancestry, 1, parentId)
-			parentId = nil
-
-			if parentData then
-				parentId = parentData.Parent
-				parentData = patch.added[parentId]
-				parentObject = instanceMap.fromIds[parentId]
-			elseif parentObject then
-				parentObject = parentObject.Parent
-				parentId = instanceMap.fromInstances[parentObject]
-				parentData = patch.added[parentId]
-			end
-		end
-
-		tree:buildAncestryNodes(ancestry, patch, instanceMap)
-
-		-- Gather detail text
-		local changeList, hint = nil, nil
-		if next(change.Properties) then
-			local unappliedChanges = findUnappliedPropsForId(unappliedPatch, change.Id)
-
-			changeList = {}
-
-			local hintBuffer, i = {}, 0
-			for prop, incoming in change.Properties do
-				i += 1
-				hintBuffer[i] = prop
-
-				local success, incomingValue = decodeValue(incoming, instanceMap)
-				if success then
-					table.insert(changeList, { prop, "N/A", incomingValue, {
-						isWarning = unappliedChanges[prop] ~= nil
-					} })
-				else
-					table.insert(changeList, { prop, "N/A", next(incoming), {
-						isWarning = unappliedChanges[prop] ~= nil
-					} })
-				end
-			end
-
-			-- Finalize detail values
-
-			-- Trim hint to top 3
-			table.sort(hintBuffer)
-			if #hintBuffer > 3 then
-				hintBuffer = {
-					hintBuffer[1],
-					hintBuffer[2],
-					hintBuffer[3],
-					i - 3 .. " more",
-				}
-			end
-			hint = table.concat(hintBuffer, ", ")
-
-			-- Sort changes and add header
-			table.sort(changeList, function(a, b)
-				return a[1] < b[1]
-			end)
-			table.insert(changeList, 1, { "Property", "Current", "Incoming" })
-		end
-
-		-- Add this node to tree
-		tree:addNode(change.Parent, {
-			id = change.Id,
-			patchType = "Add",
-			className = change.ClassName,
-			name = change.Name,
-			hint = hint,
-			changeList = changeList,
-			instance = instanceMap.fromIds[id],
-		})
-	end
-
-	return tree
+	return false
 end
 
 function PatchVisualizer:render()
-	local patch = self.props.patch or PatchSet.newEmpty()
-	local unappliedPatch = self.props.unappliedPatch or PatchSet.newEmpty()
-	local instanceMap = self.props.instanceMap
-
-	local tree = self:buildTree(patch, unappliedPatch, instanceMap)
+	local tree = self.props.tree
+	if tree == nil and self.props.patch ~= nil then
+		tree = PatchTree.build(self.props.patch, self.props.instanceMap, self.props.changeListHeaders or { "Property", "Current", "Incoming" })
+		if self.props.unappliedPatch then
+			tree = PatchTree.updateMetadata(tree, self.props.patch, self.props.instanceMap, self.props.unappliedPatch)
+		end
+	end
 
 	-- Recusively draw tree
 	local scrollElements, elementHeights = {}, {}
-	local function drawNode(node, depth)
-		local elementHeight, setElementHeight = Roact.createBinding(30)
-		table.insert(elementHeights, elementHeight)
-		table.insert(
-			scrollElements,
-			e(DomLabel, {
-				columnVisibility = self.props.columnVisibility,
-				updateEvent = self.updateEvent,
-				elementHeight = elementHeight,
-				setElementHeight = setElementHeight,
-				patchType = node.patchType,
-				className = node.className,
-				isWarning = next(findUnappliedPropsForId(unappliedPatch, node.id)) ~= nil,
-				instance = node.instance,
-				name = node.name,
-				hint = node.hint,
-				changeList = node.changeList,
-				depth = depth,
-				transparency = self.props.transparency,
-			})
-		)
 
-		for _, childNode in alphabeticalPairs(node.children) do
-			drawNode(childNode, depth + 1)
+	if tree then
+		local function drawNode(node, depth)
+			local elementHeight, setElementHeight = Roact.createBinding(30)
+			table.insert(elementHeights, elementHeight)
+			table.insert(
+				scrollElements,
+				e(DomLabel, {
+					updateEvent = self.updateEvent,
+					elementHeight = elementHeight,
+					setElementHeight = setElementHeight,
+					patchType = node.patchType,
+					className = node.className,
+					isWarning = node.isWarning,
+					instance = node.instance,
+					name = node.name,
+					hint = node.hint,
+					changeList = node.changeList,
+					depth = depth,
+					transparency = self.props.transparency,
+				})
+			)
 		end
-	end
-	for _, node in alphabeticalPairs(tree.ROOT.children) do
-		drawNode(node, 0)
+
+		tree:forEach(function(node, depth)
+			drawNode(node, depth)
+		end)
 	end
 
 	return e(BorderedContainer, {

--- a/plugin/src/App/Components/PatchVisualizer/init.lua
+++ b/plugin/src/App/Components/PatchVisualizer/init.lua
@@ -7,6 +7,7 @@ local Roact = require(Packages.Roact)
 local PatchTree = require(Plugin.PatchTree)
 local PatchSet = require(Plugin.PatchSet)
 
+local Theme = require(Plugin.App.Theme)
 local BorderedContainer = require(Plugin.App.Components.BorderedContainer)
 local VirtualScroller = require(Plugin.App.Components.VirtualScroller)
 
@@ -79,25 +80,38 @@ function PatchVisualizer:render()
 		end)
 	end
 
-	return e(BorderedContainer, {
-		transparency = self.props.transparency,
-		size = self.props.size,
-		position = self.props.position,
-		layoutOrder = self.props.layoutOrder,
-	}, {
-		VirtualScroller = e(VirtualScroller, {
-			size = UDim2.new(1, 0, 1, 0),
+	return Theme.with(function(theme)
+		return e(BorderedContainer, {
 			transparency = self.props.transparency,
-			count = #scrollElements,
-			updateEvent = self.updateEvent.Event,
-			render = function(i)
-				return scrollElements[i]
-			end,
-			getHeightBinding = function(i)
-				return elementHeights[i]
-			end,
-		}),
-	})
+			size = self.props.size,
+			position = self.props.position,
+			layoutOrder = self.props.layoutOrder,
+		}, {
+			CleanMerge = e("TextLabel", {
+				Visible = #scrollElements == 0,
+				Text = "No changes to sync, project is up to date.",
+				Font = Enum.Font.GothamMedium,
+				TextSize = 15,
+				TextColor3 = theme.Settings.Setting.DescriptionColor,
+				TextWrapped = true,
+				Size = UDim2.new(1, 0, 1, 0),
+				BackgroundTransparency = 1,
+			}),
+
+			VirtualScroller = e(VirtualScroller, {
+				size = UDim2.new(1, 0, 1, 0),
+				transparency = self.props.transparency,
+				count = #scrollElements,
+				updateEvent = self.updateEvent.Event,
+				render = function(i)
+					return scrollElements[i]
+				end,
+				getHeightBinding = function(i)
+					return elementHeights[i]
+				end,
+			}),
+		})
+	end)
 end
 
 return PatchVisualizer

--- a/plugin/src/App/Components/PatchVisualizer/init.lua
+++ b/plugin/src/App/Components/PatchVisualizer/init.lua
@@ -1,5 +1,3 @@
-local HttpService = game:GetService("HttpService")
-
 local Rojo = script:FindFirstAncestor("Rojo")
 local Plugin = Rojo.Plugin
 local Packages = Rojo.Packages

--- a/plugin/src/App/StatusPages/Confirming.lua
+++ b/plugin/src/App/StatusPages/Confirming.lua
@@ -52,7 +52,7 @@ function ConfirmingPage:render()
 				transparency = self.props.transparency,
 				layoutOrder = 3,
 
-				columnVisibility = {true, true, true},
+				changeListHeaders = { "Property", "Current", "Incoming" },
 				patch = self.props.confirmData.patch,
 				instanceMap = self.props.confirmData.instanceMap,
 			}),

--- a/plugin/src/App/StatusPages/Connected.lua
+++ b/plugin/src/App/StatusPages/Connected.lua
@@ -83,7 +83,7 @@ function ChangesDrawer:render()
 				transparency = self.props.transparency,
 				layoutOrder = 3,
 
-				tree = self.props.patchTree,
+				patchTree = self.props.patchTree,
 			}),
 		})
 	end)

--- a/plugin/src/App/StatusPages/Connected.lua
+++ b/plugin/src/App/StatusPages/Connected.lua
@@ -83,10 +83,7 @@ function ChangesDrawer:render()
 				transparency = self.props.transparency,
 				layoutOrder = 3,
 
-				columnVisibility = { true, false, true },
-				patch = self.props.patch,
-				unappliedPatch = self.props.unappliedPatch,
-				instanceMap = self.serveSession.__instanceMap,
+				tree = self.props.patchTree,
 			}),
 		})
 	end)
@@ -365,8 +362,7 @@ function ConnectedPage:render()
 			ChangesDrawer = e(ChangesDrawer, {
 				rendered = self.state.renderChanges,
 				transparency = self.props.transparency,
-				patch = self.props.patchData.patch,
-				unappliedPatch = self.props.patchData.unapplied,
+				patchTree = self.props.patchTree,
 				serveSession = self.props.serveSession,
 				height = self.changeDrawerHeight,
 				layoutOrder = 5,

--- a/plugin/src/App/init.lua
+++ b/plugin/src/App/init.lua
@@ -554,8 +554,8 @@ function App:render()
 					initDockState = Enum.InitialDockState.Right,
 					initEnabled = false,
 					overridePreviousState = false,
-					floatingSize = Vector2.new(300, 200),
-					minimumSize = Vector2.new(300, 120),
+					floatingSize = Vector2.new(320, 210),
+					minimumSize = Vector2.new(300, 210),
 
 					zIndexBehavior = Enum.ZIndexBehavior.Sibling,
 

--- a/plugin/src/App/init.lua
+++ b/plugin/src/App/init.lua
@@ -367,9 +367,11 @@ function App:startSession()
 	end)
 	self.cleanupPostcommit = serveSession.__reconciler:hookPostcommit(function(patch, instanceMap, unappliedPatch)
 		-- Update tree with unapplied metadata
-		self:setState({
-			patchTree = PatchTree.updateMetadata(self.state.patchTree, patch, instanceMap, unappliedPatch),
-		})
+		self:setState(function(prevState)
+			return {
+				patchTree = PatchTree.updateMetadata(prevState.patchTree, patch, instanceMap, unappliedPatch),
+			}
+		end)
 	end)
 
 	serveSession:onPatchApplied(function(patch, unapplied)

--- a/plugin/src/App/init.lua
+++ b/plugin/src/App/init.lua
@@ -19,6 +19,7 @@ local Dictionary = require(Plugin.Dictionary)
 local ServeSession = require(Plugin.ServeSession)
 local ApiContext = require(Plugin.ApiContext)
 local PatchSet = require(Plugin.PatchSet)
+local PatchTree = require(Plugin.PatchTree)
 local preloadAssets = require(Plugin.preloadAssets)
 local soundPlayer = require(Plugin.soundPlayer)
 local ignorePlaceIds = require(Plugin.ignorePlaceIds)
@@ -358,6 +359,19 @@ function App:startSession()
 		twoWaySync = sessionOptions.twoWaySync,
 	})
 
+	self.cleanupPrecommit = serveSession.__reconciler:hookPrecommit(function(patch, instanceMap)
+		-- Build new tree for patch
+		self:setState({
+			patchTree = PatchTree.build(patch, instanceMap, { "Property", "Old", "New" }),
+		})
+	end)
+	self.cleanupPostcommit = serveSession.__reconciler:hookPostcommit(function(patch, instanceMap, unappliedPatch)
+		-- Update tree with unapplied metadata
+		self:setState({
+			patchTree = PatchTree.updateMetadata(self.state.patchTree, patch, instanceMap, unappliedPatch),
+		})
+	end)
+
 	serveSession:onPatchApplied(function(patch, unapplied)
 		local now = os.time()
 		local old = self.state.patchData
@@ -503,6 +517,13 @@ function App:endSession()
 		appStatus = AppStatus.NotConnected,
 	})
 
+	if self.cleanupPrecommit ~= nil then
+		self.cleanupPrecommit()
+	end
+	if self.cleanupPostcommit ~= nil then
+		self.cleanupPostcommit()
+	end
+
 	Log.trace("Session terminated by user")
 end
 
@@ -590,6 +611,7 @@ function App:render()
 					Connected = createPageElement(AppStatus.Connected, {
 						projectName = self.state.projectName,
 						address = self.state.address,
+						patchTree = self.state.patchTree,
 						patchData = self.state.patchData,
 						serveSession = self.serveSession,
 

--- a/plugin/src/PatchTree.lua
+++ b/plugin/src/PatchTree.lua
@@ -343,7 +343,7 @@ end
 
 local function updateMetadata(tree, patch, instanceMap, unappliedPatch)
 	if not tree then
-		tree = buildTree(patch, instanceMap)
+		tree = build(patch, instanceMap)
 	end
 
 	for _, failedChange in unappliedPatch.updated do

--- a/plugin/src/PatchTree.lua
+++ b/plugin/src/PatchTree.lua
@@ -92,18 +92,19 @@ function Tree:forEach(callback, node, depth)
 end
 
 -- Finds a node by id, depth first
--- target is the node to search within, defaults to root
-function Tree:getNode(id, target)
+-- searchNode is the node to start the search within, defaults to root
+function Tree:getNode(id, searchNode)
     if self.idToNode[id] then
         return self.idToNode[id]
     end
 
-    for nodeId, node in target or self.ROOT.children do
+	local searchChildren = (searchNode or self.ROOT).children
+    for nodeId, node in searchChildren do
         if nodeId == id then
             self.idToNode[id] = node
             return node
         end
-        local descendant = self:getNode(id, node.children)
+        local descendant = self:getNode(id, node)
         if descendant then
             return descendant
         end

--- a/plugin/src/PatchTree.lua
+++ b/plugin/src/PatchTree.lua
@@ -351,10 +351,12 @@ local function updateMetadata(tree, patch, instanceMap, unappliedPatch)
 		local node = tree:getNode(failedChange.id)
 		if node then
 			node.isWarning = true
+			Log.trace("Marked node as warning: {} {}", node.id, node.name)
 
 			if node.changeList then
 				for _, change in node.changeList do
 					if failedChange.changedProperties[change[1]] then
+						Log.trace("  Marked property as warning: {}", change[1])
 						if change[4] == nil then
 							change[4] = {}
 						end
@@ -370,15 +372,19 @@ local function updateMetadata(tree, patch, instanceMap, unappliedPatch)
 		if node.instance then
 			if node.instance.Parent == nil and node.instance ~= game then
 				-- This instance has been removed
+				Log.trace("Removed instance from node: {} {}", node.id, node.name)
 				node.instance = nil
 			end
 		else
 			-- This instance may have been added
 			node.instance = instanceMap.fromIds[node.id]
+			if node.instance then
+				Log.trace("Added instance to node: {} {}", node.id, node.name)
+			end
 		end
 	end)
 
-	return tree
+	return table.clone(tree)
 end
 
 return {

--- a/plugin/src/PatchTree.lua
+++ b/plugin/src/PatchTree.lua
@@ -1,0 +1,373 @@
+local HttpService = game:GetService("HttpService")
+
+local Rojo = script:FindFirstAncestor("Rojo")
+local Plugin = Rojo.Plugin
+local Packages = Rojo.Packages
+
+local Log = require(Packages.Log)
+
+local Types = require(Plugin.Types)
+local decodeValue = require(Plugin.Reconciler.decodeValue)
+local getProperty = require(Plugin.Reconciler.getProperty)
+
+local function alphabeticalNext(t, state)
+	-- Equivalent of the next function, but returns the keys in the alphabetic
+	-- order of node names. We use a temporary ordered key table that is stored in the
+	-- table being iterated.
+
+	local key = nil
+	if state == nil then
+		-- First iteration, generate the index
+		local orderedIndex, i = table.create(5), 0
+		for k in t do
+			i += 1
+			orderedIndex[i] = k
+		end
+		table.sort(orderedIndex, function(a, b)
+			local nodeA, nodeB = t[a], t[b]
+			return (nodeA.name or "") < (nodeB.name or "")
+		end)
+
+		t.__orderedIndex = orderedIndex
+		key = orderedIndex[1]
+	else
+		-- Fetch the next value
+		for i, orderedState in t.__orderedIndex do
+			if orderedState == state then
+				key = t.__orderedIndex[i + 1]
+				break
+			end
+		end
+	end
+
+	if key then
+		return key, t[key]
+	end
+
+	-- No more value to return, cleanup
+	t.__orderedIndex = nil
+
+	return
+end
+
+local function alphabeticalPairs(t)
+	-- Equivalent of the pairs() iterator, but sorted
+	return alphabeticalNext, t, nil
+end
+
+local Tree = {}
+Tree.__index = Tree
+
+function Tree.new()
+    local tree = {
+        idToNode = {},
+		ROOT = {
+			className = "DataModel",
+			name = "ROOT",
+			children = {},
+		},
+    }
+    -- Add ROOT to idToNode or it won't be found by getNode since that searches *within* ROOT
+	tree.idToNode["ROOT"] = tree.ROOT
+
+    return setmetatable(tree, Tree)
+end
+
+function Tree:forEach(callback, node, depth)
+	depth = depth or 1
+	for _, child in alphabeticalPairs(if node then node.children else self.ROOT.children) do
+		callback(child, depth)
+		if type(child.children) == "table" then
+			self:forEach(callback, child, depth + 1)
+		end
+	end
+end
+
+function Tree:getNode(id, target)
+    if self.idToNode[id] then
+        return self.idToNode[id]
+    end
+
+    for nodeId, node in target or self.ROOT.children do
+        if nodeId == id then
+            self.idToNode[id] = node
+            return node
+        end
+        local descendant = self:getNode(id, node.children)
+        if descendant then
+            return descendant
+        end
+    end
+
+    return nil
+end
+
+function Tree:addNode(parent, props)
+    parent = parent or "ROOT"
+
+    local node = self:getNode(props.id)
+    if node then
+        for k, v in props do
+            node[k] = v
+        end
+        return node
+    end
+
+    node = table.clone(props)
+    node.children = {}
+
+    local parentNode = self:getNode(parent)
+    if not parentNode then
+        Log.warn("Failed to create node since parent doesnt exist: {}, {}", parent, props)
+        return
+    end
+
+    parentNode.children[node.id] = node
+    self.idToNode[node.id] = node
+
+    return node
+end
+
+function Tree:buildAncestryNodes(ancestry, patch, instanceMap)
+    -- Build nodes for ancestry by going up the tree
+    local previousId = "ROOT"
+    for _, ancestorId in ancestry do
+        local value = instanceMap.fromIds[ancestorId] or patch.added[ancestorId]
+        if not value then
+            Log.warn("Failed to find ancestor object for " .. ancestorId)
+            continue
+        end
+        self:addNode(previousId, {
+            id = ancestorId,
+            className = value.ClassName,
+            name = value.Name,
+            instance = if typeof(value) == "Instance" then value else nil,
+        })
+        previousId = ancestorId
+    end
+end
+
+local function build(patch, instanceMap, changeListHeaders)
+	local tree = Tree.new()
+
+	for _, change in patch.updated do
+		local instance = instanceMap.fromIds[change.id]
+		if not instance then
+			continue
+		end
+
+		-- Gather ancestors from existing DOM
+		local ancestry = {}
+		local parentObject = instance.Parent
+		local parentId = instanceMap.fromInstances[parentObject]
+		while parentObject do
+			table.insert(ancestry, 1, parentId)
+			parentObject = parentObject.Parent
+			parentId = instanceMap.fromInstances[parentObject]
+		end
+
+		tree:buildAncestryNodes(ancestry, patch, instanceMap)
+
+		-- Gather detail text
+		local changeList, hint = nil, nil
+		if next(change.changedProperties) or change.changedName then
+			changeList = {}
+
+			local hintBuffer, i = {}, 0
+			local function addProp(prop: string, current: any?, incoming: any?, metadata: any?)
+				i += 1
+				hintBuffer[i] = prop
+				changeList[i] = { prop, current, incoming, metadata }
+			end
+
+			-- Gather the changes
+
+			if change.changedName then
+				addProp("Name", instance.Name, change.changedName)
+			end
+
+			for prop, incoming in change.changedProperties do
+				local incomingSuccess, incomingValue = decodeValue(incoming, instanceMap)
+				local currentSuccess, currentValue = getProperty(instance, prop)
+
+				addProp(
+					prop,
+					if currentSuccess then currentValue else "[Error]",
+					if incomingSuccess then incomingValue else next(incoming)
+				)
+			end
+
+			-- Finalize detail values
+
+			-- Trim hint to top 3
+			table.sort(hintBuffer)
+			if #hintBuffer > 3 then
+				hintBuffer = {
+					hintBuffer[1],
+					hintBuffer[2],
+					hintBuffer[3],
+					i - 3 .. " more",
+				}
+			end
+			hint = table.concat(hintBuffer, ", ")
+
+			-- Sort changes and add header
+			table.sort(changeList, function(a, b)
+				return a[1] < b[1]
+			end)
+			table.insert(changeList, 1, changeListHeaders)
+		end
+
+		-- Add this node to tree
+		tree:addNode(instanceMap.fromInstances[instance.Parent], {
+			id = change.id,
+			patchType = "Edit",
+			className = instance.ClassName,
+			name = instance.Name,
+			instance = instance,
+			hint = hint,
+			changeList = changeList,
+		})
+	end
+
+	for _, idOrInstance in patch.removed do
+		local instance = if Types.RbxId(idOrInstance) then instanceMap.fromIds[idOrInstance] else idOrInstance
+		if not instance then
+			-- If we're viewing a past patch, the instance is already removed
+			-- and we therefore cannot get the tree for it anymore
+			continue
+		end
+
+		-- Gather ancestors from existing DOM
+		-- (note that they may have no ID if they're being removed as unknown)
+		local ancestry = {}
+		local parentObject = instance.Parent
+		local parentId = instanceMap.fromInstances[parentObject] or HttpService:GenerateGUID(false)
+		while parentObject do
+			instanceMap:insert(parentId, parentObject)
+			table.insert(ancestry, 1, parentId)
+			parentObject = parentObject.Parent
+			parentId = instanceMap.fromInstances[parentObject] or HttpService:GenerateGUID(false)
+		end
+
+		tree:buildAncestryNodes(ancestry, patch, instanceMap)
+
+		-- Add this node to tree
+		local nodeId = instanceMap.fromInstances[instance] or HttpService:GenerateGUID(false)
+		instanceMap:insert(nodeId, instance)
+		tree:addNode(instanceMap.fromInstances[instance.Parent], {
+			id = nodeId,
+			patchType = "Remove",
+			className = instance.ClassName,
+			name = instance.Name,
+			instance = instance,
+		})
+	end
+
+	for id, change in patch.added do
+		-- Gather ancestors from existing DOM or future additions
+		local ancestry = {}
+		local parentId = change.Parent
+		local parentData = patch.added[parentId]
+		local parentObject = instanceMap.fromIds[parentId]
+		while parentId do
+			table.insert(ancestry, 1, parentId)
+			parentId = nil
+
+			if parentData then
+				parentId = parentData.Parent
+				parentData = patch.added[parentId]
+				parentObject = instanceMap.fromIds[parentId]
+			elseif parentObject then
+				parentObject = parentObject.Parent
+				parentId = instanceMap.fromInstances[parentObject]
+				parentData = patch.added[parentId]
+			end
+		end
+
+		tree:buildAncestryNodes(ancestry, patch, instanceMap)
+
+		-- Gather detail text
+		local changeList, hint = nil, nil
+		if next(change.Properties) then
+			changeList = {}
+
+			local hintBuffer, i = {}, 0
+			for prop, incoming in change.Properties do
+				i += 1
+				hintBuffer[i] = prop
+
+				local success, incomingValue = decodeValue(incoming, instanceMap)
+				if success then
+					table.insert(changeList, { prop, "N/A", incomingValue })
+				else
+					table.insert(changeList, { prop, "N/A", next(incoming) })
+				end
+			end
+
+			-- Finalize detail values
+
+			-- Trim hint to top 3
+			table.sort(hintBuffer)
+			if #hintBuffer > 3 then
+				hintBuffer = {
+					hintBuffer[1],
+					hintBuffer[2],
+					hintBuffer[3],
+					i - 3 .. " more",
+				}
+			end
+			hint = table.concat(hintBuffer, ", ")
+
+			-- Sort changes and add header
+			table.sort(changeList, function(a, b)
+				return a[1] < b[1]
+			end)
+			table.insert(changeList, 1, changeListHeaders)
+		end
+
+		-- Add this node to tree
+		tree:addNode(change.Parent, {
+			id = change.Id,
+			patchType = "Add",
+			className = change.ClassName,
+			name = change.Name,
+			hint = hint,
+			changeList = changeList,
+			instance = instanceMap.fromIds[id],
+		})
+	end
+
+	return tree
+end
+
+local function updateMetadata(tree, patch, instanceMap, unappliedPatch)
+	if not tree then
+		tree = buildTree(patch, instanceMap)
+	end
+
+	for _, failedChange in unappliedPatch.updated do
+		local node = tree:getNode(failedChange.id)
+		if node then
+			node.isWarning = true
+
+			if node.changeList then
+				for _, change in node.changeList do
+					if failedChange.changedProperties[change[1]] then
+						if change[4] == nil then
+							change[4] = {}
+						end
+						change[4].isWarning = true
+					end
+				end
+			end
+		end
+	end
+
+	return tree
+end
+
+return {
+    build = build,
+    updateMetadata = updateMetadata,
+}

--- a/plugin/src/PatchTree.lua
+++ b/plugin/src/PatchTree.lua
@@ -1,3 +1,8 @@
+--[[
+	Methods to turn PatchSets into trees matching the DataModel containing
+	the changes and metadata for use in the PatchVisualizer component.
+]]
+
 local HttpService = game:GetService("HttpService")
 
 local Rojo = script:FindFirstAncestor("Rojo")

--- a/plugin/src/PatchTree.lua
+++ b/plugin/src/PatchTree.lua
@@ -144,10 +144,10 @@ end
 
 -- Given a list of ancestor ids in descending order, builds the nodes for them
 -- using the patch and instanceMap info
-function Tree:buildAncestryNodes(ancestry, patch, instanceMap)
+function Tree:buildAncestryNodes(ancestryIds: { string }, patch, instanceMap)
     -- Build nodes for ancestry by going up the tree
     local previousId = "ROOT"
-    for _, ancestorId in ancestry do
+    for _, ancestorId in ancestryIds do
         local value = instanceMap.fromIds[ancestorId] or patch.added[ancestorId]
         if not value then
             Log.warn("Failed to find ancestor object for " .. ancestorId)
@@ -175,16 +175,16 @@ local function build(patch, instanceMap, changeListHeaders)
 		end
 
 		-- Gather ancestors from existing DOM
-		local ancestry = {}
+		local ancestryIds = {}
 		local parentObject = instance.Parent
 		local parentId = instanceMap.fromInstances[parentObject]
 		while parentObject do
-			table.insert(ancestry, 1, parentId)
+			table.insert(ancestryIds, 1, parentId)
 			parentObject = parentObject.Parent
 			parentId = instanceMap.fromInstances[parentObject]
 		end
 
-		tree:buildAncestryNodes(ancestry, patch, instanceMap)
+		tree:buildAncestryNodes(ancestryIds, patch, instanceMap)
 
 		-- Gather detail text
 		local changeList, hint = nil, nil
@@ -258,17 +258,17 @@ local function build(patch, instanceMap, changeListHeaders)
 
 		-- Gather ancestors from existing DOM
 		-- (note that they may have no ID if they're being removed as unknown)
-		local ancestry = {}
+		local ancestryIds = {}
 		local parentObject = instance.Parent
 		local parentId = instanceMap.fromInstances[parentObject] or HttpService:GenerateGUID(false)
 		while parentObject do
 			instanceMap:insert(parentId, parentObject) -- This ensures we can find the parent later
-			table.insert(ancestry, 1, parentId)
+			table.insert(ancestryIds, 1, parentId)
 			parentObject = parentObject.Parent
 			parentId = instanceMap.fromInstances[parentObject] or HttpService:GenerateGUID(false)
 		end
 
-		tree:buildAncestryNodes(ancestry, patch, instanceMap)
+		tree:buildAncestryNodes(ancestryIds, patch, instanceMap)
 
 		-- Add this node to tree
 		local nodeId = instanceMap.fromInstances[instance] or HttpService:GenerateGUID(false)
@@ -284,12 +284,12 @@ local function build(patch, instanceMap, changeListHeaders)
 
 	for id, change in patch.added do
 		-- Gather ancestors from existing DOM or future additions
-		local ancestry = {}
+		local ancestryIds = {}
 		local parentId = change.Parent
 		local parentData = patch.added[parentId]
 		local parentObject = instanceMap.fromIds[parentId]
 		while parentId do
-			table.insert(ancestry, 1, parentId)
+			table.insert(ancestryIds, 1, parentId)
 			parentId = nil
 
 			if parentData then
@@ -305,7 +305,7 @@ local function build(patch, instanceMap, changeListHeaders)
 			end
 		end
 
-		tree:buildAncestryNodes(ancestry, patch, instanceMap)
+		tree:buildAncestryNodes(ancestryIds, patch, instanceMap)
 
 		-- Gather detail text
 		local changeList, hint = nil, nil

--- a/plugin/src/PatchTree.lua
+++ b/plugin/src/PatchTree.lua
@@ -346,6 +346,7 @@ local function updateMetadata(tree, patch, instanceMap, unappliedPatch)
 		tree = build(patch, instanceMap)
 	end
 
+	-- Update isWarning metadata
 	for _, failedChange in unappliedPatch.updated do
 		local node = tree:getNode(failedChange.id)
 		if node then
@@ -363,6 +364,19 @@ local function updateMetadata(tree, patch, instanceMap, unappliedPatch)
 			end
 		end
 	end
+
+	-- Update if instances exist
+	tree:forEach(function(node)
+		if node.instance then
+			if node.instance.Parent == nil and node.instance ~= game then
+				-- This instance has been removed
+				node.instance = nil
+			end
+		else
+			-- This instance may have been added
+			node.instance = instanceMap.fromIds[node.id]
+		end
+	end)
 
 	return tree
 end

--- a/plugin/src/Reconciler/init.lua
+++ b/plugin/src/Reconciler/init.lua
@@ -3,6 +3,9 @@
 	and mutating the Roblox DOM.
 ]]
 
+local Packages = script.Parent.Parent.Packages
+local Log = require(Packages.Log)
+
 local applyPatch = require(script.applyPatch)
 local hydrate = require(script.hydrate)
 local diff = require(script.diff)
@@ -14,12 +17,34 @@ function Reconciler.new(instanceMap)
 	local self = {
 		-- Tracks all of the instances known by the reconciler by ID.
 		__instanceMap = instanceMap,
+		__precommitCallbacks = {},
 	}
 
 	return setmetatable(self, Reconciler)
 end
 
+function Reconciler:hookPrecommit(callback: (patch: any, instanceMap: any) -> ()): () -> ()
+	table.insert(self.__precommitCallbacks, callback)
+
+	return function()
+		-- Remove the callback from the list
+		for i, cb in self.__precommitCallbacks do
+			if cb == callback then
+				table.remove(self.__precommitCallbacks, i)
+				break
+			end
+		end
+	end
+end
+
 function Reconciler:applyPatch(patch)
+	for _, callback in self.__precommitCallbacks do
+		local success, err = pcall(callback, patch, self.__instanceMap)
+		if not success then
+			Log.warn("Precommit hook errored: {}", err)
+		end
+	end
+
 	return applyPatch(self.__instanceMap, patch)
 end
 

--- a/plugin/src/Reconciler/init.lua
+++ b/plugin/src/Reconciler/init.lua
@@ -26,12 +26,14 @@ end
 
 function Reconciler:hookPrecommit(callback: (patch: any, instanceMap: any) -> ()): () -> ()
 	table.insert(self.__precommitCallbacks, callback)
+	Log.trace("Added precommit callback: {}", callback)
 
 	return function()
 		-- Remove the callback from the list
 		for i, cb in self.__precommitCallbacks do
 			if cb == callback then
 				table.remove(self.__precommitCallbacks, i)
+				Log.trace("Removed precommit callback: {}", callback)
 				break
 			end
 		end
@@ -40,12 +42,14 @@ end
 
 function Reconciler:hookPostcommit(callback: (patch: any, instanceMap: any, unappliedPatch: any) -> ()): () -> ()
 	table.insert(self.__postcommitCallbacks, callback)
+	Log.trace("Added postcommit callback: {}", callback)
 
 	return function()
 		-- Remove the callback from the list
 		for i, cb in self.__postcommitCallbacks do
 			if cb == callback then
 				table.remove(self.__postcommitCallbacks, i)
+				Log.trace("Removed postcommit callback: {}", callback)
 				break
 			end
 		end

--- a/plugin/src/Reconciler/init.lua
+++ b/plugin/src/Reconciler/init.lua
@@ -18,6 +18,7 @@ function Reconciler.new(instanceMap)
 		-- Tracks all of the instances known by the reconciler by ID.
 		__instanceMap = instanceMap,
 		__precommitCallbacks = {},
+		__postcommitCallbacks = {},
 	}
 
 	return setmetatable(self, Reconciler)
@@ -37,6 +38,20 @@ function Reconciler:hookPrecommit(callback: (patch: any, instanceMap: any) -> ()
 	end
 end
 
+function Reconciler:hookPostcommit(callback: (patch: any, instanceMap: any, unappliedPatch: any) -> ()): () -> ()
+	table.insert(self.__postcommitCallbacks, callback)
+
+	return function()
+		-- Remove the callback from the list
+		for i, cb in self.__postcommitCallbacks do
+			if cb == callback then
+				table.remove(self.__postcommitCallbacks, i)
+				break
+			end
+		end
+	end
+end
+
 function Reconciler:applyPatch(patch)
 	for _, callback in self.__precommitCallbacks do
 		local success, err = pcall(callback, patch, self.__instanceMap)
@@ -45,7 +60,16 @@ function Reconciler:applyPatch(patch)
 		end
 	end
 
-	return applyPatch(self.__instanceMap, patch)
+	local unappliedPatch = applyPatch(self.__instanceMap, patch)
+
+	for _, callback in self.__postcommitCallbacks do
+		local success, err = pcall(callback, patch, self.__instanceMap, unappliedPatch)
+		if not success then
+			Log.warn("Postcommit hook errored: {}", err)
+		end
+	end
+
+	return unappliedPatch
 end
 
 function Reconciler:hydrate(virtualInstances, rootId, rootInstance)


### PR DESCRIPTION
Closes #714.

The patch visualizer logic had a serious flaw: it was given a patch but the state of the world may be before or after that patch was applied, making it potentially impossible to build a tree from the patch data.

This PR totally reworks that, and makes some other improvements while we're at it.

- Reconciler now has precommit and postcommit hooks for patch applying
  - This is used to compute a patch tree snapshot precommit and update the tree metadata postcommit
  - Could be useful for more things down the line! Maybe patch preprocessing middleware? Who knows
- PatchVisualizer can now display Removes that happened during sync
  - It was previously missing because the removed objects no longer existed so it couldn't get any info on them (This is resolved because the info is gotten in precommit, before the instance was removed)
- PatchVisualizer now shows Old and New values instead of just Incoming during sync
  - (Still displays Current and Incoming during confirmation)
  - This is much more useful, since you now see what the changes were and not just which things were changed
- PatchVisualizer displays clarifying message when initial sync has no changes instead of just showing a blank box
- Objects in the tree UI no longer get stuck expanded when the next patch has the same instance but different info on it
- Objects in the tree UI correctly become selectable after their instance is added and unclickable when removed during sync