### PR TITLE
Catch more sync failures

### DIFF
--- a/plugin/src/InstanceMap.lua
+++ b/plugin/src/InstanceMap.lua
@@ -113,27 +113,29 @@ end
 function InstanceMap:destroyInstance(instance)
 	local id = self.fromInstances[instance]
 
+	local descendants = instance:GetDescendants()
+	instance:Destroy()
+
+	-- After the instance is successfully destroyed,
+	-- we can remove all the id mappings
+
 	if id ~= nil then
 		self:removeId(id)
 	end
 
-	for _, descendantInstance in ipairs(instance:GetDescendants()) do
+	for _, descendantInstance in descendants do
 		self:removeInstance(descendantInstance)
 	end
-
-	instance:Destroy()
 end
 
 function InstanceMap:destroyId(id)
 	local instance = self.fromIds[id]
-	self:removeId(id)
-
 	if instance ~= nil then
-		for _, descendantInstance in ipairs(instance:GetDescendants()) do
-			self:removeInstance(descendantInstance)
-		end
-
-		instance:Destroy()
+		self:destroyInstance(instance)
+	else
+		-- There is no instance with this id, so we can just remove the id
+		-- without worrying about instance destruction
+		self:removeId(id)
 	end
 end
 

--- a/plugin/src/PatchTree.lua
+++ b/plugin/src/PatchTree.lua
@@ -442,8 +442,8 @@ function PatchTree.updateMetadata(tree, patch, instanceMap, unappliedPatch)
 				then failedChange.changedName ~= nil -- Name is not in changedProperties, so it needs a special case
 				else failedChange.changedProperties[property] ~= nil
 
-			if propertyFailedToApply then
-				-- This change didn't fail
+			if not propertyFailedToApply then
+				-- This change didn't fail, no need to mark
 				continue
 			end
 			if change[4] == nil then

--- a/plugin/src/PatchTree.lua
+++ b/plugin/src/PatchTree.lua
@@ -437,7 +437,12 @@ function PatchTree.updateMetadata(tree, patch, instanceMap, unappliedPatch)
 			continue
 		end
 		for _, change in node.changeList do
-			if not failedChange.changedProperties[change[1]] then
+			local property = change[1]
+			local propertyFailedToApply = if property == "Name"
+				then failedChange.changedName ~= nil -- Name is not in changedProperties, so it needs a special case
+				else failedChange.changedProperties[property] ~= nil
+
+			if propertyFailedToApply then
 				-- This change didn't fail
 				continue
 			end
@@ -446,7 +451,7 @@ function PatchTree.updateMetadata(tree, patch, instanceMap, unappliedPatch)
 			else
 				change[4].isWarning = true
 			end
-			Log.trace("  Marked property as warning: {}.{}", node.name, change[1])
+			Log.trace("  Marked property as warning: {}.{}", node.name, property)
 		end
 	end
 	for failedAdditionId in unappliedPatch.added do

--- a/plugin/src/Reconciler/applyPatch.lua
+++ b/plugin/src/Reconciler/applyPatch.lua
@@ -175,7 +175,13 @@ local function applyPatch(instanceMap, patch)
 		end
 
 		if update.changedName ~= nil then
-			instance.Name = update.changedName
+			local ok = pcall(function()
+				instance.Name = update.changedName
+			end)
+			if not ok then
+				unappliedUpdate.changedName = update.changedName
+				partiallyApplied = true
+			end
 		end
 
 		if update.changedMetadata ~= nil then

--- a/plugin/src/Reconciler/applyPatch.lua
+++ b/plugin/src/Reconciler/applyPatch.lua
@@ -25,10 +25,15 @@ local function applyPatch(instanceMap, patch)
 	local unappliedPatch = PatchSet.newEmpty()
 
 	for _, removedIdOrInstance in ipairs(patch.removed) do
-		if Types.RbxId(removedIdOrInstance) then
-			instanceMap:destroyId(removedIdOrInstance)
-		else
-			instanceMap:destroyInstance(removedIdOrInstance)
+		local ok = pcall(function()
+			if Types.RbxId(removedIdOrInstance) then
+				instanceMap:destroyId(removedIdOrInstance)
+			else
+				instanceMap:destroyInstance(removedIdOrInstance)
+			end
+		end)
+		if not ok then
+			table.insert(unappliedPatch.removed, removedIdOrInstance)
 		end
 	end
 


### PR DESCRIPTION
- Catch removal failures
- Catch name change failures
- Don't remove IDs for instances if they weren't actually destroyed