### PR TITLE
Bump rbx_binary to 0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "rbx_binary"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10942950a57c939e540a2f977ba55e9140007d7e96c532d455502c290fdf710d"
+checksum = "ad50c13afe91296dad6508ea7e29f4b665fa56cb664ad01eaf8fdbd3da69d5e1"
 dependencies = [
  "log",
  "lz4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ memofs = { version = "0.2.0", path = "crates/memofs" }
 # rbx_reflection_database = { path = "../rbx-dom/rbx_reflection_database" }
 # rbx_xml = { path = "../rbx-dom/rbx_xml" }
 
-rbx_binary = "0.7.2"
+rbx_binary = "0.7.3"
 rbx_dom_weak = "2.6.0"
 rbx_reflection = "4.4.0"
 rbx_reflection_database = "0.2.8"


### PR DESCRIPTION
Bumps rbx_binary's version to 0.7.3 to bring in the missing `SecurityCapabilities` serialization fallback default