### PR TITLE
Fix broken serve tests on macOS

### DIFF
--- a/tests/rojo_test/serve_util.rs
+++ b/tests/rojo_test/serve_util.rs
@@ -66,7 +66,11 @@ impl TestServeSession {
 
         let source_path = Path::new(SERVE_TESTS_PATH).join(name);
         let dir = tempdir().expect("Couldn't create temporary directory");
-        let project_path = dir.path().join(name);
+        let project_path = dir
+            .path()
+            .canonicalize()
+            .expect("Couldn't canonicalize temporary directory path")
+            .join(name);
 
         let source_is_file = fs::metadata(&source_path).unwrap().is_file();
 


### PR DESCRIPTION
Right now, serve tests will fail when Rojo is built with the FSEvent backend. The cause is essentially due to the fact that `/var` (where temporary directories for serve tests are located) on macOS is actually a symlink to `/private/var`. Paths coming from FSEvent always have symlinks expanded, but Rojo never expands symlinks. So, Rojo's paths during these tests look like `/var/*` while the FSEvent paths look like `/private/var/*`. When Rojo's change processor receives these events, it considers them outside the project and does not apply any changes, causing serve tests to time out.

To work around this, we can call `Path::canonicalize` before passing the project path to `rojo serve` during serve tests. Rojo does need to better support symlinks (which would also solve the problem), but I think that can be left for another day because it's larger in scope and I mostly just want working tests before addressing #609.