### PR TITLE
Don't serialize `emitLegacyScripts` if it's `None`

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -8,9 +8,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{
-    glob::Glob, resolution::UnresolvedValue, snapshot_middleware::emit_legacy_scripts_default,
-};
+use crate::{glob::Glob, resolution::UnresolvedValue};
 
 static PROJECT_FILENAME: &str = "default.project.json";
 
@@ -75,12 +73,10 @@ pub struct Project {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub serve_address: Option<IpAddr>,
 
-    /// Determines if rojo should emit scripts with the appropriate `RunContext` for `*.client.lua` and `*.server.lua` files in the project.
-    /// Or, if rojo should keep the legacy behavior of emitting LocalScripts and Scripts with legacy Runcontext
-    #[serde(
-        default = "emit_legacy_scripts_default",
-        skip_serializing_if = "Option::is_none"
-    )]
+    /// Determines if Rojo should emit scripts with the appropriate `RunContext`
+    /// for `*.client.lua` and `*.server.lua` files in the project instead of
+    /// using `Script` and `LocalScript` Instances.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub emit_legacy_scripts: Option<bool>,
 
     /// A list of globs, relative to the folder the project file is in, that


### PR DESCRIPTION
Right now, if someone runs `rojo fmt-project` on a project that doesn't have `emitLegacyScripts` specified, it will emit a file with the default value (`true` right now). This is undesirable because it forces users into specifying a redundant field if they want to format their project.

This PR fixes that by simply removing the default for the field from Serde. Since we specify a default when we read it anyway, this has no impact on actual usage but makes `fmt-project` behave the same between 7.3 and 7.4.