### PR TITLE
Add benchmarking, perf gains, and better settings UI

### DIFF
--- a/plugin/src/App/Components/StringDiffVisualizer/init.lua
+++ b/plugin/src/App/Components/StringDiffVisualizer/init.lua
@@ -9,6 +9,7 @@ local Log = require(Packages.Log)
 local Highlighter = require(Packages.Highlighter)
 local StringDiff = require(script:FindFirstChild("StringDiff"))
 
+local Timer = require(Plugin.Timer)
 local Theme = require(Plugin.App.Theme)
 
 local CodeLabel = require(Plugin.App.Components.CodeLabel)
@@ -74,6 +75,7 @@ function StringDiffVisualizer:calculateContentSize()
 end
 
 function StringDiffVisualizer:calculateDiffLines()
+	Timer.start("StringDiffVisualizer:calculateDiffLines")
 	local oldString, newString = self.props.oldString, self.props.newString
 
 	-- Diff the two texts
@@ -133,6 +135,7 @@ function StringDiffVisualizer:calculateDiffLines()
 		end
 	end
 
+	Timer.stop()
 	return add, remove
 end
 

--- a/plugin/src/App/Components/TableDiffVisualizer/Array.lua
+++ b/plugin/src/App/Components/TableDiffVisualizer/Array.lua
@@ -4,6 +4,7 @@ local Packages = Rojo.Packages
 
 local Roact = require(Packages.Roact)
 
+local Timer = require(Plugin.Timer)
 local Assets = require(Plugin.Assets)
 local Theme = require(Plugin.App.Theme)
 
@@ -21,6 +22,7 @@ function Array:init()
 end
 
 function Array:calculateDiff()
