### PR TITLE
Create .git-blame-ignore-revs & Add Stylua pr

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# stylua formatting
+0f8e1625d572a5fe0f7b5c08653ff92cc837d346


### PR DESCRIPTION
adds stylua pr to ignore so it doesn't show on git blame history