### PR TITLE
Run CI workflow on Windows and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,12 @@ on:
 jobs:
   build:
     name: Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         rust_version: [stable, 1.70.0]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds macOS and Windows jobs to the CI workflow. This allows us to see when changes break functionality on any supported platform, which is particularly important for changes that involve the file system or file watcher.