### PR TITLE
Update Notify to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi 0.1.19",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -437,7 +437,7 @@ checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -518,6 +518,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13be71e6ca82e91bc0cb862bebaac0b2d1924a5a1d970c822b2f98b63fda8c3"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,39 +575,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0845fa252299212f0389d64ba26f34fa32cfe41588355f21ed507c59a0f64541"
 
 [[package]]
-name = "fsevent"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
-dependencies = [
- "bitflags",
- "fsevent-sys",
-]
-
-[[package]]
 name = "fsevent-sys"
-version = "2.0.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
@@ -908,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.7.1"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
  "bitflags",
  "inotify-sys",
@@ -963,15 +946,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,13 +982,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
+name = "kqueue"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+checksum = "2c8fc60ba15bf51257aa9807a48a61013db043fcf3a78cb0d916e8e396dcad98"
 dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
+dependencies = [
+ "bitflags",
+ "libc",
 ]
 
 [[package]]
@@ -1022,12 +1006,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -1046,6 +1024,16 @@ name = "linux-raw-sys"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
+
+[[package]]
+name = "lock_api"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1126,6 +1114,7 @@ dependencies = [
  "crossbeam-channel",
  "fs-err",
  "notify",
+ "notify-debouncer-full",
  "serde",
 ]
 
@@ -1146,25 +1135,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log",
- "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
@@ -1173,30 +1143,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "mio-extras"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
-dependencies = [
- "lazycell",
- "log",
- "mio 0.6.23",
- "slab",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
 ]
 
 [[package]]
