### PR TITLE
Place use of PollWatcher on mac behind a feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,6 @@
 * Add buttons for navigation on the Connected page ([#722])
 
 ### Fixes
-* Significantly improved performance of `rojo serve` and `rojo build` on macOS. [#783]
 * Significantly improved performance of `rojo sourcemap` ([#668])
 * Fixed the diff visualizer of connected sessions. ([#674])
 * Fixed disconnected session activity. ([#675])
@@ -172,7 +171,6 @@
 [#770]: https://github.com/rojo-rbx/rojo/pull/770
 [#771]: https://github.com/rojo-rbx/rojo/pull/771
 [#774]: https://github.com/rojo-rbx/rojo/pull/774
-[#783]: https://github.com/rojo-rbx/rojo/pull/783
 [rbx-dom#299]: https://github.com/rojo-rbx/rbx-dom/pull/299
 [rbx-dom#296]: https://github.com/rojo-rbx/rbx-dom/pull/296
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,7 @@ name = "build"
 harness = false
 
 [dependencies]
-memofs = { version = "0.2.0", path = "crates/memofs", features = [
-    "poll-watcher-mac",
-] }
+memofs = { version = "0.2.0", path = "crates/memofs" }
 
 # These dependencies can be uncommented when working on rbx-dom simultaneously
 # rbx_binary = { path = "../rbx-dom/rbx_binary" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,9 @@ name = "build"
 harness = false
 
 [dependencies]
-memofs = { version = "0.2.0", path = "crates/memofs" }
+memofs = { version = "0.2.0", path = "crates/memofs", features = [
+    "poll-watcher-mac",
+] }
 
 # These dependencies can be uncommented when working on rbx-dom simultaneously
 # rbx_binary = { path = "../rbx-dom/rbx_binary" }

--- a/crates/memofs/CHANGELOG.md
+++ b/crates/memofs/CHANGELOG.md
@@ -1,7 +1,7 @@
 # memofs Changelog
 
 ## Unreleased Changes
-* Changed the `StdBackend` file watcher to use `PollWatcher` on macOS.
+* Added a `poll-watcher-mac` feature to swap the `StdBackend` filewatcher to use `PollWatcher` on macOs.
 
 ## 0.2.0 (2021-08-23)
 * Updated to `crossbeam-channel` 0.5.1.

--- a/crates/memofs/Cargo.toml
+++ b/crates/memofs/Cargo.toml
@@ -15,3 +15,6 @@ crossbeam-channel = "0.5.1"
 fs-err = "2.3.0"
 notify = "6.1.1"
 serde = { version = "1.0", features = ["derive"] }
+
+[features]
+poll-watcher-mac = []

--- a/crates/memofs/src/std_backend.rs
+++ b/crates/memofs/src/std_backend.rs
@@ -15,10 +15,10 @@ use crate::{DirEntry, Metadata, ReadDir, VfsBackend, VfsEvent};
 
 /// `VfsBackend` that uses `std::fs` and the `notify` crate.
 pub struct StdBackend {
-    #[cfg(target_os = "macos")]
+    #[cfg(all(feature = "poll-watcher-mac", target_os = "macos"))]
     watcher: PollWatcher,
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(all(feature = "poll-watcher-mac", target_os = "macos")))]
     watcher: RecommendedWatcher,
 
     watcher_receiver: Receiver<VfsEvent>,


### PR DESCRIPTION
Due to the rather large uptick in CPU usage the PollWatcher backend causes, we decided on Discord to add a flag of some kind to it.

This change adds a feature to memofs to use PollWatcher but doesn't enable it by default, allowing people to build Rojo with it if they need the performance uptick. This is in line with the discussions on Discord.