### PR TITLE
Removed InstanceSnapshot snapshot_id's redudant Ref.

### DIFF
--- a/src/snapshot/instance_snapshot.rs
+++ b/src/snapshot/instance_snapshot.rs
@@ -17,9 +17,8 @@ use super::InstanceMetadata;
 // - Replace use of Variant with a sum of Variant + borrowed value
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InstanceSnapshot {
-    // FIXME: Don't use Option<Ref> anymore!
     /// A temporary ID applied to the snapshot that's used for Ref properties.
-    pub snapshot_id: Option<Ref>,
+    pub snapshot_id: Ref,
 
     /// Rojo-specific metadata associated with the instance.
     pub metadata: InstanceMetadata,
@@ -42,7 +41,7 @@ pub struct InstanceSnapshot {
 impl InstanceSnapshot {
     pub fn new() -> Self {
         Self {
-            snapshot_id: None,
+            snapshot_id: Ref::none(),
             metadata: InstanceMetadata::default(),
             name: Cow::Borrowed("DEFAULT"),
             class_name: Cow::Borrowed("DEFAULT"),
@@ -88,7 +87,7 @@ impl InstanceSnapshot {
         }
     }
 
-    pub fn snapshot_id(self, snapshot_id: Option<Ref>) -> Self {
+    pub fn snapshot_id(self, snapshot_id: Ref) -> Self {
         Self {
             snapshot_id,
             ..self
@@ -120,7 +119,7 @@ impl InstanceSnapshot {
             .collect();
 
         Self {
-            snapshot_id: Some(id),
+            snapshot_id: id,
             metadata: InstanceMetadata::default(),
             name: Cow::Owned(instance.name),
             class_name: Cow::Owned(instance.class),

--- a/src/snapshot/patch_apply.rs
+++ b/src/snapshot/patch_apply.rs
@@ -135,7 +135,7 @@ fn apply_add_child(
         context.has_refs_to_rewrite.insert(id);
     }
 
-    if let Some(snapshot_id) = snapshot_id {
+    if snapshot_id.is_some() {
         context.snapshot_id_to_instance_id.insert(snapshot_id, id);
     }
 
@@ -231,7 +231,7 @@ mod test {
         let root_id = tree.get_root_id();
 
         let snapshot = InstanceSnapshot {
-            snapshot_id: None,
+            snapshot_id: Ref::none(),
             metadata: Default::default(),
             name: Cow::Borrowed("Foo"),
             class_name: Cow::Borrowed("Bar"),

--- a/src/snapshot/patch_compute.rs
+++ b/src/snapshot/patch_compute.rs
@@ -77,8 +77,10 @@ fn compute_patch_set_internal(
     id: Ref,
     patch_set: &mut PatchSet,
 ) {
-    if let Some(snapshot_id) = snapshot.snapshot_id {
-        context.snapshot_id_to_instance_id.insert(snapshot_id, id);
+    if snapshot.snapshot_id.is_some() {
+        context
+            .snapshot_id_to_instance_id
+            .insert(snapshot.snapshot_id, id);
     }
 
     let instance = tree
@@ -244,7 +246,7 @@ mod test {
         // addition of a prop named Self, which is a self-referential Ref.
         let snapshot_id = Ref::new();
         let snapshot = InstanceSnapshot {
-            snapshot_id: Some(snapshot_id),
+            snapshot_id: snapshot_id,
             properties: hashmap! {
                 "Self".to_owned() => Variant::Ref(snapshot_id),
             },
@@ -286,13 +288,13 @@ mod test {
         // This patch describes the existing instance with a new child added.
         let snapshot_id = Ref::new();
         let snapshot = InstanceSnapshot {
-            snapshot_id: Some(snapshot_id),
+            snapshot_id: snapshot_id,
             children: vec![InstanceSnapshot {
                 properties: hashmap! {
                     "Self".to_owned() => Variant::Ref(snapshot_id),
                 },
 
-                snapshot_id: None,
+                snapshot_id: Ref::none(),
                 metadata: Default::default(),
                 name: Cow::Borrowed("child"),
                 class_name: Cow::Borrowed("child"),
@@ -311,7 +313,7 @@ mod test {
             added_instances: vec![PatchAdd {
                 parent_id: root_id,
                 instance: InstanceSnapshot {
-                    snapshot_id: None,
+                    snapshot_id: Ref::none(),
                     metadata: Default::default(),
                     properties: hashmap! {
                         "Self".to_owned() => Variant::Ref(root_id),

--- a/src/snapshot/tests/compute.rs
+++ b/src/snapshot/tests/compute.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use insta::assert_yaml_snapshot;
 use maplit::hashmap;
 
+use rbx_dom_weak::types::Ref;
 use rojo_insta_ext::RedactionMap;
 
 use crate::snapshot::{compute_patch_set, InstanceSnapshot, RojoTree};
@@ -15,7 +16,7 @@ fn set_name_and_class_name() {
     redactions.intern(tree.get_root_id());
 
     let snapshot = InstanceSnapshot {
-        snapshot_id: None,
+        snapshot_id: Ref::none(),
         metadata: Default::default(),
         name: Cow::Borrowed("Some Folder"),
         class_name: Cow::Borrowed("Folder"),
@@ -37,7 +38,7 @@ fn set_property() {
     redactions.intern(tree.get_root_id());
 
     let snapshot = InstanceSnapshot {
-        snapshot_id: None,
+        snapshot_id: Ref::none(),
         metadata: Default::default(),
         name: Cow::Borrowed("ROOT"),
         class_name: Cow::Borrowed("ROOT"),
@@ -70,7 +71,7 @@ fn remove_property() {
     }
 
     let snapshot = InstanceSnapshot {
-        snapshot_id: None,
+        snapshot_id: Ref::none(),
         metadata: Default::default(),
         name: Cow::Borrowed("ROOT"),
         class_name: Cow::Borrowed("ROOT"),
@@ -92,13 +93,13 @@ fn add_child() {
     redactions.intern(tree.get_root_id());
 
     let snapshot = InstanceSnapshot {
-        snapshot_id: None,
+        snapshot_id: Ref::none(),
         metadata: Default::default(),
         name: Cow::Borrowed("ROOT"),
         class_name: Cow::Borrowed("ROOT"),
         properties: Default::default(),
         children: vec![InstanceSnapshot {
-            snapshot_id: None,
+            snapshot_id: Ref::none(),
             metadata: Default::default(),
             name: Cow::Borrowed("New"),
             class_name: Cow::Borrowed("Folder"),
@@ -131,7 +132,7 @@ fn remove_child() {
     }
 
     let snapshot = InstanceSnapshot {
-        snapshot_id: None,
+        snapshot_id: Ref::none(),
         metadata: Default::default(),
         name: Cow::Borrowed("ROOT"),
         class_name: Cow::Borrowed("ROOT"),

--- a/src/snapshot/tests/snapshots/librojo__snapshot__tests__compute__add_child.snap
+++ b/src/snapshot/tests/snapshots/librojo__snapshot__tests__compute__add_child.snap
@@ -6,7 +6,7 @@ removed_instances: []
 added_instances:
   - parent_id: id-1
     instance:
-      snapshot_id: ~
+      snapshot_id: "00000000000000000000000000000000"
       metadata:
         ignore_unknown_instances: false
         relevant_paths: []
@@ -16,3 +16,4 @@ added_instances:
       properties: {}
       children: []
 updated_instances: []
+

--- a/src/snapshot_middleware/json_model.rs
+++ b/src/snapshot_middleware/json_model.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, collections::HashMap, path::Path, str};
 
 use anyhow::Context;
 use memofs::Vfs;
-use rbx_dom_weak::types::Attributes;
+use rbx_dom_weak::types::{Attributes, Ref};
 use serde::Deserialize;
 
 use crate::{
@@ -112,7 +112,7 @@ impl JsonModel {
         }
 
         Ok(InstanceSnapshot {
-            snapshot_id: None,
+            snapshot_id: Ref::none(),
             metadata: Default::default(),
             name: Cow::Owned(name),
             class_name: Cow::Owned(class_name),

--- a/src/snapshot_middleware/project.rs
+++ b/src/snapshot_middleware/project.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, collections::HashMap, path::Path};
 
 use anyhow::{bail, Context};
 use memofs::Vfs;
-use rbx_dom_weak::types::Attributes;
+use rbx_dom_weak::types::{Attributes, Ref};
 use rbx_reflection::ClassTag;
 
 use crate::{
@@ -271,7 +271,7 @@ pub fn snapshot_project_node(
     ));
 
     Ok(Some(InstanceSnapshot {
-        snapshot_id: None,
+        snapshot_id: Ref::none(),
         name,
         class_name,
         properties,

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__csv__test__csv_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__csv__test__csv_from_vfs.snap
@@ -1,9 +1,8 @@
 ---
 source: src/snapshot_middleware/csv.rs
 expression: instance_snapshot
-
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: false
   instigating_source:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__csv__test__csv_with_meta.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__csv__test__csv_with_meta.snap
@@ -1,9 +1,8 @@
 ---
 source: src/snapshot_middleware/csv.rs
 expression: instance_snapshot
-
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: true
   instigating_source:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__dir__test__empty_folder.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__dir__test__empty_folder.snap
@@ -1,9 +1,8 @@
 ---
 source: src/snapshot_middleware/dir.rs
-assertion_line: 127
 expression: instance_snapshot
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: false
   instigating_source:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__dir__test__folder_in_folder.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__dir__test__folder_in_folder.snap
@@ -1,9 +1,8 @@
 ---
 source: src/snapshot_middleware/dir.rs
-assertion_line: 148
 expression: instance_snapshot
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: false
   instigating_source:
@@ -23,7 +22,7 @@ name: foo
 class_name: Folder
 properties: {}
 children:
-  - snapshot_id: ~
+  - snapshot_id: "00000000000000000000000000000000"
     metadata:
       ignore_unknown_instances: false
       instigating_source:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__json__test__instance_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__json__test__instance_from_vfs.snap
@@ -1,9 +1,8 @@
 ---
 source: src/snapshot_middleware/json.rs
 expression: instance_snapshot
-
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: false
   instigating_source:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__json_model__test__model_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__json_model__test__model_from_vfs.snap
@@ -1,9 +1,8 @@
 ---
 source: src/snapshot_middleware/json_model.rs
 expression: instance_snapshot
-
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: false
   instigating_source:
@@ -17,7 +16,7 @@ properties:
   Value:
     Int64: 5
 children:
-  - snapshot_id: ~
+  - snapshot_id: "00000000000000000000000000000000"
     metadata:
       ignore_unknown_instances: false
       relevant_paths: []

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__json_model__test__model_from_vfs_legacy.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__json_model__test__model_from_vfs_legacy.snap
@@ -1,9 +1,8 @@
 ---
 source: src/snapshot_middleware/json_model.rs
-assertion_line: 186
 expression: instance_snapshot
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: false
   instigating_source:
@@ -17,7 +16,7 @@ properties:
   Value:
     Int64: 5
 children:
-  - snapshot_id: ~
+  - snapshot_id: "00000000000000000000000000000000"
     metadata:
       ignore_unknown_instances: false
       relevant_paths: []

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__client_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__client_from_vfs.snap
@@ -1,9 +1,8 @@
 ---
 source: src/snapshot_middleware/lua.rs
 expression: instance_snapshot
-
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: false
   instigating_source:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__module_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__module_from_vfs.snap
@@ -1,9 +1,8 @@
 ---
 source: src/snapshot_middleware/lua.rs
 expression: instance_snapshot
-
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: false
   instigating_source:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__module_with_meta.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__module_with_meta.snap
@@ -1,9 +1,8 @@
 ---
 source: src/snapshot_middleware/lua.rs
 expression: instance_snapshot
-
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: true
   instigating_source:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__script_disabled.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__script_disabled.snap
@@ -1,9 +1,8 @@
 ---
 source: src/snapshot_middleware/lua.rs
 expression: instance_snapshot
-
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: false
   instigating_source:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__script_with_meta.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__script_with_meta.snap
@@ -1,9 +1,8 @@
 ---
 source: src/snapshot_middleware/lua.rs
 expression: instance_snapshot
-
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: true
   instigating_source:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__server_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__server_from_vfs.snap
@@ -1,9 +1,8 @@
 ---
 source: src/snapshot_middleware/lua.rs
 expression: instance_snapshot
-
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: false
   instigating_source:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_from_direct_file.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_from_direct_file.snap
@@ -2,7 +2,7 @@
 source: src/snapshot_middleware/project.rs
 expression: instance_snapshot
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: true
   instigating_source:
@@ -14,3 +14,4 @@ name: direct-project
 class_name: Model
 properties: {}
 children: []
+

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_path_property_overrides.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_path_property_overrides.snap
@@ -1,9 +1,8 @@
 ---
 source: src/snapshot_middleware/project.rs
 expression: instance_snapshot
-
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: true
   instigating_source:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_children.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_children.snap
@@ -2,7 +2,7 @@
 source: src/snapshot_middleware/project.rs
 expression: instance_snapshot
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: true
   instigating_source:
@@ -14,7 +14,7 @@ name: children
 class_name: Folder
 properties: {}
 children:
-  - snapshot_id: ~
+  - snapshot_id: "00000000000000000000000000000000"
     metadata:
       ignore_unknown_instances: true
       instigating_source:
@@ -29,3 +29,4 @@ children:
     class_name: Model
     properties: {}
     children: []
+

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_path_to_project.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_path_to_project.snap
@@ -2,7 +2,7 @@
 source: src/snapshot_middleware/project.rs
 expression: instance_snapshot
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: true
   instigating_source:
@@ -15,3 +15,4 @@ name: path-project
 class_name: Model
 properties: {}
 children: []
+

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_path_to_project_with_children.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_path_to_project_with_children.snap
@@ -2,7 +2,7 @@
 source: src/snapshot_middleware/project.rs
 expression: instance_snapshot
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: true
   instigating_source:
@@ -15,7 +15,7 @@ name: path-child-project
 class_name: Folder
 properties: {}
 children:
-  - snapshot_id: ~
+  - snapshot_id: "00000000000000000000000000000000"
     metadata:
       ignore_unknown_instances: true
       instigating_source:
@@ -30,3 +30,4 @@ children:
     class_name: Model
     properties: {}
     children: []
+

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_path_to_txt.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_path_to_txt.snap
@@ -1,9 +1,8 @@
 ---
 source: src/snapshot_middleware/project.rs
 expression: instance_snapshot
-
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: false
   instigating_source:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_resolved_properties.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_resolved_properties.snap
@@ -1,9 +1,8 @@
 ---
 source: src/snapshot_middleware/project.rs
 expression: instance_snapshot
-
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: true
   instigating_source:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_unresolved_properties.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_unresolved_properties.snap
@@ -1,9 +1,8 @@
 ---
 source: src/snapshot_middleware/project.rs
 expression: instance_snapshot
-
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: true
   instigating_source:

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__txt__test__instance_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__txt__test__instance_from_vfs.snap
@@ -1,9 +1,8 @@
 ---
 source: src/snapshot_middleware/txt.rs
 expression: instance_snapshot
-
 ---
-snapshot_id: ~
+snapshot_id: "00000000000000000000000000000000"
 metadata:
   ignore_unknown_instances: false
   instigating_source:


### PR DESCRIPTION
Ref now is an optional inside, so it's redundant to have an option wrapping an option. The only snapshots that were changed were any that had a Ref within (from none to zeroed). Some also had some newlines added in the end.

Aside:
Since Ref is a nullable type, I'm worried about the change. For example, it's easy for someone to insert a null ref into any map where it's expected to be non-null, like in a PatchSet. 