### PR TITLE
Normalize line endings to LF in Lua middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Rojo Changelog
 
 ## Unreleased Changes
+* Rojo now converts any line endings to LF, preventing spurious diffs when syncing text or Lua files on Windows (#[854])
 * Fixed Rojo plugin failing to connect when project contains certain unreadable properties ([#848])
 * Added popout diff visualizer for table properties like Attributes and Tags ([#834])
 * Updated Theme to use Studio colors ([#838])
@@ -59,6 +60,7 @@
 [#840]: https://github.com/rojo-rbx/rojo/pull/840
 [#847]: https://github.com/rojo-rbx/rojo/pull/847
 [#848]: https://github.com/rojo-rbx/rojo/pull/848
+[#854]: https://github.com/rojo-rbx/rojo/pull/854
 
 
 ## [7.4.0] - January 16, 2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Rojo Changelog
 
 ## Unreleased Changes
-* Rojo now converts any line endings to LF, preventing spurious diffs when syncing text or Lua files on Windows (#[854])
+* Rojo now converts any line endings to LF, preventing spurious diffs when syncing text or Lua files on Windows ([#854])
 * Fixed Rojo plugin failing to connect when project contains certain unreadable properties ([#848])
 * Added popout diff visualizer for table properties like Attributes and Tags ([#834])
 * Updated Theme to use Studio colors ([#838])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Rojo Changelog
 
 ## Unreleased Changes
-* Rojo now converts any line endings to LF, preventing spurious diffs when syncing text or Lua files on Windows ([#854])
+* Rojo now converts any line endings to LF, preventing spurious diffs when syncing Lua files on Windows ([#854])
 * Fixed Rojo plugin failing to connect when project contains certain unreadable properties ([#848])
 * Added popout diff visualizer for table properties like Attributes and Tags ([#834])
 * Updated Theme to use Studio colors ([#838])

--- a/crates/memofs/CHANGELOG.md
+++ b/crates/memofs/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased Changes
 * Changed `StdBackend` file watching component to use minimal recursive watches. [#830]
+* Added `Vfs::read_to_string_lf_normalized` [#854]
 
 [#830]: https://github.com/rojo-rbx/rojo/pull/830
+[#854]: https://github.com/rojo-rbx/rojo/pull/854
 
 ## 0.2.0 (2021-08-23)
 * Updated to `crossbeam-channel` 0.5.1.

--- a/crates/memofs/CHANGELOG.md
+++ b/crates/memofs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased Changes
 * Changed `StdBackend` file watching component to use minimal recursive watches. [#830]
-* Added `Vfs::read_to_string_lf_normalized` [#854]
+* Added `Vfs::read_to_string` and `Vfs::read_to_string_lf_normalized` [#854]
 
 [#830]: https://github.com/rojo-rbx/rojo/pull/830
 [#854]: https://github.com/rojo-rbx/rojo/pull/854

--- a/src/snapshot_middleware/lua.rs
+++ b/src/snapshot_middleware/lua.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashMap, path::Path, str};
 
-use anyhow::Context;
 use memofs::{IoResultExt, Vfs};
 use rbx_dom_weak::types::Enum;
 
@@ -40,10 +39,8 @@ pub fn snapshot_lua(
         (_, ScriptType::Module) => ("ModuleScript", None),
     };
 
-    let contents = vfs.read(path)?;
-    let contents_str = str::from_utf8(&contents)
-        .with_context(|| format!("File was not valid UTF-8: {}", path.display()))?
-        .to_owned();
+    let contents = vfs.read_to_string_lf_normalized(path)?;
+    let contents_str = contents.as_str();
 
     let mut properties = HashMap::with_capacity(2);
     properties.insert("Source".to_owned(), contents_str.into());

--- a/src/snapshot_middleware/txt.rs
+++ b/src/snapshot_middleware/txt.rs
@@ -13,7 +13,7 @@ pub fn snapshot_txt(
     path: &Path,
     name: &str,
 ) -> anyhow::Result<Option<InstanceSnapshot>> {
-    let contents = vfs.read_to_string_lf_normalized(path)?;
+    let contents = vfs.read_to_string(path)?;
     let contents_str = contents.as_str();
 
     let properties = hashmap! {

--- a/src/snapshot_middleware/txt.rs
+++ b/src/snapshot_middleware/txt.rs
@@ -1,6 +1,5 @@
 use std::{path::Path, str};
 
-use anyhow::Context;
 use maplit::hashmap;
 use memofs::{IoResultExt, Vfs};
 
@@ -14,10 +13,8 @@ pub fn snapshot_txt(
     path: &Path,
     name: &str,
 ) -> anyhow::Result<Option<InstanceSnapshot>> {
-    let contents = vfs.read(path)?;
-    let contents_str = str::from_utf8(&contents)
-        .with_context(|| format!("File was not valid UTF-8: {}", path.display()))?
-        .to_owned();
+    let contents = vfs.read_to_string_lf_normalized(path)?;
+    let contents_str = contents.as_str();
 
     let properties = hashmap! {
         "Value".to_owned() => contents_str.into(),


### PR DESCRIPTION
Closes #776 by implementing a new method `Vfs::read_to_string_lf_normalized` and changing the Lua middleware to use it.

I'm not really sure why the middlewares were calling `to_owned` on `contents_str` - could it have been a limitation of earlier rbx-dom versions? 