### PR TITLE
Use GUIDs for ephemeral PluginWidgets

### DIFF
--- a/plugin/src/App/Components/Studio/StudioPluginGui.lua
+++ b/plugin/src/App/Components/Studio/StudioPluginGui.lua
@@ -1,3 +1,5 @@
+local HttpService = game:GetService("HttpService")
+
 local Rojo = script:FindFirstAncestor("Rojo")
 local Plugin = Rojo.Plugin
 local Packages = Rojo.Packages
@@ -36,7 +38,7 @@ function StudioPluginGui:init()
 		minimumSize.Y
 	)
 
-	local pluginGui = self.props.plugin:CreateDockWidgetPluginGui(self.props.id, dockWidgetPluginGuiInfo)
+	local pluginGui = self.props.plugin:CreateDockWidgetPluginGui(HttpService:GenerateGUID(false), dockWidgetPluginGuiInfo)
 
 	pluginGui.Name = self.props.id
 	pluginGui.Title = self.props.title

--- a/plugin/src/App/Components/Studio/StudioPluginGui.lua
+++ b/plugin/src/App/Components/Studio/StudioPluginGui.lua
@@ -38,7 +38,7 @@ function StudioPluginGui:init()
 		minimumSize.Y
 	)
 
-	local pluginGui = self.props.plugin:CreateDockWidgetPluginGui(HttpService:GenerateGUID(false), dockWidgetPluginGuiInfo)
+	local pluginGui = self.props.plugin:CreateDockWidgetPluginGui(if self.props.isEphemeral then HttpService:GenerateGUID(false) else self.props.id, dockWidgetPluginGuiInfo)
 
 	pluginGui.Name = self.props.id
 	pluginGui.Title = self.props.title

--- a/plugin/src/App/StatusPages/Confirming.lua
+++ b/plugin/src/App/StatusPages/Confirming.lua
@@ -140,6 +140,7 @@ function ConfirmingPage:render()
 				id = "Rojo_ConfirmingSourceDiff",
 				title = "Source diff",
 				active = self.state.showingSourceDiff,
+				isEphemeral = true,
 
 				initDockState = Enum.InitialDockState.Float,
 				overridePreviousState = true,
@@ -182,6 +183,7 @@ function ConfirmingPage:render()
 					self.props.confirmData.serverInfo.projectName or "UNKNOWN"
 				),
 				active = true,
+				isEphemeral = true,
 
 				initDockState = Enum.InitialDockState.Float,
 				overridePreviousState = false,

--- a/plugin/src/App/StatusPages/Connected.lua
+++ b/plugin/src/App/StatusPages/Connected.lua
@@ -398,6 +398,7 @@ function ConnectedPage:render()
 				id = "Rojo_ConnectedSourceDiff",
 				title = "Source diff",
 				active = self.state.showingSourceDiff,
+				isEphemeral = true,
 
 				initDockState = Enum.InitialDockState.Float,
 				overridePreviousState = false,

--- a/plugin/src/App/init.lua
+++ b/plugin/src/App/init.lua
@@ -579,6 +579,7 @@ function App:render()
 					id = pluginName,
 					title = pluginName,
 					active = self.state.guiEnabled,
+					isEphemeral = false,
 
 					initDockState = Enum.InitialDockState.Right,
 					overridePreviousState = false,


### PR DESCRIPTION
Because Roact will destroy and recreate a plugin widget if it unmounts and remounts, Studio will complain about making a new widget with the same ID as the old one.

The simplest solution is to just use GUIDs so we never have to worry about this again. The ID is used internally for storing the widget's dock state and other internal details, so we don't want *all* our widgets to use GUIDs, only the ephemeral popup ones.