### PR TITLE
Downgrade to Notify 4, use FSEvents, use minimal recursive watches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Rojo Changelog
 
 ## Unreleased Changes
+* Significantly improved performance of `rojo serve`, `rojo build --watch`, and `rojo sourcemap --watch` on macOS. [#830]
+
+[#830]: https://github.com/rojo-rbx/rojo/pull/830
 
 ## [7.4.0-rc3] - October 25, 2023
 * Changed `sourcemap --watch` to only generate the sourcemap when it's necessary ([#800])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,6 @@
 * Add buttons for navigation on the Connected page ([#722])
 
 ### Fixes
-* Significantly improved performance of `rojo serve` and `rojo build` on macOS. [#783]
 * Significantly improved performance of `rojo sourcemap` ([#668])
 * Fixed the diff visualizer of connected sessions. ([#674])
 * Fixed disconnected session activity. ([#675])
@@ -172,7 +171,6 @@
 [#770]: https://github.com/rojo-rbx/rojo/pull/770
 [#771]: https://github.com/rojo-rbx/rojo/pull/771
 [#774]: https://github.com/rojo-rbx/rojo/pull/774
-[#783]: https://github.com/rojo-rbx/rojo/pull/783
 [rbx-dom#299]: https://github.com/rojo-rbx/rbx-dom/pull/299
 [rbx-dom#296]: https://github.com/rojo-rbx/rbx-dom/pull/296
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,7 +1852,6 @@ dependencies = [
  "log",
  "maplit",
  "memofs",
- "notify",
  "num_cpus",
  "opener",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi 0.1.19",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -424,7 +424,7 @@ checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
  "redox_users",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -550,13 +550,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0845fa252299212f0389d64ba26f34fa32cfe41588355f21ed507c59a0f64541"
 
 [[package]]
-name = "fsevent-sys"
-version = "4.1.0"
+name = "fsevent"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
+dependencies = [
+ "bitflags 1.3.2",
+ "fsevent-sys",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags 1.3.2",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
@@ -857,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.9.6"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
 dependencies = [
  "bitflags 1.3.2",
  "inotify-sys",
@@ -889,6 +915,15 @@ dependencies = [
  "serde",
  "similar",
  "yaml-rust",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -928,23 +963,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "kqueue"
-version = "1.0.8"
+name = "kernel32-sys"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
@@ -952,6 +977,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -1067,14 +1098,56 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log",
+ "miow",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+dependencies = [
+ "lazycell",
+ "log",
+ "mio 0.6.23",
+ "slab",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
 ]
 
 [[package]]
@@ -1096,22 +1169,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "notify"
-version = "6.1.1"
+name = "net2"
+version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
 dependencies = [
- "bitflags 2.4.0",
- "crossbeam-channel",
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "notify"
+version = "4.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae03c8c853dba7bfd23e571ff0cff7bc9dceb40a4cd684cd1681824183f45257"
+dependencies = [
+ "bitflags 1.3.2",
  "filetime",
+ "fsevent",
  "fsevent-sys",
  "inotify",
- "kqueue",
  "libc",
- "log",
- "mio",
+ "mio 0.6.23",
+ "mio-extras",
  "walkdir",
- "windows-sys 0.48.0",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1121,7 +1204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1171,7 +1254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "293c15678e37254c15bd2f092314abb4e51d7fdde05c2021279c12631b54f005"
 dependencies = [
  "bstr",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1769,6 +1852,7 @@ dependencies = [
  "log",
  "maplit",
  "memofs",
+ "notify",
  "num_cpus",
  "opener",
  "paste",
@@ -2028,7 +2112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2191,7 +2275,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
+ "mio 0.8.8",
  "num_cpus",
  "pin-project-lite",
  "socket2 0.5.4",
@@ -2552,6 +2636,12 @@ dependencies = [
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -2559,6 +2649,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -2572,7 +2668,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2728,7 +2824,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2737,7 +2833,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2748,6 +2844,16 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if 1.0.0",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ hyper = { version = "0.14.13", features = ["server", "tcp", "http1"] }
 jod-thread = "0.1.2"
 log = "0.4.14"
 maplit = "1.0.2"
-notify = "4.0.17"
 num_cpus = "1.15.0"
 opener = "0.5.0"
 rayon = "1.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ hyper = { version = "0.14.13", features = ["server", "tcp", "http1"] }
 jod-thread = "0.1.2"
 log = "0.4.14"
 maplit = "1.0.2"
+notify = "4.0.17"
 num_cpus = "1.15.0"
 opener = "0.5.0"
 rayon = "1.7.0"

--- a/crates/memofs/CHANGELOG.md
+++ b/crates/memofs/CHANGELOG.md
@@ -1,6 +1,9 @@
 # memofs Changelog
 
 ## Unreleased Changes
+* Changed `StdBackend` file watching component to use minimal recursive watches. [#830]
+
+[#830]: https://github.com/rojo-rbx/rojo/pull/830
 
 ## 0.2.0 (2021-08-23)
 * Updated to `crossbeam-channel` 0.5.1.

--- a/crates/memofs/CHANGELOG.md
+++ b/crates/memofs/CHANGELOG.md
@@ -1,7 +1,6 @@
 # memofs Changelog
 
 ## Unreleased Changes
-* Changed the `StdBackend` file watcher to use `PollWatcher` on macOS.
 
 ## 0.2.0 (2021-08-23)
 * Updated to `crossbeam-channel` 0.5.1.

--- a/crates/memofs/Cargo.toml
+++ b/crates/memofs/Cargo.toml
@@ -13,5 +13,5 @@ homepage = "https://github.com/rojo-rbx/rojo/tree/master/memofs"
 [dependencies]
 crossbeam-channel = "0.5.1"
 fs-err = "2.3.0"
-notify = "6.1.1"
+notify = "4.0.15"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/memofs/src/std_backend.rs
+++ b/crates/memofs/src/std_backend.rs
@@ -1,23 +1,25 @@
 use std::io;
 use std::path::Path;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
 
 use crossbeam_channel::Receiver;
-
-use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
-
-#[cfg(target_os = "macos")]
-use notify::{Config, PollWatcher};
+use notify::{DebouncedEvent, RecursiveMode, Watcher};
 
 #[cfg(target_os = "macos")]
-use std::time::Duration;
+use notify::PollWatcher;
+#[cfg(not(target_os = "macos"))]
+use notify::{watcher, RecommendedWatcher};
 
 use crate::{DirEntry, Metadata, ReadDir, VfsBackend, VfsEvent};
 
 /// `VfsBackend` that uses `std::fs` and the `notify` crate.
 pub struct StdBackend {
+    // We use PollWatcher on macos because using the KQueue watcher
+    // can cause some gnarly performance problems.
     #[cfg(target_os = "macos")]
     watcher: PollWatcher,
-
     #[cfg(not(target_os = "macos"))]
     watcher: RecommendedWatcher,
 
@@ -26,39 +28,37 @@ pub struct StdBackend {
 
 impl StdBackend {
     pub fn new() -> StdBackend {
-        let (tx, rx) = crossbeam_channel::unbounded();
-
-        let event_handler = move |res: Result<Event, _>| match res {
-            Ok(event) => match event.kind {
-                EventKind::Create(_) => {
-                    for path in event.paths {
-                        let _ = tx.send(VfsEvent::Create(path));
-                    }
-                }
-                EventKind::Modify(_) => {
-                    for path in event.paths {
-                        let _ = tx.send(VfsEvent::Write(path));
-                    }
-                }
-                EventKind::Remove(_) => {
-                    for path in event.paths {
-                        let _ = tx.send(VfsEvent::Remove(path));
-                    }
-                }
-                _ => {}
-            },
-            Err(e) => println!("watch error: {:?}", e),
-        };
-
-        #[cfg(not(target_os = "macos"))]
-        let watcher = notify::recommended_watcher(event_handler).unwrap();
+        let (notify_tx, notify_rx) = mpsc::channel();
 
         #[cfg(target_os = "macos")]
-        let watcher = PollWatcher::new(
-            event_handler,
-            Config::default().with_poll_interval(Duration::from_millis(200)),
-        )
-        .unwrap();
+        let watcher = PollWatcher::new(notify_tx, Duration::from_millis(50)).unwrap();
+        #[cfg(not(target_os = "macos"))]
+        let watcher = watcher(notify_tx, Duration::from_millis(50)).unwrap();
+
+        let (tx, rx) = crossbeam_channel::unbounded();
+
+        thread::spawn(move || {
+            for event in notify_rx {
+                match event {
+                    DebouncedEvent::Create(path) => {
+                        tx.send(VfsEvent::Create(path))?;
+                    }
+                    DebouncedEvent::Write(path) => {
+                        tx.send(VfsEvent::Write(path))?;
+                    }
+                    DebouncedEvent::Remove(path) => {
+                        tx.send(VfsEvent::Remove(path))?;
+                    }
+                    DebouncedEvent::Rename(from, to) => {
+                        tx.send(VfsEvent::Remove(from))?;
+                        tx.send(VfsEvent::Create(to))?;
+                    }
+                    _ => {}
+                }
+            }
+
+            Result::<(), crossbeam_channel::SendError<VfsEvent>>::Ok(())
+        });
 
         Self {
             watcher,

--- a/crates/memofs/src/std_backend.rs
+++ b/crates/memofs/src/std_backend.rs
@@ -5,34 +5,19 @@ use std::thread;
 use std::time::Duration;
 
 use crossbeam_channel::Receiver;
-use notify::{DebouncedEvent, RecursiveMode, Watcher};
-
-#[cfg(target_os = "macos")]
-use notify::PollWatcher;
-#[cfg(not(target_os = "macos"))]
-use notify::{watcher, RecommendedWatcher};
+use notify::{watcher, DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
 
 use crate::{DirEntry, Metadata, ReadDir, VfsBackend, VfsEvent};
 
 /// `VfsBackend` that uses `std::fs` and the `notify` crate.
 pub struct StdBackend {
-    // We use PollWatcher on macos because using the KQueue watcher
-    // can cause some gnarly performance problems.
-    #[cfg(target_os = "macos")]
-    watcher: PollWatcher,
-    #[cfg(not(target_os = "macos"))]
     watcher: RecommendedWatcher,
-
     watcher_receiver: Receiver<VfsEvent>,
 }
 
 impl StdBackend {
     pub fn new() -> StdBackend {
         let (notify_tx, notify_rx) = mpsc::channel();
-
-        #[cfg(target_os = "macos")]
-        let watcher = PollWatcher::new(notify_tx, Duration::from_millis(50)).unwrap();
-        #[cfg(not(target_os = "macos"))]
         let watcher = watcher(notify_tx, Duration::from_millis(50)).unwrap();
 
         let (tx, rx) = crossbeam_channel::unbounded();

--- a/crates/memofs/src/std_backend.rs
+++ b/crates/memofs/src/std_backend.rs
@@ -1,8 +1,8 @@
-use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
+use std::{collections::HashSet, io};
 
 use crossbeam_channel::Receiver;
 use notify::{watcher, DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
@@ -13,6 +13,7 @@ use crate::{DirEntry, Metadata, ReadDir, VfsBackend, VfsEvent};
 pub struct StdBackend {
     watcher: RecommendedWatcher,
     watcher_receiver: Receiver<VfsEvent>,
+    watches: HashSet<PathBuf>,
 }
 
 impl StdBackend {
@@ -48,6 +49,7 @@ impl StdBackend {
         Self {
             watcher,
             watcher_receiver: rx,
+            watches: HashSet::new(),
         }
     }
 }
@@ -97,12 +99,22 @@ impl VfsBackend for StdBackend {
     }
 
     fn watch(&mut self, path: &Path) -> io::Result<()> {
-        self.watcher
-            .watch(path, RecursiveMode::NonRecursive)
-            .map_err(|inner| io::Error::new(io::ErrorKind::Other, inner))
+        if self.watches.contains(path)
+            || path
+                .ancestors()
+                .any(|ancestor| self.watches.contains(ancestor))
+        {
+            Ok(())
+        } else {
+            self.watches.insert(path.to_path_buf());
+            self.watcher
+                .watch(path, RecursiveMode::Recursive)
+                .map_err(|inner| io::Error::new(io::ErrorKind::Other, inner))
+        }
     }
 
     fn unwatch(&mut self, path: &Path) -> io::Result<()> {
+        self.watches.remove(path);
         self.watcher
             .unwatch(path)
             .map_err(|inner| io::Error::new(io::ErrorKind::Other, inner))


### PR DESCRIPTION
This PR makes a few changes to the file watching component of memofs' `StdBackend` to address performance problems on macOS. Closes #815 and closes #609. The amount of code churn here is unfortunate, but we haven't had a maintainer who works on macOS until now.

### Downgrade to Notify 4
First, I downgraded back to Notify 4 by reverting #816. The reason for this is the fact that Notify 6's debouncer provides incorrect results when using the FSEvents backend. Specifically, FSEvents under some circumstances emits a Create event immediately followed by a Remove event for file deletions [???], which Notify 6's debouncer then collates into zero events, never reporting any changes. Notify 4's debouncer does not have this problem.

Because the raw events can be quite noisy, we do need some form of debouncing to avoid unnecessary patch re-computations. So, we're blocked on upgrading Notify unless memofs implements its own deboucing, or we maintain our own patch until it's fixed upstream.

### Use FSEvents backend instead of PollWatcher
Next, I reverted #783. The use of `PollWatcher` worked around the massive latency described in #609, but incurred prohibitive cost as reported in #815.

### Minimize number of watch calls by leveraging Notify's recursive watch mode
I determined that the performance problem in #609 is caused by excessive calls to `FsEventWatcher::watch`. This method is potentially very expensive, and `rojo serve` calls it for every file in the project during initialization. It seems to get slower and slower the more it is called, which starts to be problematic once the number of files in the project exceeds about 1000. I profiled `rojo serve` using a debug build on a project containing 2000 Lua files, and calls to `FsEventWatcher::watch` dominated the profile, accounting for over 90% of the execution time:

<img width="1440" alt="image" src="https://github.com/rojo-rbx/rojo/assets/13822714/42f1f28f-33bc-4918-894b-63dec57062e2">

It's possible to avoid this by using Notify's recursive watch mode, and only calling `watch` on files that aren't already covered by an existing recursive watch. FSEvents is designed to watch an entire hierarchy - in other words, it will report events for any descendant of a watched directory. By using the recursive watch mode, we only have to call `watch` once per top-level directory, and once per "naked" file, i.e. a file that is directly referred to using `$path` that is not already a descendant of a watched directory. With this change, calls to `FsEventWatcher::watch` virtually disappear in the profile:

<img width="1440" alt="image" src="https://github.com/rojo-rbx/rojo/assets/13822714/525adcf3-3417-4243-8c4d-2e3c66f9b79b">

### Takeaways and alternatives?
The main takeaways here are that the underlying file watching APIs are racy, unreliable, and possibly very costly. It's also important to note that changes to memofs are hazardous, and must be tested thoroughly on each of Rojo's main supported platforms.

I looked into using the kqueue backend on macOS (which is far better behaved compared FSEvents), but it's still rather slow, and presents an additional issue: the kqueue backend opens every file it watches and stores the file descriptors, which risks exceeding the operating system's maximum open files limit. While this limit can be increased, I'd rather not have to worry about it all.