@@ -1218,32 +1164,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "net2"
-version = "0.2.38"
+name = "notify"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631"
+checksum = "5738a2795d57ea20abec2d6d76c6081186709c0024187cd5977265eda6598b51"
 dependencies = [
- "cfg-if 0.1.10",
+ "bitflags",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
  "libc",
- "winapi 0.3.9",
+ "mio",
+ "walkdir",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
-name = "notify"
-version = "4.0.17"
+name = "notify-debouncer-full"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae03c8c853dba7bfd23e571ff0cff7bc9dceb40a4cd684cd1681824183f45257"
+checksum = "416969970ec751a5d702a88c6cd19ac1332abe997fce43f96db0418550426241"
 dependencies = [
- "bitflags",
- "filetime",
- "fsevent",
- "fsevent-sys",
- "inotify",
- "libc",
- "mio 0.6.23",
- "mio-extras",
+ "crossbeam-channel",
+ "file-id",
+ "notify",
+ "parking_lot",
  "walkdir",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1253,7 +1201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1303,7 +1251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "293c15678e37254c15bd2f092314abb4e51d7fdde05c2021279c12631b54f005"
 dependencies = [
  "bstr",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1372,7 +1320,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1380,6 +1328,29 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall 0.3.5",
+ "smallvec",
+ "windows-targets 0.48.0",
+]
 
 [[package]]
 name = "paste"
@@ -2158,7 +2129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2296,7 +2267,7 @@ dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "mio 0.8.6",
+ "mio",
  "num_cpus",
  "pin-project-lite",
  "socket2",
@@ -2658,12 +2629,6 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -2671,12 +2636,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -2690,7 +2649,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2861,7 +2820,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2870,17 +2829,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ hyper = { version = "0.14.13", features = ["server", "tcp", "http1"] }
 jod-thread = "0.1.2"
 log = "0.4.14"
 maplit = "1.0.2"
-notify = "4.0.17"
+notify = "6.0.1"
 num_cpus = "1.15.0"
 opener = "0.5.0"
 rayon = "1.7.0"

--- a/crates/memofs/CHANGELOG.md
+++ b/crates/memofs/CHANGELOG.md
@@ -1,6 +1,8 @@
 # memofs Changelog
 
 ## Unreleased Changes
+* Updated `notify` to 6.0.1.
+* Added `notify-debouncer-mini` at 0.2.0 as a dependency.
 
 ## 0.2.0 (2021-08-23)
 * Updated to `crossbeam-channel` 0.5.1.

--- a/crates/memofs/Cargo.toml
+++ b/crates/memofs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "memofs"
 description = "Virtual filesystem with configurable backends."
 version = "0.2.0"
-authors = ["Lucien Greathouse <me@lpghatguy.com>"]
+authors = ["Lucien Greathouse <me@lpghatguy.com>", "utrain"]
 edition = "2018"
 readme = "README.md"
 license = "MIT"
@@ -13,5 +13,6 @@ homepage = "https://github.com/rojo-rbx/rojo/tree/master/memofs"
 [dependencies]
 crossbeam-channel = "0.5.1"
 fs-err = "2.3.0"
-notify = "4.0.15"
+notify = "6.0.1"
 serde = { version = "1.0", features = ["derive"] }
+notify-debouncer-full = "0.2.0"  

--- a/crates/memofs/src/std_backend.rs
+++ b/crates/memofs/src/std_backend.rs
@@ -148,7 +148,7 @@ impl StdBackend {
                                 notify::ErrorKind::Generic(generic) => panic!("Internal notify error (memofs): {}", generic),
                                 notify::ErrorKind::InvalidConfig(config) => panic!("Internal memofs error: Invalid configuration for the watcher. How did we get here?\n{:?}", config),
                                 notify::ErrorKind::MaxFilesWatch => panic!("Internal notify error (memofs): The maximum amount of files that can be kept track of has been reached!"),
-                                
+
                                 notify::ErrorKind::Io(err) => todo!("What happens when IO errors like this: {}", err),
                                 notify::ErrorKind::PathNotFound => todo!("What happens when a path doesn't exist?"),
                                 notify::ErrorKind::WatchNotFound => todo!("What happens when a watch is not found when trying to remove it?"),

--- a/crates/memofs/src/std_backend.rs
+++ b/crates/memofs/src/std_backend.rs
@@ -4,41 +4,157 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
-use crossbeam_channel::Receiver;
-use notify::{watcher, DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
-
 use crate::{DirEntry, Metadata, ReadDir, VfsBackend, VfsEvent};
+use crossbeam_channel::Receiver;
+use notify::{
+    event::{ModifyKind, RenameMode},
+    EventKind, RecommendedWatcher, RecursiveMode, Watcher,
+};
+use notify_debouncer_full::{new_debouncer, Debouncer, FileIdMap};
 
 /// `VfsBackend` that uses `std::fs` and the `notify` crate.
 pub struct StdBackend {
-    watcher: RecommendedWatcher,
+    watcher: Debouncer<RecommendedWatcher, FileIdMap>,
     watcher_receiver: Receiver<VfsEvent>,
 }
 
 impl StdBackend {
     pub fn new() -> StdBackend {
         let (notify_tx, notify_rx) = mpsc::channel();
-        let watcher = watcher(notify_tx, Duration::from_millis(50)).unwrap();
+        let watcher = new_debouncer(Duration::from_millis(50), None, notify_tx).unwrap();
 
         let (tx, rx) = crossbeam_channel::unbounded();
 
         thread::spawn(move || {
-            for event in notify_rx {
-                match event {
-                    DebouncedEvent::Create(path) => {
-                        tx.send(VfsEvent::Create(path))?;
+            for notification in notify_rx {
+                match notification {
+                    Ok(events) => {
+                        for event in events {
+                            if event.need_rescan() {
+                                // In this case, we need to refresh our file.
+                                // So, we can ignore the actual event (anyhow, should always be an "Other" event after auditing the code)!
+                                let path = event.paths[0].clone();
+
+                                match fs_err::metadata(&path) {
+                                    // The file still exists, we just say that it changed.
+                                    Ok(_) => tx.send(VfsEvent::Write(path))?,
+
+                                    // It is inaccessible, it doesn't exist to us.
+                                    Err(_) => tx.send(VfsEvent::Remove(path))?,
+                                };
+
+                                return Ok(());
+                            }
+
+                            match event.kind {
+                                // Vfs does not care for how the file was made.
+                                EventKind::Create(_) => {
+                                    tx.send(VfsEvent::Create(event.paths[0].clone()))?
+                                }
+
+                                // Vfs doesn't care for how the file was removed.
+                                EventKind::Remove(_) => {
+                                    tx.send(VfsEvent::Remove(event.paths[0].clone()))?
+                                }
+
+                                EventKind::Modify(modify_kind) => match modify_kind {
+                                    // We don't care for how the data was changed, it was some write.
+                                    ModifyKind::Data(_) => {
+                                        tx.send(VfsEvent::Write(event.paths[0].clone()))?
+                                    }
+
+                                    // There's several ways a rename event can be represented.
+                                    ModifyKind::Name(rename_mode) => match rename_mode {
+                                        // We get the original and the new name at the same time.
+                                        RenameMode::Both => {
+                                            tx.send(VfsEvent::Remove(event.paths[0].clone()))?;
+                                            tx.send(VfsEvent::Create(event.paths[1].clone()))?;
+                                        }
+
+                                        // We just start with the original name...
+                                        RenameMode::From => {
+                                            tx.send(VfsEvent::Remove(event.paths[0].clone()))?
+                                        }
+
+                                        // And end with the new name.
+                                        RenameMode::To => {
+                                            tx.send(VfsEvent::Create(event.paths[0].clone()))?
+                                        }
+
+                                        // Catch-all for really any modification and so we play it safe.
+                                        RenameMode::Any => {
+                                            tx.send(VfsEvent::Write(event.paths[0].clone()))?
+                                        }
+
+                                        // After auditing the code, this event will never be fired.
+                                        RenameMode::Other => panic!(
+                                            r#"EventKind(ModifyKind::Name(RenameMode::Other))) was impossibly issued!
+                                            Log an issue at memofs (rbx-rojo) with the following information:
+                                            {:#?}"#,
+                                            event
+                                        ),
+                                    },
+
+                                    // Vfs does not care for any metadata changes.
+                                    // We are screwed if permissions change, effectively making the
+                                    ModifyKind::Metadata(_) => {}
+
+                                    // After auditing the code, the only way for Modify::Any to be triggered is if the backend is...
+                                    // kqueue, then the number of links to the given path changed. We don't really care on that case.
+                                    // windows, just vaguely that a file was changed.
+                                    ModifyKind::Any => {
+                                        if cfg!(windows) {
+                                            tx.send(VfsEvent::Write(event.paths[0].clone()))?;
+                                        }
+                                    }
+
+                                    // After auditing notify, this will never be fired.
+                                    ModifyKind::Other => panic!(
+                                        r#"EventKind::Modify(ModifyKind::Other()) was impossibly issued!
+                                        Log an issue at memofs (rbx-rojo) with the following information:
+                                        {:#?}"#,
+                                        event
+                                    ),
+                                },
+
+                                // We don't need to send an event if a file is read, opened, or closed
+                                EventKind::Access(_) => {}
+
+                                // After auditing notify, this can only be fired by fsevent, but that's only imprecise mode.
+                                // We'll never be in imprecise mode since it's useless (all events default to ::Any()).
+                                EventKind::Any => panic!(
+                                    r#"EventKind::Any() was impossibly issued!
+                                    Log an issue with the following information:
+                                    {:#?}"#,
+                                    event
+                                ),
+
+                                // After auditing notify, the only way to get here is if there was a unknown event emitted by kqueue.
+                                // This is despite fsevent and inotify being able to emit this event
+                                // (this is caught earlier since they both require rescanning).
+                                // Might as well panic here and let the future us figure it out, since it seems extremely niche.
+                                EventKind::Other => panic!(
+                                    r#"EventKind::Other() was impossibly issued!
+                                    Log an issue with the following information:
+                                    {:#?}"#,
+                                    event
+                                ),
+                            }
+                        }
                     }
-                    DebouncedEvent::Write(path) => {
-                        tx.send(VfsEvent::Write(path))?;
+                    Err(errors) => {
+                        for error in errors {
+                            match error.kind {
+                                notify::ErrorKind::Generic(generic) => panic!("Internal notify error (memofs): {}", generic),
+                                notify::ErrorKind::InvalidConfig(config) => panic!("Internal memofs error: Invalid configuration for the watcher. How did we get here?\n{:?}", config),
+                                notify::ErrorKind::MaxFilesWatch => panic!("Internal notify error (memofs): The maximum amount of files that can be kept track of has been reached!"),
+                                
+                                notify::ErrorKind::Io(err) => todo!("What happens when IO errors like this: {}", err),
+                                notify::ErrorKind::PathNotFound => todo!("What happens when a path doesn't exist?"),
+                                notify::ErrorKind::WatchNotFound => todo!("What happens when a watch is not found when trying to remove it?"),
+                            }
+                        }
                     }
-                    DebouncedEvent::Remove(path) => {
-                        tx.send(VfsEvent::Remove(path))?;
-                    }
-                    DebouncedEvent::Rename(from, to) => {
-                        tx.send(VfsEvent::Remove(from))?;
-                        tx.send(VfsEvent::Create(to))?;
-                    }
-                    _ => {}
                 }
             }
 
@@ -98,12 +214,14 @@ impl VfsBackend for StdBackend {
 
     fn watch(&mut self, path: &Path) -> io::Result<()> {
         self.watcher
+            .watcher()
             .watch(path, RecursiveMode::NonRecursive)
             .map_err(|inner| io::Error::new(io::ErrorKind::Other, inner))
     }
 
     fn unwatch(&mut self, path: &Path) -> io::Result<()> {
         self.watcher
+            .watcher()
             .unwatch(path)
             .map_err(|inner| io::Error::new(io::ErrorKind::Other, inner))
     }

--- a/crates/memofs/src/std_backend.rs
+++ b/crates/memofs/src/std_backend.rs
@@ -166,7 +166,9 @@ impl StdBackend {
                                 notify::ErrorKind::InvalidConfig(config) => panic!("Internal memofs error: Invalid configuration for the watcher. How did we get here?\n{:?}", config),
                                 notify::ErrorKind::MaxFilesWatch => panic!("Internal notify error (memofs): The maximum amount of files that can be kept track of has been reached!"),
 
-                                notify::ErrorKind::Io(err) => todo!("What happens when IO errors like this: {}", err),
+                                notify::ErrorKind::Io(err) => {
+                                    println!("memofs warning: io error from notify\n {}", err)
+                                },
                                 notify::ErrorKind::PathNotFound => {
                                     let path = error.paths[0].clone();
                                     println!("memofs warning: path {} was not found!", path.display());


### PR DESCRIPTION
There are a few open questions left to answer wrt to error handling from the watch itself. I also wonder, should an exact version be placed for notify now? It leaks quite a lot of information from each of its native implementation (not without reason); meaning that the current implementation can, just, break.

`memofs` API still stays the same. Only the internal `std_backend` has change implementation. 

closes #732