### PR TITLE
Remove references to LPG's patreon

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-patreon: lpghatguy

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
     <a href="https://github.com/rojo-rbx/rojo/actions"><img src="https://github.com/rojo-rbx/rojo/workflows/CI/badge.svg" alt="Actions status" /></a>
     <a href="https://crates.io/crates/rojo"><img src="https://img.shields.io/crates/v/rojo.svg?label=latest%20release" alt="Latest server version" /></a>
     <a href="https://rojo.space/docs"><img src="https://img.shields.io/badge/docs-website-brightgreen.svg" alt="Rojo Documentation" /></a>
-    <a href="https://www.patreon.com/lpghatguy"><img src="https://img.shields.io/badge/sponsor-patreon-red" alt="Patreon" /></a>
 </div>
 
 <hr />


### PR DESCRIPTION
Given that LPG is not maintaining Rojo or its related projects, it does not make sense for us to suggest his patreon. This PR removes them.