### PR TITLE
Fix tooltips crashing on thread cancellation edge cases

### DIFF
--- a/plugin/src/App/Components/Tooltip.lua
+++ b/plugin/src/App/Components/Tooltip.lua
@@ -175,7 +175,7 @@ end
 
 function Trigger:willUnmount()
 	if self.showDelayThread then
-		task.cancel(self.showDelayThread)
+		pcall(task.cancel, self.showDelayThread)
 	end
 	if self.destroy then
 		self.destroy()
@@ -225,7 +225,7 @@ function Trigger:managePopup()
 		end)
 	else
 		if self.showDelayThread then
-			task.cancel(self.showDelayThread)
+			pcall(task.cancel, self.showDelayThread)
 			self.showDelayThread = nil
 		end
 		self.props.context.removeTip(self.id)


### PR DESCRIPTION
I forgot that thread.cancel can error.

![image](https://github.com/rojo-rbx/rojo/assets/40185666/093e972b-955c-4aa9-bad6-946ec9a53cbf)

It's harmless to us here though, so we can just pcall it.