### PR TITLE
Make CI only run in PRs that change relevant files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     - master
 
   pull_request:
-    paths: ["*.rs", "*.toml", "*.json", "*.lua", "*.luau"]
+    paths: ["*.rs", "*.toml", "*.json", "*.lua", "*.luau", "*.rbxm", "*.rbxl", "*.rbxmx", "*.rbxlx", "*.txt", "*.yml", "*.csv"]
     branches:
     - master
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     - master
 
   pull_request:
+    paths: ["*.rs", "*.toml", "*.json", "*.lua", "*.luau"]
     branches:
     - master
 


### PR DESCRIPTION
It only makes sense for us to run CI on pull requests that modify files that might change our builds. We should probably still run it on every commit though, just to be sure.

