### PR TITLE
 rbx_dom_lua rojo-rbx/rbx-dom@440f3723 (attribute validation) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@
  	This ensures that the script editor reflects any changes Rojo makes to a script while it is open in the script editor.
 
 * Fixed issues when handling `SecurityCapabilities` values ([#803], [#807])
-* Fixed Rojo plugin erroring out when attempting to sync attributes with invalid names ([#808]
+* Fixed Rojo plugin erroring out when attempting to sync attributes with invalid names ([#809]
 
 [#800]: https://github.com/rojo-rbx/rojo/pull/800
 [#801]: https://github.com/rojo-rbx/rojo/pull/801
 [#803]: https://github.com/rojo-rbx/rojo/pull/803
 [#807]: https://github.com/rojo-rbx/rojo/pull/807
-[#808]: https://github.com/rojo-rbx/rojo/pull/808
+[#808]: https://github.com/rojo-rbx/rojo/pull/809
 
 ## [7.4.0-rc2] - October 3, 2023
 * Fixed bug with parsing version for plugin validation ([#797])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
  	This ensures that the script editor reflects any changes Rojo makes to a script while it is open in the script editor.
 
 * Fixed issues when handling `SecurityCapabilities` values ([#803], [#807])
-* Fixed Rojo plugin erroring out when attempting to sync attributes with invalid names ([#809]
+* Fixed Rojo plugin erroring out when attempting to sync attributes with invalid names ([#809])
 
 [#800]: https://github.com/rojo-rbx/rojo/pull/800
 [#801]: https://github.com/rojo-rbx/rojo/pull/801

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@
  	This ensures that the script editor reflects any changes Rojo makes to a script while it is open in the script editor.
 
 * Fixed issues when handling `SecurityCapabilities` values ([#803], [#807])
+* Fixed Rojo plugin erroring out when attempting to sync attributes with invalid names ([#808]
 
 [#800]: https://github.com/rojo-rbx/rojo/pull/800
 [#801]: https://github.com/rojo-rbx/rojo/pull/801
 [#803]: https://github.com/rojo-rbx/rojo/pull/803
 [#807]: https://github.com/rojo-rbx/rojo/pull/807
+[#808]: https://github.com/rojo-rbx/rojo/pull/808
 
 ## [7.4.0-rc2] - October 3, 2023
 * Fixed bug with parsing version for plugin validation ([#797])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 [#801]: https://github.com/rojo-rbx/rojo/pull/801
 [#803]: https://github.com/rojo-rbx/rojo/pull/803
 [#807]: https://github.com/rojo-rbx/rojo/pull/807
-[#808]: https://github.com/rojo-rbx/rojo/pull/809
+[#809]: https://github.com/rojo-rbx/rojo/pull/809
 
 ## [7.4.0-rc2] - October 3, 2023
 * Fixed bug with parsing version for plugin validation ([#797])

--- a/plugin/rbx_dom_lua/customProperties.lua
+++ b/plugin/rbx_dom_lua/customProperties.lua
@@ -37,9 +37,24 @@ return {
 			end,
 			write = function(instance, _, value)
 				local existing = instance:GetAttributes()
+				local didAllWritesSucceed = true
 
-				for key, attr in pairs(value) do
-					instance:SetAttribute(key, attr)
+				for attributeName, attributeValue in pairs(value) do
+					local isNameValid =
+						-- For our SetAttribute to succeed, the attribute name must be
+						-- less than or equal to 100 characters...
+						#attributeName <= 100
+						-- ...must only contain alphanumeric characters, periods, hyphens,
+						-- underscores, or forward slashes...
+						and attributeName:match("[^%w%.%-_/]") == nil
+						-- ... and must not use the RBX prefix, which is reserved by Roblox.
+						and attributeName:sub(1, 3) ~= "RBX"
+
+					if isNameValid then
+						instance:SetAttribute(attributeName, attributeValue)
+					else
+						didAllWritesSucceed = false
+					end
 				end
 
 				for key in pairs(existing) do
@@ -48,7 +63,7 @@ return {
 					end
 				end
 
-				return true
+				return didAllWritesSucceed
 			end,
 		},
 		Tags = {


### PR DESCRIPTION
Brings over some changes to rbx_dom_lua to validate attribute names before calling `Instance:SetAttribute`. This should prevent Rojo from falling over when it attempts to sync an attribute with an invalid name.