### PR TITLE
Don't override initial state for source diff view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Add new plugin template to the `init` command ([#738])
 * Added rich Source diffs in patch visualizer ([#748])
 * Fix PatchTree performance issues ([#755])
+* Don't override the initial enabled state for source diffing ([#760])
 
 [#745]: https://github.com/rojo-rbx/rojo/pull/745
 [#668]: https://github.com/rojo-rbx/rojo/pull/668
@@ -46,6 +47,7 @@
 [#738]: https://github.com/rojo-rbx/rojo/pull/738
 [#748]: https://github.com/rojo-rbx/rojo/pull/748
 [#755]: https://github.com/rojo-rbx/rojo/pull/755
+[#760]: https://github.com/rojo-rbx/rojo/pull/760
 
 ## [7.3.0] - April 22, 2023
 * Added `$attributes` to project format. ([#574])

--- a/plugin/src/App/StatusPages/Confirming.lua
+++ b/plugin/src/App/StatusPages/Confirming.lua
@@ -184,7 +184,7 @@ function ConfirmingPage:render()
 				active = true,
 
 				initDockState = Enum.InitialDockState.Float,
-				overridePreviousState = true,
+				overridePreviousState = false,
 				floatingSize = Vector2.new(500, 350),
 				minimumSize = Vector2.new(400, 250),
 

--- a/plugin/src/App/StatusPages/Connected.lua
+++ b/plugin/src/App/StatusPages/Connected.lua
@@ -400,7 +400,7 @@ function ConnectedPage:render()
 				active = self.state.showingSourceDiff,
 
 				initDockState = Enum.InitialDockState.Float,
-				overridePreviousState = true,
+				overridePreviousState = false,
 				floatingSize = Vector2.new(500, 350),
 				minimumSize = Vector2.new(400, 250),
 


### PR DESCRIPTION
Due to an implementation detail with Roact (it calls `Destroy` on unmount), we have to recreate the source diff viewer plugin gui everytime a patch is visualized.

This ends up causing trouble because Studio doesn't like it if you create a plugin with the same ID. This was causing the plugin to die when trying to visualize a source diff. 

I have no idea why this is the case, but this fixes that from what my tests have showed. 🤷🏼 