### PR TITLE
Fix theme

### DIFF
--- a/plugin/src/App/Theme.lua
+++ b/plugin/src/App/Theme.lua
@@ -64,7 +64,7 @@ local lightTheme = strict("LightTheme", {
 		},
 	},
 	Dropdown = {
-		TextColor = Color3.fromHex("00000"),
+		TextColor = Color3.fromHex("000000"),
 		BorderColor = Color3.fromHex("AFAFAF"),
 		BackgroundColor = Color3.fromHex("EEEEEE"),
 		Open = {
@@ -94,8 +94,8 @@ local lightTheme = strict("LightTheme", {
 		Warning = Color3.fromHex("FF8E3C"),
 	},
 	ConnectionDetails = {
-		ProjectNameColor = Color3.fromHex("00000"),
-		AddressColor = Color3.fromHex("00000"),
+		ProjectNameColor = Color3.fromHex("000000"),
+		AddressColor = Color3.fromHex("000000"),
 		DisconnectColor = BRAND_COLOR,
 	},
 	Settings = {
@@ -114,7 +114,7 @@ local lightTheme = strict("LightTheme", {
 		VersionColor = Color3.fromHex("727272"),
 	},
 	Notification = {
-		InfoColor = Color3.fromHex("00000"),
+		InfoColor = Color3.fromHex("000000"),
 		CloseColor = BRAND_COLOR,
 	},
 	ErrorColor = Color3.fromHex("000000"),


### PR DESCRIPTION
Apparently #761 broke Rojo, because we had a 5 char shortcut 00000 which Color3 doesn't know how to handle as it expects 6 char 000000. Super simple fix.