### PR TITLE
Make the `name` field in projects optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Rojo Changelog
 
 ## Unreleased Changes
-* Made the `name` field optional on project files when they are not the top-level project ([#870])
+* Made the `name` field optional on project files ([#870])
  	Files named `default.project.json` inherit the name of the folder they're in and all other projects
     are named as expect (e.g. `foo.project.json` becomes an Instance named `foo`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Rojo Changelog
 
 ## Unreleased Changes
+* Made the `name` field optional on project files when they are not the top-level project ([#870])
+ 	Files named `default.project.json` inherit the name of the folder they're in and all other projects
+    are named as expect (e.g. `foo.project.json` becomes an Instance named `foo`)
+
+    There is no change in behavior if `name` is set.
 * Fixed incorrect results when serving model pivots ([#868])
 * Rojo now converts any line endings to LF, preventing spurious diffs when syncing Lua files on Windows ([#854])
 * Fixed Rojo plugin failing to connect when project contains certain unreadable properties ([#848])
@@ -63,6 +68,7 @@
 [#848]: https://github.com/rojo-rbx/rojo/pull/848
 [#854]: https://github.com/rojo-rbx/rojo/pull/854
 [#868]: https://github.com/rojo-rbx/rojo/pull/868
+[#870]: https://github.com/rojo-rbx/rojo/pull/870
 
 
 ## [7.4.0] - January 16, 2024

--- a/rojo-test/build-test-snapshots/end_to_end__tests__build__no_name_default_project.snap
+++ b/rojo-test/build-test-snapshots/end_to_end__tests__build__no_name_default_project.snap
@@ -1,0 +1,22 @@
+---
+source: tests/tests/build.rs
+expression: contents
+---
+<roblox version="4">
+  <Item class="Folder" referent="0">
+    <Properties>
+      <string name="Name">top-level</string>
+    </Properties>
+    <Item class="Folder" referent="1">
+      <Properties>
+        <string name="Name">second-level</string>
+      </Properties>
+      <Item class="IntValue" referent="2">
+        <Properties>
+          <string name="Name">third-level</string>
+          <int64 name="Value">1337</int64>
+        </Properties>
+      </Item>
+    </Item>
+  </Item>
+</roblox>

--- a/rojo-test/build-test-snapshots/end_to_end__tests__build__no_name_project.snap
+++ b/rojo-test/build-test-snapshots/end_to_end__tests__build__no_name_project.snap
@@ -1,0 +1,22 @@
+---
+source: tests/tests/build.rs
+expression: contents
+---
+<roblox version="4">
+  <Item class="Folder" referent="0">
+    <Properties>
+      <string name="Name">no_name_project</string>
+    </Properties>
+    <Item class="Folder" referent="1">
+      <Properties>
+        <string name="Name">second-level</string>
+      </Properties>
+      <Item class="BoolValue" referent="2">
+        <Properties>
+          <string name="Name">bool_value</string>
+          <bool name="Value">true</bool>
+        </Properties>
+      </Item>
+    </Item>
+  </Item>
+</roblox>

--- a/rojo-test/build-test-snapshots/end_to_end__tests__build__no_name_top_level_project.snap
+++ b/rojo-test/build-test-snapshots/end_to_end__tests__build__no_name_top_level_project.snap
@@ -1,0 +1,13 @@
+---
+source: tests/tests/build.rs
+assertion_line: 107
+expression: contents
+---
+<roblox version="4">
+  <Item class="StringValue" referent="0">
+    <Properties>
+      <string name="Name">no_name_top_level_project</string>
+      <string name="Value">If this isn't named `no_name_top_level_project`, something went wrong!</string>
+    </Properties>
+  </Item>
+</roblox>

--- a/rojo-test/build-tests/no_name_default_project/default.project.json
+++ b/rojo-test/build-tests/no_name_default_project/default.project.json
@@ -1,0 +1,9 @@
+{
+  "name": "top-level",
+  "tree": {
+    "$className": "Folder",
+    "second-level": {
+      "$path": "src"
+    }
+  }
+}

--- a/rojo-test/build-tests/no_name_default_project/src/third-level/default.project.json
+++ b/rojo-test/build-tests/no_name_default_project/src/third-level/default.project.json
@@ -1,0 +1,8 @@
+{
+  "tree": {
+    "$className": "IntValue",
+    "$properties": {
+      "Value": 1337
+    }
+  }
+}

--- a/rojo-test/build-tests/no_name_project/default.project.json
+++ b/rojo-test/build-tests/no_name_project/default.project.json
@@ -1,0 +1,9 @@
+{
+  "name": "no_name_project",
+  "tree": {
+    "$className": "Folder",
+    "second-level": {
+      "$path": "src"
+    }
+  }
+}

--- a/rojo-test/build-tests/no_name_project/src/bool_value.project.json
+++ b/rojo-test/build-tests/no_name_project/src/bool_value.project.json
@@ -1,0 +1,8 @@
+{
+  "tree": {
+    "$className": "BoolValue",
+    "$properties": {
+      "Value": true
+    }
+  }
+}

--- a/rojo-test/build-tests/no_name_top_level_project/default.project.json
+++ b/rojo-test/build-tests/no_name_top_level_project/default.project.json
@@ -1,0 +1,8 @@
+{
+  "tree": {
+    "$className": "StringValue",
+    "$properties": {
+      "Value": "If this isn't named `no_name_top_level_project`, something went wrong!"
+    }
+  }
+}

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__no_name_default_project_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__no_name_default_project_all.snap
@@ -1,0 +1,39 @@
+---
+source: tests/tests/serve.rs
+expression: "read_response.intern_and_redact(&mut redactions, root_id)"
+---
+instances:
+  id-2:
+    Children:
+      - id-3
+    ClassName: Folder
+    Id: id-2
+    Metadata:
+      ignoreUnknownInstances: true
+    Name: top-level
+    Parent: "00000000000000000000000000000000"
+    Properties: {}
+  id-3:
+    Children:
+      - id-4
+    ClassName: Folder
+    Id: id-3
+    Metadata:
+      ignoreUnknownInstances: false
+    Name: second-level
+    Parent: id-2
+    Properties: {}
+  id-4:
+    Children: []
+    ClassName: IntValue
+    Id: id-4
+    Metadata:
+      ignoreUnknownInstances: true
+    Name: third-level
+    Parent: id-3
+    Properties:
+      Value:
+        Int64: 1337
+messageCursor: 0
+sessionId: id-1
+

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__no_name_default_project_info.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__no_name_default_project_info.snap
@@ -1,0 +1,14 @@
+---
+source: tests/tests/serve.rs
+assertion_line: 316
+expression: redactions.redacted_yaml(info)
+---
+expectedPlaceIds: ~
+gameId: ~
+placeId: ~
+projectName: top-level
+protocolVersion: 4
+rootInstanceId: id-2
+serverVersion: "[server-version]"
+sessionId: id-1
+

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__no_name_project_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__no_name_project_all.snap
@@ -1,0 +1,40 @@
+---
+source: tests/tests/serve.rs
+assertion_line: 338
+expression: "read_response.intern_and_redact(&mut redactions, root_id)"
+---
+instances:
+  id-2:
+    Children:
+      - id-3
+    ClassName: Folder
+    Id: id-2
+    Metadata:
+      ignoreUnknownInstances: true
+    Name: no_name_project
+    Parent: "00000000000000000000000000000000"
+    Properties: {}
+  id-3:
+    Children:
+      - id-4
+    ClassName: Folder
+    Id: id-3
+    Metadata:
+      ignoreUnknownInstances: false
+    Name: second-level
+    Parent: id-2
+    Properties: {}
+  id-4:
+    Children: []
+    ClassName: BoolValue
+    Id: id-4
+    Metadata:
+      ignoreUnknownInstances: true
+    Name: bool_value
+    Parent: id-3
+    Properties:
+      Value:
+        Bool: true
+messageCursor: 0
+sessionId: id-1
+

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__no_name_project_info.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__no_name_project_info.snap
@@ -1,0 +1,14 @@
+---
+source: tests/tests/serve.rs
+assertion_line: 335
+expression: redactions.redacted_yaml(info)
+---
+expectedPlaceIds: ~
+gameId: ~
+placeId: ~
+projectName: no_name_project
+protocolVersion: 4
+rootInstanceId: id-2
+serverVersion: "[server-version]"
+sessionId: id-1
+

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__no_name_top_level_project_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__no_name_top_level_project_all.snap
@@ -1,0 +1,20 @@
+---
+source: tests/tests/serve.rs
+assertion_line: 357
+expression: "read_response.intern_and_redact(&mut redactions, root_id)"
+---
+instances:
+  id-2:
+    Children: []
+    ClassName: StringValue
+    Id: id-2
+    Metadata:
+      ignoreUnknownInstances: true
+    Name: no_name_top_level_project
+    Parent: "00000000000000000000000000000000"
+    Properties:
+      Value:
+        String: "If this isn't named `no_name_top_level_project`, something went wrong!"
+messageCursor: 0
+sessionId: id-1
+

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__no_name_top_level_project_info.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__no_name_top_level_project_info.snap
@@ -1,0 +1,14 @@
+---
+source: tests/tests/serve.rs
+assertion_line: 351
+expression: redactions.redacted_yaml(info)
+---
+expectedPlaceIds: ~
+gameId: ~
+placeId: ~
+projectName: no_name_top_level_project
+protocolVersion: 4
+rootInstanceId: id-2
+serverVersion: "[server-version]"
+sessionId: id-1
+

--- a/rojo-test/serve-tests/no_name_default_project/default.project.json
+++ b/rojo-test/serve-tests/no_name_default_project/default.project.json
@@ -1,0 +1,9 @@
+{
+  "name": "top-level",
+  "tree": {
+    "$className": "Folder",
+    "second-level": {
+      "$path": "src"
+    }
+  }
+}

--- a/rojo-test/serve-tests/no_name_default_project/src/third-level/default.project.json
+++ b/rojo-test/serve-tests/no_name_default_project/src/third-level/default.project.json
@@ -1,0 +1,8 @@
+{
+  "tree": {
+    "$className": "IntValue",
+    "$properties": {
+      "Value": 1337
+    }
+  }
+}

--- a/rojo-test/serve-tests/no_name_project/default.project.json
+++ b/rojo-test/serve-tests/no_name_project/default.project.json
@@ -1,0 +1,9 @@
+{
+  "name": "no_name_project",
+  "tree": {
+    "$className": "Folder",
+    "second-level": {
+      "$path": "src"
+    }
+  }
+}

--- a/rojo-test/serve-tests/no_name_project/src/bool_value.project.json
+++ b/rojo-test/serve-tests/no_name_project/src/bool_value.project.json
@@ -1,0 +1,8 @@
+{
+  "tree": {
+    "$className": "BoolValue",
+    "$properties": {
+      "Value": true
+    }
+  }
+}

--- a/rojo-test/serve-tests/no_name_top_level_project/default.project.json
+++ b/rojo-test/serve-tests/no_name_top_level_project/default.project.json
@@ -1,0 +1,8 @@
+{
+  "tree": {
+    "$className": "StringValue",
+    "$properties": {
+      "Value": "If this isn't named `no_name_top_level_project`, something went wrong!"
+    }
+  }
+}

--- a/src/project.rs
+++ b/src/project.rs
@@ -39,7 +39,7 @@ enum Error {
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct Project {
     /// The name of the top-level instance described by the project.
-    pub name: String,
+    pub name: Option<String>,
 
     /// The tree of instances described by this project. Projects always
     /// describe at least one instance.

--- a/src/serve_session.rs
+++ b/src/serve_session.rs
@@ -110,7 +110,7 @@ impl ServeSession {
 
         log::debug!("Loading project file from {}", project_path.display());
 
-        let root_project = match vfs.read(&project_path).with_not_found()? {
+        let mut root_project = match vfs.read(&project_path).with_not_found()? {
             Some(contents) => Project::load_from_slice(&contents, &project_path)?,
             None => {
                 return Err(ServeSessionError::NoProjectFound {
@@ -119,8 +119,34 @@ impl ServeSession {
             }
         };
         if root_project.name.is_none() {
-            return Err(ServeSessionError::NoProjectName);
+            if let Some(file_name) = project_path.file_name().and_then(|s| s.to_str()) {
+                if file_name == "default.project.json" {
+                    let folder_name = project_path
+                        .parent()
+                        .and_then(Path::file_name)
+                        .and_then(|s| s.to_str());
+                    if let Some(folder_name) = folder_name {
+                        root_project.name = Some(folder_name.to_string());
+                    } else {
+                        return Err(ServeSessionError::FolderNameInvalid {
+                            path: project_path.to_path_buf(),
+                        });
+                    }
+                } else if let Some(trimmed) = file_name.strip_suffix(".project.json") {
+                    root_project.name = Some(trimmed.to_string());
+                } else {
+                    return Err(ServeSessionError::ProjectNameInvalid {
+                        path: project_path.to_path_buf(),
+                    });
+                }
+            } else {
+                return Err(ServeSessionError::ProjectNameInvalid {
+                    path: project_path.to_path_buf(),
+                });
+            }
         }
+        // Rebind it to make it no longer mutable
+        let root_project = root_project;
 
         let mut tree = RojoTree::new(InstanceSnapshot::new());
 
@@ -237,8 +263,13 @@ pub enum ServeSessionError {
     )]
     NoProjectFound { path: PathBuf },
 
-    #[error("Rojo requires the top-level project file to have the 'name' field set.")]
-    NoProjectName,
+    #[error("The folder for the provided project cannot be used as a project name: {}\n\
+            Consider setting the `name` field on this project.", .path.display())]
+    FolderNameInvalid { path: PathBuf },
+
+    #[error("The file name of the provided project cannot be used as a project name: {}.\n\
+            Consider setting the `name` field on this project.", .path.display())]
+    ProjectNameInvalid { path: PathBuf },
 
     #[error(transparent)]
     Io {

--- a/src/serve_session.rs
+++ b/src/serve_session.rs
@@ -118,6 +118,9 @@ impl ServeSession {
                 });
             }
         };
+        if root_project.name.is_none() {
+            return Err(ServeSessionError::NoProjectName);
+        }
 
         let mut tree = RojoTree::new(InstanceSnapshot::new());
 
@@ -190,7 +193,10 @@ impl ServeSession {
     }
 
     pub fn project_name(&self) -> &str {
-        &self.root_project.name
+        self.root_project
+            .name
+            .as_ref()
+            .expect("all top-level projects must have their name set")
     }
 
     pub fn project_port(&self) -> Option<u16> {
@@ -230,6 +236,9 @@ pub enum ServeSessionError {
         .path.display()
     )]
     NoProjectFound { path: PathBuf },
+
+    #[error("Rojo requires the top-level project file to have the 'name' field set.")]
+    NoProjectName,
 
     #[error(transparent)]
     Io {

--- a/src/snapshot_middleware/mod.rs
+++ b/src/snapshot_middleware/mod.rs
@@ -66,7 +66,14 @@ pub fn snapshot_from_vfs(
             for rule in default_sync_rules() {
                 if rule.matches(&init_path) {
                     return match rule.middleware {
-                        Middleware::Project => snapshot_project(context, vfs, &init_path),
+                        Middleware::Project => {
+                            let name = init_path
+                                .parent()
+                                .and_then(Path::parent)
+                                .and_then(Path::file_name)
+                                .and_then(|s| s.to_str()).expect("default.project.json should be inside a folder with a unicode name");
+                            snapshot_project(context, vfs, &init_path, name)
+                        }
 
                         Middleware::ModuleScript => {
                             snapshot_lua_init(context, vfs, &init_path, ScriptType::Module)
@@ -218,9 +225,7 @@ impl Middleware {
             Self::ServerScript => snapshot_lua(context, vfs, path, name, ScriptType::Server),
             Self::ClientScript => snapshot_lua(context, vfs, path, name, ScriptType::Client),
             Self::ModuleScript => snapshot_lua(context, vfs, path, name, ScriptType::Module),
-            // At the moment, snapshot_project does not use `name` so we
-            // don't provide it.
-            Self::Project => snapshot_project(context, vfs, path),
+            Self::Project => snapshot_project(context, vfs, path, name),
             Self::Rbxm => snapshot_rbxm(context, vfs, path, name),
             Self::Rbxmx => snapshot_rbxmx(context, vfs, path, name),
             Self::Toml => snapshot_toml(context, vfs, path, name),
@@ -280,8 +285,7 @@ fn default_sync_rules() -> &'static [SyncRule] {
             sync_rule!("*.client.lua", ClientScript, ".client.lua"),
             sync_rule!("*.client.luau", ClientScript, ".client.luau"),
             sync_rule!("*.{lua,luau}", ModuleScript),
-            // Project middleware doesn't use the file name.
-            sync_rule!("*.project.json", Project),
+            sync_rule!("*.project.json", Project, ".project.json"),
             sync_rule!("*.model.json", JsonModel, ".model.json"),
             sync_rule!("*.json", Json, ".json", "*.meta.json"),
             sync_rule!("*.toml", Toml),

--- a/src/snapshot_middleware/mod.rs
+++ b/src/snapshot_middleware/mod.rs
@@ -69,7 +69,6 @@ pub fn snapshot_from_vfs(
                         Middleware::Project => {
                             let name = init_path
                                 .parent()
-                                .and_then(Path::parent)
                                 .and_then(Path::file_name)
                                 .and_then(|s| s.to_str()).expect("default.project.json should be inside a folder with a unicode name");
                             snapshot_project(context, vfs, &init_path, name)

--- a/src/snapshot_middleware/project.rs
+++ b/src/snapshot_middleware/project.rs
@@ -19,9 +19,11 @@ pub fn snapshot_project(
     context: &InstanceContext,
     vfs: &Vfs,
     path: &Path,
+    name: &str,
 ) -> anyhow::Result<Option<InstanceSnapshot>> {
     let project = Project::load_from_slice(&vfs.read(path)?, path)
         .with_context(|| format!("File was not a valid Rojo project: {}", path.display()))?;
+    let project_name = project.name.as_deref().unwrap_or(name);
 
     let mut context = context.clone();
     context.clear_sync_rules();
@@ -45,7 +47,7 @@ pub fn snapshot_project(
             .unwrap(),
     );
 
-    match snapshot_project_node(&context, path, &project.name, &project.tree, vfs, None)? {
+    match snapshot_project_node(&context, path, project_name, &project.tree, vfs, None)? {
         Some(found_snapshot) => {
             let mut snapshot = found_snapshot;
             // Setting the instigating source to the project file path is a little
@@ -354,12 +356,16 @@ mod test {
         )
         .unwrap();
 
-        let mut vfs = Vfs::new(imfs);
+        let vfs = Vfs::new(imfs);
 
-        let instance_snapshot =
-            snapshot_project(&InstanceContext::default(), &mut vfs, Path::new("/foo"))
-                .expect("snapshot error")
-                .expect("snapshot returned no instances");
+        let instance_snapshot = snapshot_project(
+            &InstanceContext::default(),
+            &vfs,
+            Path::new("/foo"),
+            "NOT_IN_SNAPSHOT",
+        )
+        .expect("snapshot error")
+        .expect("snapshot returned no instances");
 
         insta::assert_yaml_snapshot!(instance_snapshot);
     }
@@ -384,12 +390,13 @@ mod test {
         )
         .unwrap();
 
-        let mut vfs = Vfs::new(imfs);
+        let vfs = Vfs::new(imfs);
 
         let instance_snapshot = snapshot_project(
             &InstanceContext::default(),
-            &mut vfs,
+            &vfs,
             Path::new("/foo/hello.project.json"),
+            "NOT_IN_SNAPSHOT",
         )
         .expect("snapshot error")
         .expect("snapshot returned no instances");
@@ -422,12 +429,13 @@ mod test {
         )
         .unwrap();
 
-        let mut vfs = Vfs::new(imfs);
+        let vfs = Vfs::new(imfs);
 
         let instance_snapshot = snapshot_project(
             &InstanceContext::default(),
-            &mut vfs,
+            &vfs,
             Path::new("/foo.project.json"),
+            "NOT_IN_SNAPSHOT",
         )
         .expect("snapshot error")
         .expect("snapshot returned no instances");
@@ -458,12 +466,13 @@ mod test {
         )
         .unwrap();
 
-        let mut vfs = Vfs::new(imfs);
+        let vfs = Vfs::new(imfs);
 
         let instance_snapshot = snapshot_project(
             &InstanceContext::default(),
-            &mut vfs,
+            &vfs,
             Path::new("/foo.project.json"),
+            "NOT_IN_SNAPSHOT",
         )
         .expect("snapshot error")
         .expect("snapshot returned no instances");
@@ -495,12 +504,13 @@ mod test {
         )
         .unwrap();
 
-        let mut vfs = Vfs::new(imfs);
+        let vfs = Vfs::new(imfs);
 
         let instance_snapshot = snapshot_project(
             &InstanceContext::default(),
-            &mut vfs,
+            &vfs,
             Path::new("/foo.project.json"),
+            "NOT_IN_SNAPSHOT",
         )
         .expect("snapshot error")
         .expect("snapshot returned no instances");
@@ -529,12 +539,13 @@ mod test {
         )
         .unwrap();
 
-        let mut vfs = Vfs::new(imfs);
+        let vfs = Vfs::new(imfs);
 
         let instance_snapshot = snapshot_project(
             &InstanceContext::default(),
-            &mut vfs,
+            &vfs,
             Path::new("/foo/default.project.json"),
+            "NOT_IN_SNAPSHOT",
         )
         .expect("snapshot error")
         .expect("snapshot returned no instances");
@@ -570,12 +581,13 @@ mod test {
         )
         .unwrap();
 
-        let mut vfs = Vfs::new(imfs);
+        let vfs = Vfs::new(imfs);
 
         let instance_snapshot = snapshot_project(
             &InstanceContext::default(),
-            &mut vfs,
+            &vfs,
             Path::new("/foo/default.project.json"),
+            "NOT_IN_SNAPSHOT",
         )
         .expect("snapshot error")
         .expect("snapshot returned no instances");
@@ -615,12 +627,13 @@ mod test {
         )
         .unwrap();
 
-        let mut vfs = Vfs::new(imfs);
+        let vfs = Vfs::new(imfs);
 
         let instance_snapshot = snapshot_project(
             &InstanceContext::default(),
-            &mut vfs,
+            &vfs,
             Path::new("/foo/default.project.json"),
+            "NOT_IN_SNAPSHOT",
         )
         .expect("snapshot error")
         .expect("snapshot returned no instances");
@@ -665,12 +678,46 @@ mod test {
         )
         .unwrap();
 
-        let mut vfs = Vfs::new(imfs);
+        let vfs = Vfs::new(imfs);
 
         let instance_snapshot = snapshot_project(
             &InstanceContext::default(),
-            &mut vfs,
+            &vfs,
             Path::new("/foo/default.project.json"),
+            "NOT_IN_SNAPSHOT",
+        )
+        .expect("snapshot error")
+        .expect("snapshot returned no instances");
+
+        insta::assert_yaml_snapshot!(instance_snapshot);
+    }
+
+    #[test]
+    fn no_name_project() {
+        let _ = env_logger::try_init();
+
+        let mut imfs = InMemoryFs::new();
+        imfs.load_snapshot(
+            "/foo",
+            VfsSnapshot::dir(hashmap! {
+                "default.project.json" => VfsSnapshot::file(r#"
+                    {
+                        "tree": {
+                            "$className": "Model"
+                        }
+                    }
+                "#),
+            }),
+        )
+        .unwrap();
+
+        let vfs = Vfs::new(imfs);
+
+        let instance_snapshot = snapshot_project(
+            &InstanceContext::default(),
+            &vfs,
+            Path::new("/foo/default.project.json"),
+            "no_name_project",
         )
         .expect("snapshot error")
         .expect("snapshot returned no instances");

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__no_name_project.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__no_name_project.snap
@@ -1,0 +1,19 @@
+---
+source: src/snapshot_middleware/project.rs
+assertion_line: 725
+expression: instance_snapshot
+---
+snapshot_id: "00000000000000000000000000000000"
+metadata:
+  ignore_unknown_instances: true
+  instigating_source:
+    Path: /foo/default.project.json
+  relevant_paths:
+    - /foo/default.project.json
+  context:
+    emit_legacy_scripts: true
+name: no_name_project
+class_name: Model
+properties: {}
+children: []
+

--- a/tests/tests/build.rs
+++ b/tests/tests/build.rs
@@ -62,6 +62,8 @@ gen_build_tests! {
     sync_rule_alone,
     sync_rule_complex,
     sync_rule_nested_projects,
+    no_name_default_project,
+    no_name_project,
 }
 
 fn run_build_test(test_name: &str) {
@@ -73,7 +75,7 @@ fn run_build_test(test_name: &str) {
     let output_path = output_dir.path().join(format!("{}.rbxmx", test_name));
 
     let output = Command::new(ROJO_PATH)
-        .args(&[
+        .args([
             "build",
             input_path.to_str().unwrap(),
             "-o",

--- a/tests/tests/build.rs
+++ b/tests/tests/build.rs
@@ -64,6 +64,7 @@ gen_build_tests! {
     sync_rule_nested_projects,
     no_name_default_project,
     no_name_project,
+    no_name_top_level_project,
 }
 
 fn run_build_test(test_name: &str) {

--- a/tests/tests/serve.rs
+++ b/tests/tests/serve.rs
@@ -306,3 +306,38 @@ fn sync_rule_no_extension() {
         );
     });
 }
+
+#[test]
+fn no_name_default_project() {
+    run_serve_test("no_name_default_project", |session, mut redactions| {
+        let info = session.get_api_rojo().unwrap();
+        let root_id = info.root_instance_id;
+
+        assert_yaml_snapshot!(
+            "no_name_default_project_info",
+            redactions.redacted_yaml(info)
+        );
+
+        let read_response = session.get_api_read(root_id).unwrap();
+        assert_yaml_snapshot!(
+            "no_name_default_project_all",
+            read_response.intern_and_redact(&mut redactions, root_id)
+        );
+    });
+}
+
+#[test]
+fn no_name_project() {
+    run_serve_test("no_name_project", |session, mut redactions| {
+        let info = session.get_api_rojo().unwrap();
+        let root_id = info.root_instance_id;
+
+        assert_yaml_snapshot!("no_name_project_info", redactions.redacted_yaml(info));
+
+        let read_response = session.get_api_read(root_id).unwrap();
+        assert_yaml_snapshot!(
+            "no_name_project_all",
+            read_response.intern_and_redact(&mut redactions, root_id)
+        );
+    });
+}

--- a/tests/tests/serve.rs
+++ b/tests/tests/serve.rs
@@ -341,3 +341,22 @@ fn no_name_project() {
         );
     });
 }
+
+#[test]
+fn no_name_top_level_project() {
+    run_serve_test("no_name_top_level_project", |session, mut redactions| {
+        let info = session.get_api_rojo().unwrap();
+        let root_id = info.root_instance_id;
+
+        assert_yaml_snapshot!(
+            "no_name_top_level_project_info",
+            redactions.redacted_yaml(info)
+        );
+
+        let read_response = session.get_api_read(root_id).unwrap();
+        assert_yaml_snapshot!(
+            "no_name_top_level_project_all",
+            read_response.intern_and_redact(&mut redactions, root_id)
+        );
+    });
+}


### PR DESCRIPTION
Closes #858.

If a project is named `default.project.json`, it acts as an `init` file and gains the name of the folder it's inside of. If it is named something other than `default.project.json`, it gains the name of the file with `.project.json` trimmed off. So e.g. `foo.project.json` becomes `foo`.