### PR TITLE
Add ambiguous value support for MaterialColors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Added rich Source diffs in patch visualizer ([#748])
 * Fix PatchTree performance issues ([#755])
 * Don't override the initial enabled state for source diffing ([#760])
+* Added support for `Terrain.MaterialColors` ([#770])
 
 [#761]: https://github.com/rojo-rbx/rojo/pull/761
 [#745]: https://github.com/rojo-rbx/rojo/pull/745
@@ -50,6 +51,7 @@
 [#748]: https://github.com/rojo-rbx/rojo/pull/748
 [#755]: https://github.com/rojo-rbx/rojo/pull/755
 [#760]: https://github.com/rojo-rbx/rojo/pull/760
+[#770]: https://github.com/rojo-rbx/rojo/pull/770
 
 ## [7.3.0] - April 22, 2023
 * Added `$attributes` to project format. ([#574])

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -2,8 +2,8 @@ use std::borrow::Borrow;
 
 use anyhow::{bail, format_err};
 use rbx_dom_weak::types::{
-    Attributes, CFrame, Color3, Content, Enum, Font, Matrix3, Tags, Variant, VariantType, Vector2,
-    Vector3,
+    Attributes, CFrame, Color3, Content, Enum, Font, MaterialColors, Matrix3, Tags, Variant,
+    VariantType, Vector2, Vector3,
 };
 use rbx_reflection::{DataType, PropertyDescriptor};
 use serde::{Deserialize, Serialize};
@@ -50,6 +50,7 @@ pub enum AmbiguousValue {
     Array12([f64; 12]),
     Attributes(Attributes),
     Font(Font),
+    MaterialColors(MaterialColors),
 }
 
 impl AmbiguousValue {
@@ -142,6 +143,10 @@ impl AmbiguousValue {
 
                 (VariantType::Font, AmbiguousValue::Font(value)) => Ok(value.into()),
 
+                (VariantType::MaterialColors, AmbiguousValue::MaterialColors(value)) => {
+                    Ok(value.into())
+                }
+
                 (_, unresolved) => Err(format_err!(
                     "Wrong type of value for property {}.{}. Expected {:?}, got {}",
                     class_name,
@@ -180,6 +185,7 @@ impl AmbiguousValue {
             AmbiguousValue::Array12(_) => "an array of twelve numbers",
             AmbiguousValue::Attributes(_) => "an object containing attributes",
             AmbiguousValue::Font(_) => "an object describing a Font",
+            AmbiguousValue::MaterialColors(_) => "an object describing MaterialColors",
         }
     }
 }
@@ -349,6 +355,29 @@ mod test {
                 style: FontStyle::Normal,
                 cached_face_id: None,
             })
+        )
+    }
+
+    #[test]
+    fn material_colors() {
+        use rbx_dom_weak::types::{Color3uint8, TerrainMaterials};
+
+        let mut material_colors = MaterialColors::new();
+        material_colors.set_color(TerrainMaterials::Grass, Color3uint8::new(10, 20, 30));
+        material_colors.set_color(TerrainMaterials::Asphalt, Color3uint8::new(40, 50, 60));
+        material_colors.set_color(TerrainMaterials::LeafyGrass, Color3uint8::new(255, 155, 55));
+
+        assert_eq!(
+            resolve(
+                "Terrain",
+                "MaterialColors",
+                r#"{
+                    "Grass": [10, 20, 30],
+                    "Asphalt": [40, 50, 60],
+                    "LeafyGrass": [255, 155, 55]
+                }"#
+            ),
+            Variant::MaterialColors(material_colors)
         )
     }
 }


### PR DESCRIPTION
The last release of rbx_dom had support for `Terrain.MaterialColors`. This allows it to be specified directly instead of only via the fully-qualified syntax.