### PR TITLE
Ensure plugin and Cargo version match exact at compile-time

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -48,12 +48,8 @@ fn main() -> Result<(), anyhow::Error> {
     let plugin_version =
         Version::parse(fs::read_to_string(plugin_root.join("Version.txt"))?.trim())?;
 
-    assert!(
-        our_version.major == plugin_version.major,
-        "plugin version does not match Cargo version"
-    );
-    assert!(
-        our_version.minor == plugin_version.minor,
+    assert_eq!(
+        our_version, plugin_version,
         "plugin version does not match Cargo version"
     );
 


### PR DESCRIPTION
In #794, I changed the build script to guarantee that Rojo's plugin and CLI had the same major and minor version. In hindsight, this was a mistake though because it allows things like build metadata and pre-releases to slide through.

This changes that check to just check that they're absolutely identical because there's no reason that we should ever bundle an out of date plugin with the CLI.