### PR TITLE
Improve Rojo sync reliability

### DIFF
--- a/plugin/src/ApiContext.lua
+++ b/plugin/src/ApiContext.lua
@@ -11,13 +11,6 @@ local validateApiInfo = Types.ifEnabled(Types.ApiInfoResponse)
 local validateApiRead = Types.ifEnabled(Types.ApiReadResponse)
 local validateApiSubscribe = Types.ifEnabled(Types.ApiSubscribeResponse)
 
---[[
-	Returns a promise that will never resolve nor reject.
-]]
-local function hangingPromise()
-	return Promise.new(function() end)
-end
-
 local function rejectFailedRequests(response)
 	if response.code >= 400 then
 		local message = string.format("HTTP %s:\n%s", tostring(response.code), response.body)
@@ -212,12 +205,8 @@ function ApiContext:retrieveMessages()
 	local function sendRequest()
 		local request = Http.get(url)
 			:catch(function(err)
-				if err.type == Http.Error.Kind.Timeout then
-					if self.__connected then
-						return sendRequest()
-					else
-						return hangingPromise()
-					end
+				if err.type == Http.Error.Kind.Timeout and self.__connected then
+					return sendRequest()
 				end
 
 				return Promise.reject(err)


### PR DESCRIPTION
Closes #734.

Rojo's main sync loop was a recursive promise method, which may have been obscuring issues. Additionally, ApiContext would choose to silently hang forever where we wanted to silence an error after disconnect, which may have been happening erroneously and causing silent hangs.

I have rewritten these so that ServeSession is non recursive and also knows how to handle ApiContext errors correctly in any state so that the hanging promise solution is no longer needed. Also, it may have not been needed ever since I added promise cancelling to ApiContext, but either way it's certainly not needed now.