### PR TITLE
Ignore any unreadable property in Reconciler:diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Rojo Changelog
 
 ## Unreleased Changes
+* Fixed Rojo plugin failing to connect when project contains certain unreadable properties ([#848])
 * Added popout diff visualizer for table properties like Attributes and Tags ([#834])
 * Updated Theme to use Studio colors ([#838])
 * Added experimental setting for Auto Connect in playtests ([#840])
@@ -55,6 +56,7 @@
 [#834]: https://github.com/rojo-rbx/rojo/pull/834
 [#838]: https://github.com/rojo-rbx/rojo/pull/838
 [#840]: https://github.com/rojo-rbx/rojo/pull/840
+[#848]: https://github.com/rojo-rbx/rojo/pull/848
 
 ## [7.4.0] - January 16, 2024
 * Improved the visualization for array properties like Tags ([#829])

--- a/plugin/src/Reconciler/diff.lua
+++ b/plugin/src/Reconciler/diff.lua
@@ -177,10 +177,8 @@ local function diff(instanceMap, virtualInstances, rootId)
 
 				if err.kind == Error.UnknownProperty then
 					Log.trace("Skipping unknown property {}.{}", err.details.className, err.details.propertyName)
-				elseif err.kind == Error.UnreadableProperty then
-					Log.trace("Skipping unreadable property {}.{}", err.details.className, err.details.propertyName)
 				else
-					return false, err
+					Log.trace("Skipping unreadable property {}.{}", err.details.className, err.details.propertyName)
 				end
 			end
 		end


### PR DESCRIPTION
This PR closes #841 by ignoring any properties in `Reconciler:diff` that fail to read for any reason. Before, `Reconciler:diff` would simply exit with an error when it encountered properties that failed to read for an unknown reason.