### PR TITLE
Allow `Terrain` to be included in projects without a classname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Added rich Source diffs in patch visualizer ([#748])
 * Fix PatchTree performance issues ([#755])
 * Don't override the initial enabled state for source diffing ([#760])
+* Allow `Terrain` to be specified without a classname ([#771])
 
 [#761]: https://github.com/rojo-rbx/rojo/pull/761
 [#745]: https://github.com/rojo-rbx/rojo/pull/745
@@ -50,6 +51,7 @@
 [#748]: https://github.com/rojo-rbx/rojo/pull/748
 [#755]: https://github.com/rojo-rbx/rojo/pull/755
 [#760]: https://github.com/rojo-rbx/rojo/pull/760
+[#771]: https://github.com/rojo-rbx/rojo/pull/771
 
 ## [7.3.0] - April 22, 2023
 * Added `$attributes` to project format. ([#574])

--- a/src/snapshot_middleware/project.rs
+++ b/src/snapshot_middleware/project.rs
@@ -301,6 +301,11 @@ fn infer_class_name(name: &str, parent_class: Option<&str>) -> Option<Cow<'stati
         if name == "StarterPlayerScripts" || name == "StarterCharacterScripts" {
             return Some(Cow::Owned(name.to_owned()));
         }
+    } else if parent_class == "Workspace" {
+        // Workspace has a special Terrain class inside it
+        if name == "Terrain" {
+            return Some(Cow::Owned(name.to_owned()));
+        }
     }
 
     None


### PR DESCRIPTION
Services, `StarterPlayerScripts`, and `StarterCharacterScripts` are currently special-cased to allow them to be specified in project files without a classname. This does the same to `Terrain` since it's a singleton in the same style as those.