### PR TITLE
Improve visualization for arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Rojo Changelog
 
 ## Unreleased Changes
+* Improved the visualization for array properties like Tags ([#829])
+
+[#829]: https://github.com/rojo-rbx/rojo/pull/829
 
 ## [7.4.0-rc3] - October 25, 2023
 * Changed `sourcemap --watch` to only generate the sourcemap when it's necessary ([#800])

--- a/plugin/src/App/Components/PatchVisualizer/DisplayValue.lua
+++ b/plugin/src/App/Components/PatchVisualizer/DisplayValue.lua
@@ -53,8 +53,23 @@ local function DisplayValue(props)
 			elseif next(props.value) == nil then
 				-- If it's empty, show empty braces
 				textRepresentation = "{}"
+			elseif next(props.value) == 1 then
+				-- We don't need to support mixed tables, so checking the first key is enough
+				-- to determine if it's a simple array
+				local out, i = table.create(#props.value), 0
+				for k, v in props.value do
+					i += 1
+
+					-- Wrap strings in quotes
+					if type(v) == "string" then
+						v = '"' .. v .. '"'
+					end
+
+					out[i] = tostring(v)
+				end
+				textRepresentation = "{ " .. table.concat(out, ", ") .. " }"
 			else
-				-- If it has children, list them out
+				-- Otherwise, show the table contents as a dictionary
 				local out, i = {}, 0
 				for k, v in pairs(props.value) do
 					i += 1


### PR DESCRIPTION
Closes #757.

Old:
![257411332-98f81ed0-13b7-46c8-8595-8cef10b679f1](https://github.com/rojo-rbx/rojo/assets/40185666/31db2c76-6041-4da7-a340-58f99497eff4)

New:
![image](https://github.com/rojo-rbx/rojo/assets/40185666/d9defb90-5d06-41c2-b4d8-d2593d65ecd8)

Down the line, I do aim to replace the simple string representation of tables with a more visual spreadsheet-esque UI, but this is an easy improvement immediately.