### PR TITLE
Support ambiguous syntax for Font properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Patch visualizer now indicates what changes failed to apply. ([#717])
 * Add buttons for navigation on the Connected page ([#722])
 * Improve tooltip behavior ([#723])
+* Added better support for `Font` properties ([#731])
 
 [#668]: https://github.com/rojo-rbx/rojo/pull/668
 [#674]: https://github.com/rojo-rbx/rojo/pull/674
@@ -28,6 +29,7 @@
 [#717]: https://github.com/rojo-rbx/rojo/pull/717
 [#722]: https://github.com/rojo-rbx/rojo/pull/722
 [#723]: https://github.com/rojo-rbx/rojo/pull/723
+[#731]: https://github.com/rojo-rbx/rojo/pull/731
 
 ## [7.3.0] - April 22, 2023
 * Added `$attributes` to project format. ([#574])

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 
 use anyhow::{bail, format_err};
 use rbx_dom_weak::types::{
-    Attributes, CFrame, Color3, Content, Enum, Matrix3, Tags, Variant, VariantType, Vector2,
+    Attributes, CFrame, Color3, Content, Enum, Font, Matrix3, Tags, Variant, VariantType, Vector2,
     Vector3,
 };
 use rbx_reflection::{DataType, PropertyDescriptor};
@@ -49,6 +49,7 @@ pub enum AmbiguousValue {
     Array4([f64; 4]),
     Array12([f64; 12]),
     Attributes(Attributes),
+    Font(Font),
 }
 
 impl AmbiguousValue {
@@ -139,6 +140,8 @@ impl AmbiguousValue {
 
                 (VariantType::Attributes, AmbiguousValue::Attributes(value)) => Ok(value.into()),
 
+                (VariantType::Font, AmbiguousValue::Font(value)) => Ok(value.into()),
+
                 (_, unresolved) => Err(format_err!(
                     "Wrong type of value for property {}.{}. Expected {:?}, got {}",
                     class_name,
@@ -176,6 +179,7 @@ impl AmbiguousValue {
             AmbiguousValue::Array4(_) => "an array of four numbers",
             AmbiguousValue::Array12(_) => "an array of twelve numbers",
             AmbiguousValue::Attributes(_) => "an object containing attributes",
+            AmbiguousValue::Font(_) => "an object describing a Font",
         }
     }
 }
@@ -327,5 +331,24 @@ mod test {
             resolve("Lighting", "Technology", "\"Voxel\""),
             Variant::Enum(Enum::from_u32(1)),
         );
+    }
+
+    #[test]
+    fn font() {
+        use rbx_dom_weak::types::{FontStyle, FontWeight};
+
+        assert_eq!(
+            resolve(
+                "TextLabel",
+                "FontFace",
+                r#"{"family": "rbxasset://fonts/families/RobotoMono.json", "weight": "Thin", "style": "Normal"}"#
+            ),
+            Variant::Font(Font {
+                family: "rbxasset://fonts/families/RobotoMono.json".into(),
+                weight: FontWeight::Thin,
+                style: FontStyle::Normal,
+                cached_face_id: None,
+            })
+        )
     }
 }


### PR DESCRIPTION
Given how unambiguous `Font` as a datatype actually is, it makes not very much sense to require people use the fully qualified syntax for `FontFace` and any other properties that come up. So, this PR adds a new ambiguous syntax that supports it.

Long-term, I think we should reconsider our strategy for font families to make it more obvious how to set them (maybe use an enum instead of a raw string?) but that's an issue for another day.