### PR TITLE
Don't include package author in CLI help

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -25,7 +25,7 @@ pub use self::upload::UploadCommand;
 
 /// Command line options that Rojo accepts, defined using the clap crate.
 #[derive(Debug, Parser)]
-#[clap(name = "Rojo", version, about, author)]
+#[clap(name = "Rojo", version, about)]
 pub struct Options {
     #[clap(flatten)]
     pub global: GlobalOptions,


### PR DESCRIPTION
LPG is at the moment listed by name and email in the `help` for Rojo. We should probably remove that before cutting a new release.