### PR TITLE
Allow building Rojo with `profile-with-tracy` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,19 +1498,19 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89dff0959d98c9758c88826cc002e2c3d0b9dfac4139711d1f30de442f1139b"
+checksum = "0f0f7f43585c34e4fdd7497d746bc32e14458cf11c69341cc0587b1d825dde42"
 dependencies = [
  "profiling-procmacros",
- "tracy-client 0.16.3",
+ "tracy-client",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb156a45b6b9fe8027497422179fb65afc84d36707a7ca98297bf06bccb8d43f"
+checksum = "ce97fecd27bc49296e5e20518b5a1bb54a14f7d5fe6228bc9686ee2a74915cc8"
 dependencies = [
  "quote 1.0.33",
  "syn 2.0.37",
@@ -1876,7 +1876,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
- "tracy-client 0.13.2",
  "uuid",
  "walkdir",
  "winreg 0.10.1",
@@ -2384,33 +2383,13 @@ dependencies = [
 
 [[package]]
 name = "tracy-client"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ebfe7a24c18b5ba86d8920c124b41b942352f863fbe0c84d3d63428fa1860f"
-dependencies = [
- "loom",
- "once_cell",
- "tracy-client-sys 0.17.1",
-]
-
-[[package]]
-name = "tracy-client"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03684af8fb393cc7903210d868e4cb9f5c1e156737be38f52c4217fb21b86bf6"
 dependencies = [
  "loom",
  "once_cell",
- "tracy-client-sys 0.21.2",
-]
-
-[[package]]
-name = "tracy-client-sys"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "178d021455e83078bb38c00b70046b95117ef0a0312cbef925f426d833d11c79"
-dependencies = [
- "cc",
+ "tracy-client-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,9 @@ default = []
 # Enable this feature to live-reload assets from the web UI.
 dev_live_assets = []
 
-profile-with-tracy = ["profiling/profile-with-tracy", "tracy-client"]
+# Run Rojo with this feature to open a Tracy session.
+# Currently uses protocol v63, last supported in Tracy 0.9.1.
+profile-with-tracy = ["profiling/profile-with-tracy"]
 
 [workspace]
 members = ["crates/*"]
@@ -87,8 +89,7 @@ thiserror = "1.0.30"
 tokio = { version = "1.12.0", features = ["rt", "rt-multi-thread"] }
 uuid = { version = "1.0.0", features = ["v4", "serde"] }
 clap = { version = "3.1.18", features = ["derive"] }
-profiling = "1.0.6"
-tracy-client = { version = "0.13.2", optional = true }
+profiling = "1.0.14"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.10.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use librojo::cli::Options;
 
 fn main() {
     #[cfg(feature = "profile-with-tracy")]
-    tracy_client::Client::start();
+    profiling::tracy_client::Client::start();
 
     panic::set_hook(Box::new(|panic_info| {
         // PanicInfo's payload is usually a &'static str or String.


### PR DESCRIPTION
Closes #855.

This resolves the problem with building Rojo while the `profile-with-tracy` feature is on. I just removed `tracy_client` as a direct dependency of ours and used the re-export that `profiling` provides since it guarantees we'll never be out of sync again.

Provided `profiling` respects semver, this shouldn't have any problems going forward.