### PR TITLE
Mitigate problems with uploading to data.roblox.com

### DIFF
--- a/src/cli/upload.rs
+++ b/src/cli/upload.rs
@@ -138,7 +138,7 @@ fn do_upload(buffer: Vec<u8>, asset_id: u64, cookie: &str) -> anyhow::Result<()>
     // This endpoint is used only for fetching a CSRF token, as the upload endpoint 
     // requires one. Because this endpoint itself requires a CSRF token for all
     // requests, it will provide one in its response headers, with a HTTP 403 response.
-    let csrf_response = client.post("https://economy.roblox.com/v1/purchases/products/1")
+    let csrf_response = client.post("https://auth.roblox.com")
         .header(COOKIE, &cookie_string)
         .header(CONTENT_LENGTH, 0)
         .send()?;

--- a/src/cli/upload.rs
+++ b/src/cli/upload.rs
@@ -125,6 +125,12 @@ fn do_upload(buffer: Vec<u8>, asset_id: u64, cookie: &str) -> anyhow::Result<()>
         cookie
     );
 
+    let mut content_type = "application/octet-stream";
+
+    if buffer.starts_with(b"<roblox ") {
+        content_type = "application/xml";
+    }
+
     let client = reqwest::blocking::Client::new();
 
     log::debug!("Obtaining CSRF token...");
@@ -146,10 +152,10 @@ fn do_upload(buffer: Vec<u8>, asset_id: u64, cookie: &str) -> anyhow::Result<()>
     log::debug!("Uploading to Roblox...");
     
     let response = client
-        .post(&url)
+        .post(url)
         .header(COOKIE, &cookie_string)
         .header(USER_AGENT, "Roblox/WinInet")
-        .header(CONTENT_TYPE, "application/xml")
+        .header(CONTENT_TYPE, content_type)
         .header(ACCEPT, "application/json")
         .header("X-CSRF-TOKEN", csrf_token.unwrap())
         .body(buffer.clone())


### PR DESCRIPTION
See https://devforum.roblox.com/t/dataroblox-upload-endpoint-appears-to-no-longer-function/2510735

Recently, the error page for /Data/Upload.ashx has broken, throwing off Rojo's process for uploading to it, as it relies on it to obtain a CSRF token. In response, this changes it to always obtain a CSRF token from an alternate source.

Bonus improvement - proper content-type value.

<img width="1221" alt="OQD4jIsiXU" src="https://github.com/rojo-rbx/rojo/assets/41478239/559e8e7e-89d8-468a-912f-bf90a43282fc">
