### PR TITLE
Protect against syncing and building the wrong project types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Fix PatchTree performance issues ([#755])
 * Don't override the initial enabled state for source diffing ([#760])
 * Projects can no longer be built with the wrong file extension ([#772])
+* Projects can no longer be served if they don't have a DataModel root ([#722])
 
 [#761]: https://github.com/rojo-rbx/rojo/pull/761
 [#745]: https://github.com/rojo-rbx/rojo/pull/745

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Added rich Source diffs in patch visualizer ([#748])
 * Fix PatchTree performance issues ([#755])
 * Don't override the initial enabled state for source diffing ([#760])
+* Projects can no longer be built with the wrong file extension ([#772])
 
 [#761]: https://github.com/rojo-rbx/rojo/pull/761
 [#745]: https://github.com/rojo-rbx/rojo/pull/745
@@ -50,6 +51,7 @@
 [#748]: https://github.com/rojo-rbx/rojo/pull/748
 [#755]: https://github.com/rojo-rbx/rojo/pull/755
 [#760]: https://github.com/rojo-rbx/rojo/pull/760
+[#772]: https://github.com/rojo-rbx/rojo/pull/772
 
 ## [7.3.0] - April 22, 2023
 * Added `$attributes` to project format. ([#574])

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -20,6 +20,11 @@ const UNKNOWN_OUTPUT_KIND_ERR: &str = "Could not detect what kind of file to bui
 const UNKNOWN_PLUGIN_KIND_ERR: &str = "Could not detect what kind of file to build. \
                                        Expected plugin file to end in .rbxm or .rbxmx.";
 
+const PLACE_AS_MODEL_ERR: &str = "Cannot build a place project file as a model file. \
+                                       Expected output file to end in .rbxl or .rbxlx.";
+const MODEL_AS_PLACE_ERR: &str = "Cannot build a model project file as a place file. \
+                                       Expected output file file to end in .rbxm or .rbxmx.";
+
 /// Generates a model or place file from the Rojo project.
 #[derive(Debug, Parser)]
 pub struct BuildCommand {
@@ -167,6 +172,17 @@ fn write_model(
 
     let tree = session.tree();
     let root_id = tree.get_root_id();
+
+    let root_class = tree.get_instance(root_id).unwrap().class_name();
+
+    // Bail out of building a model if the internal project is wrong.
+    if matches!(output_kind, OutputKind::Rbxm | OutputKind::Rbxmx) && root_class == "DataModel" {
+        bail!(PLACE_AS_MODEL_ERR)
+    } else if matches!(output_kind, OutputKind::Rbxl | OutputKind::Rbxlx)
+        && root_class != "DataModel"
+    {
+        bail!(MODEL_AS_PLACE_ERR)
+    }
 
     log::trace!("Opening output file for write");
     let mut file = BufWriter::new(File::create(output)?);

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -16,6 +16,9 @@ use super::{resolve_path, GlobalOptions};
 const DEFAULT_BIND_ADDRESS: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
 const DEFAULT_PORT: u16 = 34872;
 
+const SYNCING_MODEL_ERR: &str = "Cannot sync a model project file. \
+    Projects must have a `DataModel` at their root to be synced.";
+
 /// Expose a Rojo project to the Rojo Studio plugin.
 #[derive(Debug, Parser)]
 pub struct ServeCommand {
@@ -40,6 +43,17 @@ impl ServeCommand {
         let vfs = Vfs::new_default();
 
         let session = Arc::new(ServeSession::new(vfs, project_path)?);
+
+        // `ServeSession.tree()` is locking, so we have to let it fall out
+        // of scope when we're done.
+        {
+            let tree = session.tree();
+            // This cannot fail because a root cant' ever not exist.
+            let root = tree.get_instance(tree.get_root_id()).unwrap();
+            if root.class_name() != "DataModel" {
+                anyhow::bail!(SYNCING_MODEL_ERR)
+            }
+        }
 
         let ip = self
             .address


### PR DESCRIPTION
Closes #736.

Prevents projects with a data model as a root from being built as a model file and vice versa. Also prevents syncing model files altogether.

This should mitigate a few of the more common problems with building Rojo projects. I'm not sure whether I should revert #691 or not. The check it adds is made moot with this PR, but it could be a good failsafe. Open to suggestion.