### PR TITLE
Skip sourcemap generation when unaffected by changes in watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Rojo Changelog
 
 ## Unreleased Changes
+* Skip sourcemap generation when unaffected by changes in watch mode ([#800])
+
+[#800]: https://github.com/rojo-rbx/rojo/pull/800
 
 ## [7.4.0-rc2] - October 3, 2023
 * Fixed bug with parsing version for plugin validation ([#797])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Rojo Changelog
 
 ## Unreleased Changes
-* Skip sourcemap generation when unaffected by changes in watch mode ([#800])
+* Changed `sourcemap --watch` to only generate the sourcemap when it's necessary ([#800])
 
 [#800]: https://github.com/rojo-rbx/rojo/pull/800
 

--- a/src/cli/sourcemap.rs
+++ b/src/cli/sourcemap.rs
@@ -134,7 +134,7 @@ fn patch_set_affects_sourcemap(
             || set.added.iter().any(|referent| {
                 let instance = tree
                     .get_instance(*referent)
-                    .expect("instance did not exist");
+                    .expect("instance did not exist when updating sourcemap");
                 filter(&instance)
             })
             // 3. An existing instance has its class name, name,
@@ -146,7 +146,7 @@ fn patch_set_affects_sourcemap(
                 if changed {
                     let instance = tree
                         .get_instance(updated.id)
-                        .expect("instance did not exist");
+                        .expect("instance did not exist when updating sourcemap");
                     filter(&instance)
                 } else {
                     false

--- a/src/cli/sourcemap.rs
+++ b/src/cli/sourcemap.rs
@@ -14,7 +14,7 @@ use tokio::runtime::Runtime;
 
 use crate::{
     serve_session::ServeSession,
-    snapshot::{InstanceWithMeta, RojoTree},
+    snapshot::{AppliedPatchSet, InstanceWithMeta, RojoTree},
 };
 
 use super::resolve_path;
@@ -90,10 +90,12 @@ impl SourcemapCommand {
 
             loop {
                 let receiver = session.message_queue().subscribe(cursor);
-                let (new_cursor, _patch_set) = rt.block_on(receiver).unwrap();
+                let (new_cursor, patch_set) = rt.block_on(receiver).unwrap();
                 cursor = new_cursor;
 
-                write_sourcemap(&session, self.output.as_deref(), filter)?;
+                if patch_set_affects_sourcemap(&session, &patch_set, filter) {
+                    write_sourcemap(&session, self.output.as_deref(), filter)?;
+                }
             }
         }
 
@@ -114,6 +116,43 @@ fn filter_non_scripts(instance: &InstanceWithMeta) -> bool {
         instance.class_name(),
         "Script" | "LocalScript" | "ModuleScript"
     )
+}
+
+fn patch_set_affects_sourcemap(
+    session: &ServeSession,
+    patch_set: &[AppliedPatchSet],
+    filter: fn(&InstanceWithMeta) -> bool,
+) -> bool {
+    let tree = session.tree();
+
+    // A sourcemap has probably changed when:
+    patch_set.par_iter().any(|set| {
+        // 1. An instance was removed, in which case it will no
+        // longer exist in the tree and we cant check the filter
+        !set.removed.is_empty()
+            // 2. An instance passes the filter
+            || set.added.iter().any(|referent| {
+                let instance = tree
+                    .get_instance(*referent)
+                    .expect("instance did not exist");
+                filter(&instance)
+            })
+            // 3. An existing instance has its class name, name,
+            // or file paths changed, and passes the filter
+            || set.updated.iter().any(|updated| {
+                let changed = updated.changed_class_name.is_some()
+                    || updated.changed_name.is_some()
+                    || updated.changed_metadata.is_some();
+                if changed {
+                    let instance = tree
+                        .get_instance(updated.id)
+                        .expect("instance did not exist");
+                    filter(&instance)
+                } else {
+                    false
+                }
+            })
+    })
 }
 
 fn recurse_create_node<'a>(

--- a/src/cli/sourcemap.rs
+++ b/src/cli/sourcemap.rs
@@ -130,7 +130,7 @@ fn patch_set_affects_sourcemap(
         // 1. An instance was removed, in which case it will no
         // longer exist in the tree and we cant check the filter
         !set.removed.is_empty()
-            // 2. An instance passes the filter
+            // 2. A newly added instance passes the filter
             || set.added.iter().any(|referent| {
                 let instance = tree
                     .get_instance(*referent)


### PR DESCRIPTION
This PR implements a mechanism for avoiding unnecessary sourcemap re-creation in `rojo sourcemap --watch`.

Consumers of `rojo sourcemap --watch` will no longer see new sourcemaps when changes to script sources and other properties occur, or when instances that have been ignored are changed, neither of which would actually make for changes in the sourcemap JSON body itself. 
This massively benefits tools such as [luau-lsp](https://github.com/JohnnyMorganz/luau-lsp) and [rojo-viewer](https://github.com/filiptibell/rojo-viewer) that would previously need to parse sourcemaps every time the user makes changes to the contents of a script or other source file, which tend to be the most common operations.

The approach taken here is intentionally conservative - we could reasonably track refs and be even more granular, but I feel like that is out of scope for this initial PR and could lead to hard-to-find bugs if we're not careful. It is something that may be worth exploring in the future, though.