+	Timer.start("Array:calculateDiff")
 	--[[
 		Find the indexes that are added or removed from the array,
 		and display them side by side with gaps for the indexes that
@@ -63,6 +65,7 @@ function Array:calculateDiff()
 		j += 1
 	end
 
+	Timer.stop()
 	return diff
 end
 

--- a/plugin/src/App/Components/TableDiffVisualizer/Dictionary.lua
+++ b/plugin/src/App/Components/TableDiffVisualizer/Dictionary.lua
@@ -4,6 +4,7 @@ local Packages = Rojo.Packages
 
 local Roact = require(Packages.Roact)
 
+local Timer = require(Plugin.Timer)
 local Assets = require(Plugin.Assets)
 local Theme = require(Plugin.App.Theme)
 
@@ -21,6 +22,7 @@ function Dictionary:init()
 end
 
 function Dictionary:calculateDiff()
+	Timer.start("Dictionary:calculateDiff")
 	local oldTable, newTable = self.props.oldTable or {}, self.props.newTable or {}
 
 	-- Diff the two tables and find the added keys, removed keys, and changed keys
@@ -59,6 +61,7 @@ function Dictionary:calculateDiff()
 		return a.key < b.key
 	end)
 
+	Timer.stop()
 	return diff
 end
 

--- a/plugin/src/App/StatusPages/Confirming.lua
+++ b/plugin/src/App/StatusPages/Confirming.lua
@@ -4,6 +4,8 @@ local Packages = Rojo.Packages
 
 local Roact = require(Packages.Roact)
 
+local Timer = require(Plugin.Timer)
+local PatchTree = require(Plugin.PatchTree)
 local Settings = require(Plugin.Settings)
 local Theme = require(Plugin.App.Theme)
 local TextButton = require(Plugin.App.Components.TextButton)
@@ -23,6 +25,7 @@ function ConfirmingPage:init()
 	self.containerSize, self.setContainerSize = Roact.createBinding(Vector2.new(0, 0))
 
 	self:setState({
+		patchTree = nil,
 		showingStringDiff = false,
 		oldString = "",
 		newString = "",
@@ -30,6 +33,28 @@ function ConfirmingPage:init()
 		oldTable = {},
 		newTable = {},
 	})
+
+	if self.props.confirmData and self.props.confirmData.patch and self.props.confirmData.instanceMap then
+		self:buildPatchTree()
+	end
+end
+
+function ConfirmingPage:didUpdate(prevProps)
+	if prevProps.confirmData ~= self.props.confirmData then
+		self:buildPatchTree()
+	end
+end
+
+function ConfirmingPage:buildPatchTree()
+	Timer.start("ConfirmingPage:buildPatchTree")
+	self:setState({
+		patchTree = PatchTree.build(
+			self.props.confirmData.patch,
+			self.props.confirmData.instanceMap,
+			{ "Property", "Current", "Incoming" }
+		),
+	})
+	Timer.stop()
 end
 
 function ConfirmingPage:render()
@@ -61,9 +86,7 @@ function ConfirmingPage:render()
 				transparency = self.props.transparency,
 				layoutOrder = 3,
 
-				changeListHeaders = { "Property", "Current", "Incoming" },
-				patch = self.props.confirmData.patch,
-				instanceMap = self.props.confirmData.instanceMap,
+				patchTree = self.state.patchTree,
 
 				showStringDiff = function(oldString: string, newString: string)
 					self:setState({

--- a/plugin/src/App/StatusPages/Settings/Setting.lua
+++ b/plugin/src/App/StatusPages/Settings/Setting.lua
@@ -121,8 +121,14 @@ function Setting:render()
 				BackgroundTransparency = 1,
 			}, {
 				Name = e("TextLabel", {
-					Text = (if self.props.experimental then '<font color="#FF8E3C">⚠ </font>' else "")
-						.. self.props.name,
+					Text = (
+						if self.props.experimental
+							then '<font color="#FF8E3C">⚠ </font>'
+							elseif
+								self.props.developerDebug
+							then '<font family="rbxasset://fonts/families/Guru.json" color="#0D58E5">⚑ </font>' -- Guru is the only font with the flag emoji
+							else ""
+					) .. self.props.name,
 					Font = Enum.Font.GothamBold,
 					TextSize = 17,
 					TextColor3 = theme.Setting.NameColor,
@@ -137,8 +143,10 @@ function Setting:render()
 				}),
 
 				Description = e("TextLabel", {
-					Text = (if self.props.experimental then '<font color="#FF8E3C">[Experimental] </font>' else "")
-						.. self.props.description,
+					Text = (if self.props.experimental
+						then '<font color="#FF8E3C">[Experimental] </font>'
+						elseif self.props.developerDebug then '<font color="#0D58E5">[Dev Debug] </font>'
+						else "") .. self.props.description,
 					Font = Enum.Font.Gotham,
 					LineHeight = 1.2,
 					TextSize = 14,

--- a/plugin/src/App/StatusPages/Settings/Setting.lua
+++ b/plugin/src/App/StatusPages/Settings/Setting.lua
@@ -126,7 +126,7 @@ function Setting:render()
 							then '<font color="#FF8E3C">⚠ </font>'
 							elseif
 								self.props.developerDebug
-							then '<font family="rbxasset://fonts/families/Guru.json" color="#0D58E5">⚑ </font>' -- Guru is the only font with the flag emoji
+							then '<font family="rbxasset://fonts/families/Guru.json" color="#35B5FF">⚑ </font>' -- Guru is the only font with the flag emoji
 							else ""
 					) .. self.props.name,
 					Font = Enum.Font.GothamBold,
@@ -145,7 +145,7 @@ function Setting:render()
 				Description = e("TextLabel", {
 					Text = (if self.props.experimental
 						then '<font color="#FF8E3C">[Experimental] </font>'
-						elseif self.props.developerDebug then '<font color="#0D58E5">[Dev Debug] </font>'
+						elseif self.props.developerDebug then '<font color="#35B5FF">[Dev Debug] </font>'
 						else "") .. self.props.description,
 					Font = Enum.Font.Gotham,
 					LineHeight = 1.2,

--- a/plugin/src/App/StatusPages/Settings/init.lua
+++ b/plugin/src/App/StatusPages/Settings/init.lua
@@ -84,159 +84,161 @@ function SettingsPage:render()
 	return Theme.with(function(theme)
 		theme = theme.Settings
 
-		return e(ScrollingFrame, {
-			size = UDim2.new(1, 0, 1, 0),
-			contentSize = self.contentSize,
-			transparency = self.props.transparency,
-		}, {
+		return Roact.createFragment({
 			Navbar = e(Navbar, {
 				onBack = self.props.onBack,
 				transparency = self.props.transparency,
 				layoutOrder = layoutIncrement(),
 			}),
-
-			ShowNotifications = e(Setting, {
-				id = "showNotifications",
-				name = "Show Notifications",
-				description = "Popup notifications in viewport",
+			Content = e(ScrollingFrame, {
+				size = UDim2.new(1, 0, 1, -47),
+				position = UDim2.new(0, 0, 0, 47),
+				contentSize = self.contentSize,
 				transparency = self.props.transparency,
-				layoutOrder = layoutIncrement(),
-			}),
-
-			SyncReminder = e(Setting, {
-				id = "syncReminder",
-				name = "Sync Reminder",
-				description = "Notify to sync when opening a place that has previously been synced",
-				transparency = self.props.transparency,
-				visible = Settings:getBinding("showNotifications"),
-				layoutOrder = layoutIncrement(),
-			}),
-
-			ConfirmationBehavior = e(Setting, {
-				id = "confirmationBehavior",
-				name = "Confirmation Behavior",
-				description = "When to prompt for confirmation before syncing",
-				transparency = self.props.transparency,
-				layoutOrder = layoutIncrement(),
-
-				options = confirmationBehaviors,
-			}),
-
-			LargeChangesConfirmationThreshold = e(Setting, {
-				id = "largeChangesConfirmationThreshold",
-				name = "Confirmation Threshold",
-				description = "How many modified instances to be considered a large change",
-				transparency = self.props.transparency,
-				layoutOrder = layoutIncrement(),
-				visible = Settings:getBinding("confirmationBehavior"):map(function(value)
-					return value == "Large Changes"
-				end),
-				input = e(TextInput, {
-					size = UDim2.new(0, 40, 0, 28),
-					text = Settings:getBinding("largeChangesConfirmationThreshold"):map(function(value)
-						return tostring(value)
-					end),
+			}, {
+				ShowNotifications = e(Setting, {
+					id = "showNotifications",
+					name = "Show Notifications",
+					description = "Popup notifications in viewport",
 					transparency = self.props.transparency,
-					enabled = true,
-					onEntered = function(text)
-						local number = tonumber(string.match(text, "%d+"))
-						if number then
-							Settings:set("largeChangesConfirmationThreshold", math.clamp(number, 1, 999))
-						else
-							-- Force text back to last valid value
-							Settings:set(
-								"largeChangesConfirmationThreshold",
-								Settings:get("largeChangesConfirmationThreshold")
-							)
-						end
+					layoutOrder = layoutIncrement(),
+				}),
+
+				SyncReminder = e(Setting, {
+					id = "syncReminder",
+					name = "Sync Reminder",
+					description = "Notify to sync when opening a place that has previously been synced",
+					transparency = self.props.transparency,
+					visible = Settings:getBinding("showNotifications"),
+					layoutOrder = layoutIncrement(),
+				}),
+
+				ConfirmationBehavior = e(Setting, {
+					id = "confirmationBehavior",
+					name = "Confirmation Behavior",
+					description = "When to prompt for confirmation before syncing",
+					transparency = self.props.transparency,
+					layoutOrder = layoutIncrement(),
+
+					options = confirmationBehaviors,
+				}),
+
+				LargeChangesConfirmationThreshold = e(Setting, {
+					id = "largeChangesConfirmationThreshold",
+					name = "Confirmation Threshold",
+					description = "How many modified instances to be considered a large change",
+					transparency = self.props.transparency,
+					layoutOrder = layoutIncrement(),
+					visible = Settings:getBinding("confirmationBehavior"):map(function(value)
+						return value == "Large Changes"
+					end),
+					input = e(TextInput, {
+						size = UDim2.new(0, 40, 0, 28),
+						text = Settings:getBinding("largeChangesConfirmationThreshold"):map(function(value)
+							return tostring(value)
+						end),
+						transparency = self.props.transparency,
+						enabled = true,
+						onEntered = function(text)
+							local number = tonumber(string.match(text, "%d+"))
+							if number then
+								Settings:set("largeChangesConfirmationThreshold", math.clamp(number, 1, 999))
+							else
+								-- Force text back to last valid value
+								Settings:set(
+									"largeChangesConfirmationThreshold",
+									Settings:get("largeChangesConfirmationThreshold")
+								)
+							end
+						end,
+					}),
+				}),
+
+				PlaySounds = e(Setting, {
+					id = "playSounds",
+					name = "Play Sounds",
+					description = "Toggle sound effects",
+					transparency = self.props.transparency,
+					layoutOrder = layoutIncrement(),
+				}),
+
+				AutoConnectPlaytestServer = e(Setting, {
+					id = "autoConnectPlaytestServer",
+					name = "Auto Connect Playtest Server",
+					description = "Automatically connect game server to Rojo when playtesting while connected in Edit",
+					experimental = true,
+					transparency = self.props.transparency,
+					layoutOrder = layoutIncrement(),
+				}),
+
+				OpenScriptsExternally = e(Setting, {
+					id = "openScriptsExternally",
+					name = "Open Scripts Externally",
+					description = "Attempt to open scripts in an external editor",
+					locked = self.props.syncActive,
+					experimental = true,
+					transparency = self.props.transparency,
+					layoutOrder = layoutIncrement(),
+				}),
+
+				TwoWaySync = e(Setting, {
+					id = "twoWaySync",
+					name = "Two-Way Sync",
+					description = "Editing files in Studio will sync them into the filesystem",
+					locked = self.props.syncActive,
+					experimental = true,
+					transparency = self.props.transparency,
+					layoutOrder = layoutIncrement(),
+				}),
+
+				LogLevel = e(Setting, {
+					id = "logLevel",
+					name = "Log Level",
+					description = "Plugin output verbosity level",
+					developerDebug = true,
+					transparency = self.props.transparency,
+					layoutOrder = layoutIncrement(),
+
+					options = invertedLevels,
+					showReset = Settings:getBinding("logLevel"):map(function(value)
+						return value ~= "Info"
+					end),
+					onReset = function()
+						Settings:set("logLevel", "Info")
 					end,
 				}),
-			}),
 
-			PlaySounds = e(Setting, {
-				id = "playSounds",
-				name = "Play Sounds",
-				description = "Toggle sound effects",
-				transparency = self.props.transparency,
-				layoutOrder = layoutIncrement(),
-			}),
+				TypecheckingEnabled = e(Setting, {
+					id = "typecheckingEnabled",
+					name = "Typechecking",
+					description = "Toggle typechecking on the API surface",
+					developerDebug = true,
+					transparency = self.props.transparency,
+					layoutOrder = layoutIncrement(),
+				}),
 
-			AutoConnectPlaytestServer = e(Setting, {
-				id = "autoConnectPlaytestServer",
-				name = "Auto Connect Playtest Server",
-				description = "Automatically connect game server to Rojo when playtesting while connected in Edit",
-				experimental = true,
-				transparency = self.props.transparency,
-				layoutOrder = layoutIncrement(),
-			}),
+				TimingLogsEnabled = e(Setting, {
+					id = "timingLogsEnabled",
+					name = "Timing Logs",
+					description = "Toggle logging timing of internal actions for benchmarking Rojo performance",
+					developerDebug = true,
+					transparency = self.props.transparency,
+					layoutOrder = layoutIncrement(),
+				}),
 
-			OpenScriptsExternally = e(Setting, {
-				id = "openScriptsExternally",
-				name = "Open Scripts Externally",
-				description = "Attempt to open scripts in an external editor",
-				locked = self.props.syncActive,
-				experimental = true,
-				transparency = self.props.transparency,
-				layoutOrder = layoutIncrement(),
-			}),
+				Layout = e("UIListLayout", {
+					FillDirection = Enum.FillDirection.Vertical,
+					SortOrder = Enum.SortOrder.LayoutOrder,
 
-			TwoWaySync = e(Setting, {
-				id = "twoWaySync",
-				name = "Two-Way Sync",
-				description = "Editing files in Studio will sync them into the filesystem",
-				locked = self.props.syncActive,
-				experimental = true,
-				transparency = self.props.transparency,
-				layoutOrder = layoutIncrement(),
-			}),
+					[Roact.Change.AbsoluteContentSize] = function(object)
+						self.setContentSize(object.AbsoluteContentSize)
+					end,
+				}),
 
-			LogLevel = e(Setting, {
-				id = "logLevel",
-				name = "Log Level",
-				description = "Plugin output verbosity level",
-				developerDebug = true,
-				transparency = self.props.transparency,
-				layoutOrder = layoutIncrement(),
-
-				options = invertedLevels,
-				showReset = Settings:getBinding("logLevel"):map(function(value)
-					return value ~= "Info"
-				end),
-				onReset = function()
-					Settings:set("logLevel", "Info")
-				end,
-			}),
-
-			TypecheckingEnabled = e(Setting, {
-				id = "typecheckingEnabled",
-				name = "Typechecking",
-				description = "Toggle typechecking on the API surface",
-				developerDebug = true,
-				transparency = self.props.transparency,
-				layoutOrder = layoutIncrement(),
-			}),
-
-			TimingLogsEnabled = e(Setting, {
-				id = "timingLogsEnabled",
-				name = "Timing Logs",
-				description = "Toggle logging timing of internal actions for benchmarking Rojo performance",
-				developerDebug = true,
-				transparency = self.props.transparency,
-				layoutOrder = layoutIncrement(),
-			}),
-
-			Layout = e("UIListLayout", {
-				FillDirection = Enum.FillDirection.Vertical,
-				SortOrder = Enum.SortOrder.LayoutOrder,
-
-				[Roact.Change.AbsoluteContentSize] = function(object)
-					self.setContentSize(object.AbsoluteContentSize)
-				end,
-			}),
-
-			Padding = e("UIPadding", {
-				PaddingLeft = UDim.new(0, 20),
-				PaddingRight = UDim.new(0, 20),
+				Padding = e("UIPadding", {
+					PaddingLeft = UDim.new(0, 20),
+					PaddingRight = UDim.new(0, 20),
+				}),
 			}),
 		})
 	end)

--- a/plugin/src/App/StatusPages/Settings/init.lua
+++ b/plugin/src/App/StatusPages/Settings/init.lua
@@ -194,6 +194,7 @@ function SettingsPage:render()
 				id = "logLevel",
 				name = "Log Level",
 				description = "Plugin output verbosity level",
+				developerDebug = true,
 				transparency = self.props.transparency,
 				layoutOrder = layoutIncrement(),
 
@@ -210,6 +211,16 @@ function SettingsPage:render()
 				id = "typecheckingEnabled",
 				name = "Typechecking",
 				description = "Toggle typechecking on the API surface",
+				developerDebug = true,
+				transparency = self.props.transparency,
+				layoutOrder = layoutIncrement(),
+			}),
+
+			TimingLogsEnabled = e(Setting, {
+				id = "timingLogsEnabled",
+				name = "Timing Logs",
+				description = "Toggle logging timing of internal actions for benchmarking Rojo performance",
+				developerDebug = true,
 				transparency = self.props.transparency,
 				layoutOrder = layoutIncrement(),
 			}),

--- a/plugin/src/PatchTree.lua
+++ b/plugin/src/PatchTree.lua
@@ -134,6 +134,7 @@ function Tree:addNode(parent, props)
 		for k, v in props do
 			node[k] = v
 		end
+		Timer.stop()
 		return node
 	end
 
@@ -144,6 +145,7 @@ function Tree:addNode(parent, props)
 	local parentNode = self:getNode(parent)
 	if not parentNode then
 		Log.warn("Failed to create node since parent doesnt exist: {}, {}", parent, props)
+		Timer.stop()
 		return
 	end
 
@@ -431,30 +433,15 @@ function PatchTree.build(patch, instanceMap, changeListHeaders)
 	return tree
 end
 
--- Creates a deep copy of a tree for immutability purposes in Roact
-function PatchTree.clone(tree)
-	Timer.start("PatchTree.clone")
-	if not tree then
-		return
-	end
-
-	local newTree = Tree.new()
-	tree:forEach(function(node)
-		newTree:addNode(node.parentId, table.clone(node))
-	end)
-
-	Timer.stop()
-
-	return newTree
-end
-
 -- Updates the metadata of a tree with the unapplied patch and currently existing instances
 -- Builds a new tree from the data if one isn't provided
 -- Always returns a new tree for immutability purposes in Roact
 function PatchTree.updateMetadata(tree, patch, instanceMap, unappliedPatch)
 	Timer.start("PatchTree.updateMetadata")
 	if tree then
-		tree = PatchTree.clone(tree)
+		-- A shallow copy is enough for our purposes here since we really only need a new top-level object
+		-- for immutable comparison checks in Roact
+		tree = table.clone(tree)
 	else
 		tree = PatchTree.build(patch, instanceMap)
 	end

--- a/plugin/src/PatchTree.lua
+++ b/plugin/src/PatchTree.lua
@@ -9,10 +9,9 @@ local Rojo = script:FindFirstAncestor("Rojo")
 local Plugin = Rojo.Plugin
 local Packages = Rojo.Packages
 
-local Timer = require(script.Parent.Timer)
-
 local Log = require(Packages.Log)
 
+local Timer = require(Plugin.Timer)
 local Types = require(Plugin.Types)
 local decodeValue = require(Plugin.Reconciler.decodeValue)
 local getProperty = require(Plugin.Reconciler.getProperty)

--- a/plugin/src/PatchTree.lua
+++ b/plugin/src/PatchTree.lua
@@ -238,17 +238,23 @@ function PatchTree.build(patch, instanceMap, changeListHeaders)
 				-- We only want to have 3 hints
 				-- to keep it deterministic, we sort them alphabetically
 
+				-- Either this prop overflows, or it makes another one move to overflow
+				hintOverflow += 1
+
+				-- Shortcut for the common case
+				if hintBuffer[3] <= prop then
+					-- This prop is below the last hint, no need to insert
+					return
+				end
+
 				-- Find the first available spot
 				for i, hintItem in hintBuffer do
-					if hintItem > prop then
+					if prop < hintItem then
 						-- This prop is before the currently selected hint,
 						-- so take its place and then continue to find a spot for the old hint
 						hintBuffer[i], prop = prop, hintBuffer[i]
 					end
 				end
-
-				-- Either this prop overflowed, or it replaced one that overflowed.
-				hintOverflow += 1
 			end
 
 			-- Gather the changes

--- a/plugin/src/PatchTree.lua
+++ b/plugin/src/PatchTree.lua
@@ -161,7 +161,8 @@ function Tree:buildAncestryNodes(previousId: string?, ancestryIds: { string }, p
 	-- Build nodes for ancestry by going up the tree
 	previousId = previousId or "ROOT"
 
-	for _, ancestorId in ancestryIds do
+	for i = #ancestryIds, 1, -1 do
+		local ancestorId = ancestryIds[i]
 		local value = instanceMap.fromIds[ancestorId] or patch.added[ancestorId]
 		if not value then
 			Log.warn("Failed to find ancestor object for " .. ancestorId)
@@ -197,7 +198,7 @@ function PatchTree.build(patch, instanceMap, changeListHeaders)
 		end
 
 		-- Gather ancestors from existing DOM
-		local ancestryIds = {}
+		local ancestryIds, ancestryIndex = {}, 0
 		local parentObject = instance.Parent
 		local parentId = instanceMap.fromInstances[parentObject]
 		local previousId = nil
@@ -208,7 +209,8 @@ function PatchTree.build(patch, instanceMap, changeListHeaders)
 				break
 			end
 
-			table.insert(ancestryIds, 1, parentId)
+			ancestryIndex += 1
+			ancestryIds[ancestryIndex] = parentId
 			knownAncestors[parentId] = true
 			parentObject = parentObject.Parent
 			parentId = instanceMap.fromInstances[parentObject]

--- a/plugin/src/Reconciler/init.lua
+++ b/plugin/src/Reconciler/init.lua
@@ -3,10 +3,13 @@
 	and mutating the Roblox DOM.
 ]]
 
-local Packages = script.Parent.Parent.Packages
+local Rojo = script:FindFirstAncestor("Rojo")
+local Plugin = Rojo.Plugin
+local Packages = Rojo.Packages
+
 local Log = require(Packages.Log)
 
-local Timer = require(script.Parent.Timer)
+local Timer = require(Plugin.Timer)
 
 local applyPatch = require(script.applyPatch)
 local hydrate = require(script.hydrate)

--- a/plugin/src/Settings.lua
+++ b/plugin/src/Settings.lua
@@ -20,6 +20,7 @@ local defaultSettings = {
 	playSounds = true,
 	typecheckingEnabled = false,
 	logLevel = "Info",
+	timingLogsEnabled = false,
 	priorEndpoints = {},
 }
 

--- a/plugin/src/Timer.lua
+++ b/plugin/src/Timer.lua
@@ -1,6 +1,14 @@
 local Packages = script.Parent.Parent.Packages
 local Log = require(Packages.Log)
 
+local Settings = require(script.Parent.Settings)
+
+-- Cache enabled to avoid overhead impacting timings
+local timerEnabled = Settings:get("timingLogsEnabled")
+Settings:onChanged("timingLogsEnabled", function(enabled)
+	timerEnabled = enabled
+end)
+
 local clock = os.clock
 
 local Timer = {
@@ -8,6 +16,10 @@ local Timer = {
 }
 
 function Timer.start(label)
+	if not timerEnabled then
+		return
+	end
+
 	local start = clock()
 	if not label then
 		Log.error("Timer.start: label is required")
@@ -18,6 +30,10 @@ function Timer.start(label)
 end
 
 function Timer.stop()
+	if not timerEnabled then
+		return
+	end
+
 	local stop = clock()
 
 	local entry = table.remove(Timer._entries)
@@ -37,7 +53,7 @@ function Timer.stop()
 
 	local start = entry[2]
 	local duration = stop - start
-	Log.info(string.format("%s took %.2f ms", label, duration * 1000))
+	Log.info(string.format("%s took %.3f ms", label, duration * 1000))
 end
 
 return Timer

--- a/plugin/src/Timer.lua
+++ b/plugin/src/Timer.lua
@@ -9,7 +9,7 @@ local Timer = {
 function Timer._start(label)
 	local start = clock()
 	if not label then
-		error("[Rojo-Timer] Timer.start: label is required")
+		error("[Rojo-Timer] Timer.start: label is required", 2)
 		return
 	end
 

--- a/plugin/src/Timer.lua
+++ b/plugin/src/Timer.lua
@@ -1,0 +1,43 @@
+local Packages = script.Parent.Parent.Packages
+local Log = require(Packages.Log)
+
+local clock = os.clock
+
+local Timer = {
+	_entries = {},
+}
+
+function Timer.start(label)
+	local start = clock()
+	if not label then
+		Log.error("Timer.start: label is required")
+		return
+	end
+
+	table.insert(Timer._entries, { label, start })
+end
+
+function Timer.stop()
+	local stop = clock()
+
+	local entry = table.remove(Timer._entries)
+	if not entry then
+		Log.error("Timer.stop: no label to stop")
+		return
+	end
+
+	local label = entry[1]
+	if #Timer._entries > 0 then
+		local priorLabels = {}
+		for _, priorEntry in ipairs(Timer._entries) do
+			table.insert(priorLabels, priorEntry[1])
+		end
+		label = table.concat(priorLabels, "/") .. "/" .. label
+	end
+
+	local start = entry[2]
+	local duration = stop - start
+	Log.info(string.format("%s took %.2f ms", label, duration * 1000))
+end
+
+return Timer

--- a/plugin/src/Timer.lua
+++ b/plugin/src/Timer.lua
@@ -21,7 +21,7 @@ function Timer._stop()
 
 	local entry = table.remove(Timer._entries)
 	if not entry then
-		error("[Rojo-Timer] Timer.stop: no label to stop")
+		error("[Rojo-Timer] Timer.stop: no label to stop", 2)
 		return
 	end
 

--- a/plugin/src/Timer.lua
+++ b/plugin/src/Timer.lua
@@ -1,6 +1,3 @@
-local Packages = script.Parent.Parent.Packages
-local Log = require(Packages.Log)
-
 local Settings = require(script.Parent.Settings)
 
 -- Cache enabled to avoid overhead impacting timings
@@ -22,7 +19,7 @@ function Timer.start(label)
 
 	local start = clock()
 	if not label then
-		Log.error("Timer.start: label is required")
+		error("[Rojo-Timer] Timer.start: label is required")
 		return
 	end
 
@@ -38,7 +35,7 @@ function Timer.stop()
 
 	local entry = table.remove(Timer._entries)
 	if not entry then
-		Log.error("Timer.stop: no label to stop")
+		error("[Rojo-Timer] Timer.stop: no label to stop")
 		return
 	end
 
@@ -53,7 +50,7 @@ function Timer.stop()
 
 	local start = entry[2]
 	local duration = stop - start
-	Log.info(string.format("%s took %.3f ms", label, duration * 1000))
+	print(string.format("[Rojo-Timer] %s took %.3f ms", label, duration * 1000))
 end
 
 return Timer


### PR DESCRIPTION
- Mark dev debug settings like we mark experimental settings
- Create dev setting to enable timing logs
  - When timing is disabled, timer functions are replaced with a no-op to minimize overhead 
- Add timing logs to major internal actions
- Make patchTree notably faster in a few key areas
- Make confirming page's patch visualizer reduce wasteful work

Also fixed a pet peeve of mine- the back button in the settings menu no longer scrolls off screen so you can now go back without having to scroll back up

![image](https://github.com/rojo-rbx/rojo/assets/40185666/7cba78d1-3629-472a-9e53-ad6ae130721f)