### PR TITLE
Add plugin build flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Improve tooltip behavior ([#723])
 * Better settings controls ([#725])
 * Rework patch visualizer with many fixes and improvements ([#726])
+* Add `plugin` flag to the `build` command that outputs to the local plugins folder ([#735])
 
 [#668]: https://github.com/rojo-rbx/rojo/pull/668
 [#674]: https://github.com/rojo-rbx/rojo/pull/674
@@ -32,6 +33,7 @@
 [#723]: https://github.com/rojo-rbx/rojo/pull/723
 [#725]: https://github.com/rojo-rbx/rojo/pull/725
 [#726]: https://github.com/rojo-rbx/rojo/pull/726
+[#735]: https://github.com/rojo-rbx/rojo/pull/735
 
 ## [7.3.0] - April 22, 2023
 * Added `$attributes` to project format. ([#574])

--- a/benches/build.rs
+++ b/benches/build.rs
@@ -31,11 +31,12 @@ fn bench_build_place(c: &mut Criterion, name: &str, path: &str) {
 fn place_setup<P: AsRef<Path>>(input_path: P) -> (TempDir, BuildCommand) {
     let dir = tempdir().unwrap();
     let input = input_path.as_ref().to_path_buf();
-    let output = dir.path().join("output.rbxlx");
+    let output = Some(dir.path().join("output.rbxlx"));
 
     let options = BuildCommand {
         project: input,
         watch: false,
+        plugin: None,
         output,
     };
 

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -4,10 +4,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::Context;
-use clap::Parser;
+use anyhow::{bail, Context};
+use clap::{CommandFactory, Parser};
 use fs_err::File;
 use memofs::Vfs;
+use roblox_install::RobloxStudio;
 use tokio::runtime::Runtime;
 
 use crate::serve_session::ServeSession;
@@ -28,7 +29,13 @@ pub struct BuildCommand {
     ///
     /// Should end in .rbxm, .rbxl, .rbxmx, or .rbxlx.
     #[clap(long, short)]
-    pub output: PathBuf,
+    pub output: Option<PathBuf>,
+
+    /// Alternative to the output flag that outputs the result in the local plugins folder.
+    ///
+    /// Should end in .rbxm, .rbxl, .rbxmx, or .rbxlx.
+    #[clap(long, short)]
+    pub plugin: Option<PathBuf>,
 
     /// Whether to automatically rebuild when any input files change.
     #[clap(long)]
@@ -37,18 +44,47 @@ pub struct BuildCommand {
 
 impl BuildCommand {
     pub fn run(self) -> anyhow::Result<()> {
+        let output_path = match (self.output, self.plugin) {
+            (Some(_), Some(_)) => {
+                BuildCommand::command()
+                    .error(
+                        clap::ErrorKind::ArgumentConflict,
+                        "the argument '--output <OUTPUT>' cannot be used with '--plugin <PLUGIN>'",
+                    )
+                    .exit();
+            }
+            (None, None) => {
+                BuildCommand::command()
+                    .error(
+                        clap::ErrorKind::MissingRequiredArgument,
+                        "one of the following arguments must be provided: \n    --output <OUTPUT>\n    --plugin <PLUGIN>",
+                    )
+                    .exit();
+            }
+            (Some(output), None) => output,
+            (None, Some(plugin)) => {
+                if plugin.is_absolute() {
+                    bail!("plugin flag path cannot be absolute.")
+                }
+
+                let studio = RobloxStudio::locate()?;
+
+                studio.plugins_path().join(plugin)
+            }
+        };
+
         let project_path = resolve_path(&self.project);
 
-        let output_kind = detect_output_kind(&self.output).context(UNKNOWN_OUTPUT_KIND_ERR)?;
+        let output_kind = detect_output_kind(&output_path).context(UNKNOWN_OUTPUT_KIND_ERR)?;
 
         log::trace!("Constructing in-memory filesystem");
         let vfs = Vfs::new_default();
         vfs.set_watch_enabled(self.watch);
 
-        let session = ServeSession::new(vfs, &project_path)?;
+        let session = ServeSession::new(vfs, project_path)?;
         let mut cursor = session.message_queue().cursor();
 
-        write_model(&session, &self.output, output_kind)?;
+        write_model(&session, &output_path, output_kind)?;
 
         if self.watch {
             let rt = Runtime::new().unwrap();
@@ -58,7 +94,7 @@ impl BuildCommand {
                 let (new_cursor, _patch_set) = rt.block_on(receiver).unwrap();
                 cursor = new_cursor;
 
-                write_model(&session, &self.output, output_kind)?;
+                write_model(&session, &output_path, output_kind)?;
             }
         }
 

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -35,7 +35,7 @@ pub struct BuildCommand {
 
     /// Alternative to the output flag that outputs the result in the local plugins folder.
     ///
-    /// Should end in .rbxm, .rbxl.
+    /// Should end in .rbxm or .rbxl.
     #[clap(long, short)]
     pub plugin: Option<PathBuf>,
 


### PR DESCRIPTION
Resolves #715. 

It will not output to the correct place if the user configures the location of their plugin folder. That functionality would have to be added to `roblox_install`. I haven't looked into whether it's possible or not yet.

Here is what the output looks like:
![image](https://github.com/rojo-rbx/rojo/assets/48431591/7fd051c4-4e1b-487f-af8d-bc4b6c9b82c7)
![image](https://github.com/rojo-rbx/rojo/assets/48431591/cf829cd2-7a3b-4040-bac7-3d4e033868f3)
![image](https://github.com/rojo-rbx/rojo/assets/48431591/4dad7446-2679-4560-91c4-d25a8b2f340b)


I wasn't able to get the error cases to say "rojo build" in the usage section.