### PR TITLE
Don't remind to sync if the lock is claimed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 * Improved the visualization for array properties like Tags ([#829])
 * Significantly improved performance of `rojo serve`, `rojo build --watch`, and `rojo sourcemap --watch` on macOS. ([#830])
 * Changed *.lua files that init command generates to *.luau ([#831])
+* Does not remind users to sync if the sync lock is claimed already ([#833])
 
 [#829]: https://github.com/rojo-rbx/rojo/pull/829
 [#830]: https://github.com/rojo-rbx/rojo/pull/830
 [#831]: https://github.com/rojo-rbx/rojo/pull/831
+[#833]: https://github.com/rojo-rbx/rojo/pull/833
 
 ## [7.4.0-rc3] - October 25, 2023
 * Changed `sourcemap --watch` to only generate the sourcemap when it's necessary ([#800])

--- a/plugin/src/App/init.lua
+++ b/plugin/src/App/init.lua
@@ -136,6 +136,7 @@ function App:init()
 		and self.serveSession == nil
 		and Settings:get("syncReminder")
 		and self:getLastSyncTimestamp()
+		and (self:isSyncLockAvailable())
 	then
 		self:addNotification("You've previously synced this place. Would you like to reconnect?", 300, {
 			Connect = {
@@ -283,10 +284,37 @@ function App:getHostAndPort()
 	return host, port
 end
 
+function App:isSyncLockAvailable()
+	if #Players:GetPlayers() == 0 then
+		-- Team Create is not active, so no one can be holding the lock
+		return true
+	end
+
+	local lock = ServerStorage:FindFirstChild("__Rojo_SessionLock")
+	if not lock then
+		-- No lock is made yet, so it is available
+		return true
+	end
+
+	if lock.Value and lock.Value ~= Players.LocalPlayer and lock.Value.Parent then
+		-- Someone else is holding the lock
+		return false, lock.Value
+	end
+
+	-- The lock exists, but is not claimed
+	return true
+end
+
 function App:claimSyncLock()
 	if #Players:GetPlayers() == 0 then
 		Log.trace("Skipping sync lock because this isn't in Team Create")
 		return true
+	end
+
+	local isAvailable, priorOwner = self:isSyncLockAvailable()
+	if not isAvailable then
+		Log.trace("Skipping sync lock because it is already claimed")
+		return false, priorOwner
 	end
 
 	local lock = ServerStorage:FindFirstChild("__Rojo_SessionLock")
@@ -298,11 +326,6 @@ function App:claimSyncLock()
 		lock.Parent = ServerStorage
 		Log.trace("Created and claimed sync lock")
 		return true
-	end
-
-	if lock.Value and lock.Value ~= Players.LocalPlayer and lock.Value.Parent then
-		Log.trace("Found existing sync lock owned by {}", lock.Value)
-		return false, lock.Value
 	end
 
 	lock.Value = Players.LocalPlayer


### PR DESCRIPTION
If the sync lock is claimed in Team Create, the user cannot sync. Therefore, a sync reminder notification is unhelpful as it is calling to an invalid action.