### PR TITLE
Catch failed http requests that didn't error so we can handle them correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added popout diff visualizer for table properties like Attributes and Tags ([#834])
 * Updated Theme to use Studio colors ([#838])
 * Added experimental setting for Auto Connect in playtests ([#840])
+* Fixed http error handling so Rojo can be used in Github Codespaces ([#847])
 * Projects may now specify rules for syncing files as if they had a different file extension. ([#813])
  	This is specified via a new field on project files, `syncRules`:
 
@@ -55,6 +56,7 @@
 [#834]: https://github.com/rojo-rbx/rojo/pull/834
 [#838]: https://github.com/rojo-rbx/rojo/pull/838
 [#840]: https://github.com/rojo-rbx/rojo/pull/840
+[#847]: https://github.com/rojo-rbx/rojo/pull/847
 
 ## [7.4.0] - January 16, 2024
 * Improved the visualization for array properties like Tags ([#829])

--- a/plugin/http/Error.lua
+++ b/plugin/http/Error.lua
@@ -3,12 +3,12 @@ Error.__index = Error
 
 Error.Kind = {
 	HttpNotEnabled = {
-		message = "Rojo requires HTTP access, which is not enabled.\n" ..
-			"Check your game settings, located in the 'Home' tab of Studio.",
+		message = "Rojo requires HTTP access, which is not enabled.\n"
+			.. "Check your game settings, located in the 'Home' tab of Studio.",
 	},
 	ConnectFailed = {
-		message = "Couldn't connect to the Rojo server.\n" ..
-			"Make sure the server is running — use 'rojo serve' to run it!",
+		message = "Couldn't connect to the Rojo server.\n"
+			.. "Make sure the server is running — use 'rojo serve' to run it!",
 	},
 	Timeout = {
 		message = "HTTP request timed out.",
@@ -61,6 +61,15 @@ function Error.fromRobloxErrorString(message)
 	end
 
 	return Error.new(Error.Kind.Unknown, message)
+end
+
+function Error.fromResponse(response)
+	local lower = (response.body or ""):lower()
+	if response.code == 408 or response.code == 504 or lower:find("timed? ?out") then
+		return Error.new(Error.Kind.Timeout)
+	end
+
+	return Error.new(Error.Kind.Unknown, string.format("%s: %s", tostring(response.code), tostring(response.body)))
 end
 
 return Error

--- a/plugin/http/init.lua
+++ b/plugin/http/init.lua
@@ -30,8 +30,13 @@ local function performRequest(requestParams)
 			end)
 
 			if success then
-				Log.trace("Request {} success, status code {}", requestId, response.StatusCode)
-				resolve(HttpResponse.fromRobloxResponse(response))
+				Log.trace("Request {} success, response {:#?}", requestId, response)
+				local httpResponse = HttpResponse.fromRobloxResponse(response)
+				if httpResponse:isSuccess() then
+					resolve(httpResponse)
+				else
+					reject(HttpError.fromResponse(httpResponse))
+				end
 			else
 				Log.trace("Request {} failure: {:?}", requestId, response)
 				reject(HttpError.fromRobloxErrorString(response))


### PR DESCRIPTION
The `http.get` promise treated any request that made it through the `pcall` without erroring as a success to `resolve`.
`ApiContext` would then check the status code and `reject`, but by then it's too late to handle gracefully and we just show the error code and stop the sync.

This improves that. We create a relevant `Error` object for requests that are not success codes, so that `ApiContext` can handle them correctly.

The immediate impact is that GitHub Codespaces is now compatible with Rojo, since requests to the [forwarded port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace) receive a [504 Gateway Timeout](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504) after 100 seconds. Given our long polling, we simply resend requests that return a timeout.