### PR TITLE
Insert Model.NeedsPivotMigration in insert_instance when missing

### DIFF
--- a/rojo-test/build-test-snapshots/end_to_end__tests__build__rbxmx_in_folder.snap
+++ b/rojo-test/build-test-snapshots/end_to_end__tests__build__rbxmx_in_folder.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/tests/build.rs
 expression: contents
-
 ---
 <roblox version="4">
   <Item class="Folder" referent="0">
@@ -25,6 +24,7 @@ expression: contents
           <R21>0</R21>
           <R22>1</R22>
         </CoordinateFrame>
+        <bool name="NeedsPivotMigration">false</bool>
         <Ref name="PrimaryPart">null</Ref>
         <BinaryString name="Tags"></BinaryString>
       </Properties>

--- a/rojo-test/build-test-snapshots/end_to_end__tests__build__unresolved_values.snap
+++ b/rojo-test/build-test-snapshots/end_to_end__tests__build__unresolved_values.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/tests/build.rs
 expression: contents
-
 ---
 <roblox version="4">
   <Item class="DataModel" referent="0">
@@ -22,6 +21,7 @@ expression: contents
     <Item class="Workspace" referent="2">
       <Properties>
         <string name="Name">Workspace</string>
+        <bool name="NeedsPivotMigration">false</bool>
       </Properties>
       <Item class="BoolValue" referent="3">
         <Properties>

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_json_model_all-2.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_json_model_all-2.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/tests/serve.rs
 expression: "read_response.intern_and_redact(&mut redactions, root_id)"
-
 ---
 instances:
   id-2:
@@ -22,7 +21,9 @@ instances:
       ignoreUnknownInstances: false
     Name: test
     Parent: id-2
-    Properties: {}
+    Properties:
+      NeedsPivotMigration:
+        Bool: false
 messageCursor: 1
 sessionId: id-1
 

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_json_model_subscribe.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__empty_json_model_subscribe.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/tests/serve.rs
 expression: "subscribe_response.intern_and_redact(&mut redactions, ())"
-
 ---
 messageCursor: 1
 messages:
@@ -14,7 +13,9 @@ messages:
           ignoreUnknownInstances: false
         Name: test
         Parent: id-2
-        Properties: {}
+        Properties:
+          NeedsPivotMigration:
+            Bool: false
     removed: []
     updated: []
 sessionId: id-1

--- a/src/snapshot/tree.rs
+++ b/src/snapshot/tree.rs
@@ -90,8 +90,8 @@ impl RojoTree {
         // !!!!!!!!!! UGLY HACK !!!!!!!!!!
         //
         // This is a set of special cases working around a more general problem upstream
-        // in rbx-dom that causes issues pivots to not build to file correctly, described
-        // in github.com/rojo-rbx/rojo/issues/628.
+        // in rbx-dom that causes pivots to not build to file correctly, described in
+        // github.com/rojo-rbx/rojo/issues/628.
         //
         // We need to insert the NeedsPivotMigration property with a value of false on
         // every instance that inherits from Model for pivots to build correctly.


### PR DESCRIPTION
This PR closes #628 by adding a change to the 7.4.x branch that inserts `Model.NeedsPivotMigration` when it's missing from any instance that inherits from `Model`.

This is a pretty poor solution, but this bug needs to be fixed for 7.4.1 and the scope of the work in rojo-rbx/rbx-dom#385 (which when closed, will properly fix the underlying problem) is a little too large to comfortably fit into 7.4.1. 

Please make sure I got all the classes, and of course test the changes (I did confirm that they work myself, but it's good to have more sets of eyes)