### PR TITLE
Fix PatchTree performance issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Added better support for `Font` properties ([#731])
 * Add new plugin template to the `init` command ([#738])
 * Added rich Source diffs in patch visualizer ([#748])
+* Fix PatchTree performance issues ([#755])
 
 [#745]: https://github.com/rojo-rbx/rojo/pull/745
 [#668]: https://github.com/rojo-rbx/rojo/pull/668
@@ -44,6 +45,7 @@
 [#731]: https://github.com/rojo-rbx/rojo/pull/731
 [#738]: https://github.com/rojo-rbx/rojo/pull/738
 [#748]: https://github.com/rojo-rbx/rojo/pull/748
+[#755]: https://github.com/rojo-rbx/rojo/pull/755
 
 ## [7.3.0] - April 22, 2023
 * Added `$attributes` to project format. ([#574])

--- a/plugin/src/PatchTree.lua
+++ b/plugin/src/PatchTree.lua
@@ -113,6 +113,10 @@ function Tree:getNode(id, searchNode)
     return nil
 end
 
+function Tree:doesNodeExist(id)
+	return self.idToNode[id] ~= nil
+end
+
 -- Adds a node to the tree as a child of the node with id == parent
 -- If parent is nil, it defaults to root
 -- props must contain id, and cannot contain children or parentId
@@ -121,6 +125,15 @@ function Tree:addNode(parent, props)
 	assert(props.id, "props must contain id")
 
     parent = parent or "ROOT"
+
+	if self:doesNodeExist(props.id) then
+		-- Update existing node
+		local node = self:getNode(props.id)
+        for k, v in props do
+            node[k] = v
+        end
+        return node
+	end
 
     local node = table.clone(props)
     node.children = {}

--- a/plugin/src/PatchTree.lua
+++ b/plugin/src/PatchTree.lua
@@ -64,18 +64,18 @@ local Tree = {}
 Tree.__index = Tree
 
 function Tree.new()
-    local tree = {
-        idToNode = {},
+	local tree = {
+		idToNode = {},
 		ROOT = {
 			className = "DataModel",
 			name = "ROOT",
 			children = {},
 		},
-    }
-    -- Add ROOT to idToNode or it won't be found by getNode since that searches *within* ROOT
+	}
+	-- Add ROOT to idToNode or it won't be found by getNode since that searches *within* ROOT
 	tree.idToNode["ROOT"] = tree.ROOT
 
-    return setmetatable(tree, Tree)
+	return setmetatable(tree, Tree)
 end
 
 -- Iterates over all sub-nodes, depth first
@@ -94,23 +94,23 @@ end
 -- Finds a node by id, depth first
 -- searchNode is the node to start the search within, defaults to root
 function Tree:getNode(id, searchNode)
-    if self.idToNode[id] then
-        return self.idToNode[id]
-    end
+	if self.idToNode[id] then
+		return self.idToNode[id]
+	end
 
 	local searchChildren = (searchNode or self.ROOT).children
-    for nodeId, node in searchChildren do
-        if nodeId == id then
-            self.idToNode[id] = node
-            return node
-        end
-        local descendant = self:getNode(id, node)
-        if descendant then
-            return descendant
-        end
-    end
+	for nodeId, node in searchChildren do
+		if nodeId == id then
+			self.idToNode[id] = node
+			return node
+		end
+		local descendant = self:getNode(id, node)
+		if descendant then
+			return descendant
+		end
+	end
 
-    return nil
+	return nil
 end
 
 function Tree:doesNodeExist(id)
@@ -124,53 +124,53 @@ end
 function Tree:addNode(parent, props)
 	assert(props.id, "props must contain id")
 
-    parent = parent or "ROOT"
+	parent = parent or "ROOT"
 
 	if self:doesNodeExist(props.id) then
 		-- Update existing node
 		local node = self:getNode(props.id)
-        for k, v in props do
-            node[k] = v
-        end
-        return node
+		for k, v in props do
+			node[k] = v
+		end
+		return node
 	end
 
-    local node = table.clone(props)
-    node.children = {}
+	local node = table.clone(props)
+	node.children = {}
 	node.parentId = parent
 
-    local parentNode = self:getNode(parent)
-    if not parentNode then
-        Log.warn("Failed to create node since parent doesnt exist: {}, {}", parent, props)
-        return
-    end
+	local parentNode = self:getNode(parent)
+	if not parentNode then
+		Log.warn("Failed to create node since parent doesnt exist: {}, {}", parent, props)
+		return
+	end
 
-    parentNode.children[node.id] = node
-    self.idToNode[node.id] = node
+	parentNode.children[node.id] = node
+	self.idToNode[node.id] = node
 
-    return node
+	return node
 end
 
 -- Given a list of ancestor ids in descending order, builds the nodes for them
 -- using the patch and instanceMap info
 function Tree:buildAncestryNodes(previousId: string?, ancestryIds: { string }, patch, instanceMap)
-    -- Build nodes for ancestry by going up the tree
-    previousId = previousId or "ROOT"
+	-- Build nodes for ancestry by going up the tree
+	previousId = previousId or "ROOT"
 
-    for _, ancestorId in ancestryIds do
-        local value = instanceMap.fromIds[ancestorId] or patch.added[ancestorId]
-        if not value then
-            Log.warn("Failed to find ancestor object for " .. ancestorId)
-            continue
-        end
-        self:addNode(previousId, {
-            id = ancestorId,
-            className = value.ClassName,
-            name = value.Name,
-            instance = if typeof(value) == "Instance" then value else nil,
-        })
-        previousId = ancestorId
-    end
+	for _, ancestorId in ancestryIds do
+		local value = instanceMap.fromIds[ancestorId] or patch.added[ancestorId]
+		if not value then
+			Log.warn("Failed to find ancestor object for " .. ancestorId)
+			continue
+		end
+		self:addNode(previousId, {
+			id = ancestorId,
+			className = value.ClassName,
+			name = value.Name,
+			instance = if typeof(value) == "Instance" then value else nil,
+		})
+		previousId = ancestorId
+	end
 end
 
 local PatchTree = {}


### PR DESCRIPTION
When building the tree, I've implemented a few improvements:

- We no longer traverse the full ancestry for every leaf node- we exit early when we find a node that already exists
- We no longer search the entire tree to see if a node id exists before creating one with that id, we just check if is in the map