### PR TITLE
Demote unapplied patch warnings to debug logs

### DIFF
--- a/plugin/src/ServeSession.lua
+++ b/plugin/src/ServeSession.lua
@@ -282,7 +282,7 @@ function ServeSession:__initialSync(serverInfo)
 			local unappliedPatch = self.__reconciler:applyPatch(catchUpPatch)
 
 			if not PatchSet.isEmpty(unappliedPatch) then
-				Log.warn(
+				Log.debug(
 					"Could not apply all changes requested by the Rojo server:\n{}",
 					PatchSet.humanSummary(self.__instanceMap, unappliedPatch)
 				)
@@ -309,7 +309,7 @@ function ServeSession:__mainSyncLoop()
 						local unappliedPatch = self.__reconciler:applyPatch(message)
 
 						if not PatchSet.isEmpty(unappliedPatch) then
-							Log.warn(
+							Log.debug(
 								"Could not apply all changes requested by the Rojo server:\n{}",
 								PatchSet.humanSummary(self.__instanceMap, unappliedPatch)
 							)


### PR DESCRIPTION
These warnings always appear for properties like `Capabilities`, `SourceAssetId`, etc. and tend to scare users who are syncing models. This information is now surfaced in the patch visualizer, so I think these warnings can be demoted to debug logs. 