### PR TITLE
Backport #854 to Rojo 7.4 (Lua LF normalization)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Rojo Changelog
 
 ## Unreleased Changes
+* Rojo now converts any line endings to LF, preventing spurious diffs when syncing Lua files on Windows ([#854])
 * Fixed Rojo plugin failing to connect when project contains certain unreadable properties ([#848])
 * Fixed various cases where patch visualizer would not display sync failures ([#845], [#844])
 * Fixed http error handling so Rojo can be used in Github Codespaces ([#847])
@@ -9,6 +10,7 @@
 [#845]: https://github.com/rojo-rbx/rojo/pull/845
 [#844]: https://github.com/rojo-rbx/rojo/pull/844
 [#847]: https://github.com/rojo-rbx/rojo/pull/847
+[#854]: https://github.com/rojo-rbx/rojo/pull/854
 
 ## [7.4.0] - January 16, 2024
 * Improved the visualization for array properties like Tags ([#829])

--- a/crates/memofs/CHANGELOG.md
+++ b/crates/memofs/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased Changes
 * Changed `StdBackend` file watching component to use minimal recursive watches. [#830]
+* Added `Vfs::read_to_string` and `Vfs::read_to_string_lf_normalized` [#854]
 
 [#830]: https://github.com/rojo-rbx/rojo/pull/830
+[#854]: https://github.com/rojo-rbx/rojo/pull/854
 
 ## 0.2.0 (2021-08-23)
 * Updated to `crossbeam-channel` 0.5.1.

--- a/crates/memofs/src/lib.rs
+++ b/crates/memofs/src/lib.rs
@@ -22,9 +22,9 @@ mod noop_backend;
 mod snapshot;
 mod std_backend;
 
-use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, MutexGuard};
+use std::{io, str};
 
 pub use in_memory_fs::InMemoryFs;
 pub use noop_backend::NoopBackend;
@@ -155,6 +155,24 @@ impl VfsInner {
         Ok(Arc::new(contents))
     }
 
+    fn read_to_string<P: AsRef<Path>>(&mut self, path: P) -> io::Result<Arc<String>> {
+        let path = path.as_ref();
+        let contents = self.backend.read(path)?;
+
+        if self.watch_enabled {
+            self.backend.watch(path)?;
+        }
+
+        let contents_str = str::from_utf8(&contents).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("File was not valid UTF-8: {}", path.display()),
+            )
+        })?;
+
+        Ok(Arc::new(contents_str.into()))
+    }
+
     fn write<P: AsRef<Path>, C: AsRef<[u8]>>(&mut self, path: P, contents: C) -> io::Result<()> {
         let path = path.as_ref();
         let contents = contents.as_ref();
@@ -256,6 +274,33 @@ impl Vfs {
     pub fn read<P: AsRef<Path>>(&self, path: P) -> io::Result<Arc<Vec<u8>>> {
         let path = path.as_ref();
         self.inner.lock().unwrap().read(path)
+    }
+
+    /// Read a file from the VFS (or from the underlying backend if it isn't
+    /// resident) into a string.
+    ///
+    /// Roughly equivalent to [`std::fs::read_to_string`][std::fs::read_to_string].
+    ///
+    /// [std::fs::read_to_string]: https://doc.rust-lang.org/stable/std/fs/fn.read_to_string.html
+    #[inline]
+    pub fn read_to_string<P: AsRef<Path>>(&self, path: P) -> io::Result<Arc<String>> {
+        let path = path.as_ref();
+        self.inner.lock().unwrap().read_to_string(path)
+    }
+
+    /// Read a file from the VFS (or the underlying backend if it isn't
+    /// resident) into a string, and normalize its line endings to LF.
+    ///
+    /// Roughly equivalent to [`std::fs::read_to_string`][std::fs::read_to_string], but also performs
+    /// line ending normalization.
+    ///
+    /// [std::fs::read_to_string]: https://doc.rust-lang.org/stable/std/fs/fn.read_to_string.html
+    #[inline]
+    pub fn read_to_string_lf_normalized<P: AsRef<Path>>(&self, path: P) -> io::Result<Arc<String>> {
+        let path = path.as_ref();
+        let contents = self.inner.lock().unwrap().read_to_string(path)?;
+
+        Ok(contents.lines().collect::<Vec<&str>>().join("\n").into())
     }
 
     /// Write a file to the VFS and the underlying backend.

--- a/src/snapshot_middleware/lua.rs
+++ b/src/snapshot_middleware/lua.rs
@@ -1,6 +1,5 @@
-use std::{collections::HashMap, path::Path, str};
+use std::{collections::HashMap, path::Path};
 
-use anyhow::Context;
 use memofs::{IoResultExt, Vfs};
 use rbx_dom_weak::types::Enum;
 
@@ -58,10 +57,8 @@ pub fn snapshot_lua(
         (_, ScriptType::Module) => ("ModuleScript", None),
     };
 
-    let contents = vfs.read(path)?;
-    let contents_str = str::from_utf8(&contents)
-        .with_context(|| format!("File was not valid UTF-8: {}", path.display()))?
-        .to_owned();
+    let contents = vfs.read_to_string_lf_normalized(path)?;
+    let contents_str = contents.as_str();
 
     let mut properties = HashMap::with_capacity(2);
     properties.insert("Source".to_owned(), contents_str.into());

--- a/src/snapshot_middleware/txt.rs
+++ b/src/snapshot_middleware/txt.rs
@@ -1,6 +1,5 @@
-use std::{path::Path, str};
+use std::path::Path;
 
-use anyhow::Context;
 use maplit::hashmap;
 use memofs::{IoResultExt, Vfs};
 
@@ -14,11 +13,8 @@ pub fn snapshot_txt(
     path: &Path,
 ) -> anyhow::Result<Option<InstanceSnapshot>> {
     let name = path.file_name_trim_end(".txt")?;
-
-    let contents = vfs.read(path)?;
-    let contents_str = str::from_utf8(&contents)
-        .with_context(|| format!("File was not valid UTF-8: {}", path.display()))?
-        .to_owned();
+    let contents = vfs.read_to_string(path)?;
+    let contents_str = contents.as_str();
 
     let properties = hashmap! {
         "Value".to_owned() => contents_str.into(),


### PR DESCRIPTION
This PR adds Lua LF normalization to the 7.4.x branch. 

This wasn't a particularly clean cherry pick because the Lua and text middlewares were altered slightly by #813, which did not make it into 7.4. Please double check my conflict resolution and make sure I got it right!