### PR TITLE
Conserve CI minutes via cache, skip macOS+Windows MSRV builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,16 @@ jobs:
         rust_version: [stable, 1.70.0]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
+        # It's unnecessary to build using MSRV on macOS and Windows
+        # because MSRV builds will not fail on a platform specific
+        # basis. So, we skip these two configurations to conserve
+        # GitHub Actions minutes.
+        exclude:
+          - os: macos-latest
+            rust_version: 1.70.0
+          - os: windows-latest
+            rust_version: 1.70.0
+
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
         override: true
         components: rustfmt, clippy
 
+    - name: Rust cache
+      uses: Swatinem/rust-cache@v2
+
     - name: Setup Aftman
       uses: ok-nick/setup-aftman@v0.3.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,18 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: [stable, 1.70.0]
         os: [ubuntu-latest, windows-latest, macos-latest]
-
-        # It's unnecessary to build using MSRV on macOS and Windows
-        # because MSRV builds will not fail on a platform specific
-        # basis. So, we skip these two configurations to conserve
-        # GitHub Actions minutes.
-        exclude:
-          - os: macos-latest
-            rust_version: 1.70.0
-          - os: windows-latest
-            rust_version: 1.70.0
 
     steps:
     - uses: actions/checkout@v3
@@ -37,7 +26,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: ${{ matrix.rust_version }}
+        toolchain: stable
         override: true
         profile: minimal
 
@@ -54,6 +43,33 @@ jobs:
 
     - name: Test
       run: cargo test --locked --verbose
+
+  msrv:
+    name: Check MSRV
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.70.0
+        override: true
+        profile: minimal
+
+    - name: Rust cache
+      uses: Swatinem/rust-cache@v2
+
+    - name: Setup Aftman
+      uses: ok-nick/setup-aftman@v0.3.0
+      with:
+        version: 'v0.2.7'
+
+    - name: Build
+      run: cargo build --locked --verbose
 
   lint:
     name: Rustfmt, Clippy, & Stylua

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
         override: true
         profile: minimal
 
+    - name: Rust cache
+      uses: Swatinem/rust-cache@v2
+
     - name: Setup Aftman
       uses: ok-nick/setup-aftman@v0.3.0
       with:


### PR DESCRIPTION
Windows and macOS runners consume GitHub Actions minutes at [2x and 10x the rate of Linux runners, respectively](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#minute-multipliers). This is a bit concerning now that there are two Windows jobs and two macOS jobs, introduced in #825. 

This PR aims to reduce the cost by:
* Adding [rust-cache](https://github.com/Swatinem/rust-cache/) to reduce the amount of time spent. I'm aware there were some concerns raised about CI caches in general in #496 - are they still a blocker?
* Removing the unnecessary Windows and macOS MSRV build jobs. If an MSRV build fails on one platform due to usage of new language features, then it will fail on all of them.

@Kampfkarren may have to change this repository's required status checks before this PR can be merged