### PR TITLE
Fix PatchTree incorrect changeList entries on decode failure

### DIFF
--- a/plugin/src/PatchTree.lua
+++ b/plugin/src/PatchTree.lua
@@ -233,7 +233,7 @@ function PatchTree.build(patch, instanceMap, changeListHeaders)
 				addProp(
 					prop,
 					if currentSuccess then currentValue else "[Error]",
-					if incomingSuccess then incomingValue else next(incoming)
+					if incomingSuccess then incomingValue else select(2, next(incoming))
 				)
 			end
 
@@ -359,7 +359,7 @@ function PatchTree.build(patch, instanceMap, changeListHeaders)
 				if success then
 					table.insert(changeList, { prop, "N/A", incomingValue })
 				else
-					table.insert(changeList, { prop, "N/A", next(incoming) })
+					table.insert(changeList, { prop, "N/A", select(2, next(incoming)) })
 				end
 			end
 


### PR DESCRIPTION
While I was testing #803, I discovered that `PatchTree.build` can create malformed `changeList` entries when a property decode fails. This causes errors when other parts of the system (such as `DomLabel`) attempt to interact with them. The core of the problem is that we're using `next` to obtain prop type-value pairs from the encoded property values in the incoming patch. `next` returns multiple values (in this case, the type followed by the value), which are then passed as-is to `addProp` or the table cons. What we want instead is to only pass the prop value.

This PR simply uses a `select` to only pass the prop value. I can also assign the result of `next` to variables in these cases if we think `select` is too ugly... 