### PR TITLE
Properly handle build metadata in semver parsing in plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased Changes
 
+* Fixed bug with parsing version for plugin validation ([#797])
+
+[#797]: https://github.com/rojo-rbx/rojo/pull/797
+
 ## [7.4.0-rc1] - October 3, 2023
 ### Additions
 #### Project format

--- a/plugin/src/Config.lua
+++ b/plugin/src/Config.lua
@@ -3,7 +3,7 @@ local strict = require(script.Parent.strict)
 local isDevBuild = script.Parent.Parent:FindFirstChild("ROJO_DEV_BUILD") ~= nil
 
 local Version = script.Parent.Parent.Version
-local major, minor, patch, metadata = Version.Value:match("^(%d+)%.(%d+)%.(%d+)(.+)$")
+local major, minor, patch, metadata = Version.Value:match("^(%d+)%.(%d+)%.(%d+)(.*)$")
 
 local realVersion = { major, minor, patch, metadata }
 for i = 1, 3 do

--- a/plugin/src/Config.lua
+++ b/plugin/src/Config.lua
@@ -3,8 +3,9 @@ local strict = require(script.Parent.strict)
 local isDevBuild = script.Parent.Parent:FindFirstChild("ROJO_DEV_BUILD") ~= nil
 
 local Version = script.Parent.Parent.Version
-local realVersion = Version.Value:split(".")
+local major, minor, patch, metadata = Version.Value:match("^(%d+)%.(%d+)%.(%d+)(.+)$")
 
+local realVersion = { major, minor, patch, metadata }
 for i = 1, 3 do
 	local num = tonumber(realVersion[i])
 	if num then


### PR DESCRIPTION
I made an oopsie and as a result versions of the plugin with metadata won't run. This fixes that.