### PR TITLE
Bump rbx_dom_lua rojo-rbx/rbx-dom@e7a5b91c (ScriptEditorService)

### DIFF
--- a/plugin/rbx_dom_lua/customProperties.lua
+++ b/plugin/rbx_dom_lua/customProperties.lua
@@ -1,4 +1,5 @@
 local CollectionService = game:GetService("CollectionService")
+local ScriptEditorService = game:GetService("ScriptEditorService")
 
 --- A list of `Enum.Material` values that are used for Terrain.MaterialColors
 local TERRAIN_MATERIAL_COLORS = {
@@ -112,6 +113,36 @@ return {
 				for material, color in value do
 					instance:SetMaterialColor(material, color)
 				end
+				return true
+			end,
+		},
+	},
+	Script = {
+		Source = {
+			read = function(instance: Script)
+				return true, ScriptEditorService:GetEditorSource(instance)
+			end,
+			write = function(instance: Script, _, value: string)
+				task.spawn(function()
+					ScriptEditorService:UpdateSourceAsync(instance, function()
+						return value
+					end)
+				end)
+				return true
+			end,
+		},
+	},
+	ModuleScript = {
+		Source = {
+			read = function(instance: ModuleScript)
+				return true, ScriptEditorService:GetEditorSource(instance)
+			end,
+			write = function(instance: ModuleScript, _, value: string)
+				task.spawn(function()
+					ScriptEditorService:UpdateSourceAsync(instance, function()
+						return value
+					end)
+				end)
 				return true
 			end,
 		},

--- a/plugin/rbx_dom_lua/database.json
+++ b/plugin/rbx_dom_lua/database.json
@@ -1,9 +1,9 @@
 {
   "Version": [
     0,
-    596,
+    597,
     1,
-    5960685
+    5970668
   ],
   "Classes": {
     "Accessory": {
@@ -4502,6 +4502,17 @@
           }
         }
       },
+      "DefaultProperties": {}
+    },
+    "AvatarCreationService": {
+      "Name": "AvatarCreationService",
+      "Tags": [
+        "NotCreatable",
+        "NotReplicated",
+        "Service"
+      ],
+      "Superclass": "Instance",
+      "Properties": {},
       "DefaultProperties": {}
     },
     "AvatarEditorService": {
@@ -15560,9 +15571,7 @@
     },
     "DragDetector": {
       "Name": "DragDetector",
-      "Tags": [
-        "NotBrowsable"
-      ],
+      "Tags": [],
       "Superclass": "ClickDetector",
       "Properties": {
         "ActivatedCursorIcon": {
@@ -28121,6 +28130,17 @@
         }
       }
     },
+    "LogReporterService": {
+      "Name": "LogReporterService",
+      "Tags": [
+        "NotCreatable",
+        "NotReplicated",
+        "Service"
+      ],
+      "Superclass": "Instance",
+      "Properties": {},
+      "DefaultProperties": {}
+    },
     "LogService": {
       "Name": "LogService",
       "Tags": [
@@ -31192,7 +31212,7 @@
         },
         "Source": {
           "Name": "Source",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "Custom",
           "DataType": {
             "Value": "String"
           },
@@ -41454,7 +41474,7 @@
       "Properties": {
         "Source": {
           "Name": "Source",
-          "Scriptability": "ReadWrite",
+          "Scriptability": "Custom",
           "DataType": {
             "Value": "String"
           },
@@ -47977,6 +47997,19 @@
             }
           }
         },
+        "Camera Speed Adjust Binding": {
+          "Name": "Camera Speed Adjust Binding",
+          "Scriptability": "ReadWrite",
+          "DataType": {
+            "Enum": "CameraSpeedAdjustBinding"
+          },
+          "Tags": [],
+          "Kind": {
+            "Canonical": {
+              "Serialization": "Serializes"
+            }
+          }
+        },
         "Camera Zoom to Mouse Position": {
           "Name": "Camera Zoom to Mouse Position",
           "Scriptability": "ReadWrite",
@@ -49545,7 +49578,9 @@
     },
     "StudioAttachment": {
       "Name": "StudioAttachment",
-      "Tags": [],
+      "Tags": [
+        "NotReplicated"
+      ],
       "Superclass": "Instance",
       "Properties": {
         "AutoHideParent": {
@@ -49614,52 +49649,11 @@
           }
         }
       },
-      "DefaultProperties": {
-        "Attributes": {
-          "Attributes": {}
-        },
-        "AutoHideParent": {
-          "Bool": false
-        },
-        "Capabilities": {
-          "SecurityCapabilities": 0
-        },
-        "DefinesCapabilities": {
-          "Bool": false
-        },
-        "IsArrowVisible": {
-          "Bool": false
-        },
-        "Offset": {
-          "Vector2": [
-            0.0,
-            0.0
-          ]
-        },
-        "SourceAnchorPoint": {
-          "Vector2": [
-            0.0,
-            0.0
-          ]
-        },
-        "SourceAssetId": {
-          "Int64": -1
-        },
-        "Tags": {
-          "Tags": []
-        },
-        "TargetAnchorPoint": {
-          "Vector2": [
-            0.0,
-            0.0
-          ]
-        }
-      }
+      "DefaultProperties": {}
     },
     "StudioCallout": {
       "Name": "StudioCallout",
       "Tags": [
-        "NotCreatable",
         "NotReplicated"
       ],
       "Superclass": "Instance",
@@ -64701,6 +64695,14 @@
         "EdgeBump": 1
       }
     },
+    "CameraSpeedAdjustBinding": {
+      "name": "CameraSpeedAdjustBinding",
+      "items": {
+        "AltScroll": 2,
+        "None": 0,
+        "RmbScroll": 1
+      }
+    },
     "CameraType": {
       "name": "CameraType",
       "items": {
@@ -67514,6 +67516,9 @@
         "Mid": 36,
         "Midlight": 98,
         "Notification": 4,
+        "OnboardingCover": 132,
+        "OnboardingHighlight": 133,
+        "OnboardingShadow": 134,
         "RibbonButton": 19,
         "RibbonTab": 15,
         "RibbonTabTopBar": 16,


### PR DESCRIPTION
This PR updates the Rojo plugin's rbx_dom_lua version. Note that it does not change the server whatsoever - this should be fine, since the only real changes are a change to scriptability of `Script.Source` and `ModuleScript.Source`, plus the custom setters/getters.