### PR TITLE
Build tree ancestry correctly

### DIFF
--- a/plugin/src/PatchTree.lua
+++ b/plugin/src/PatchTree.lua
@@ -163,8 +163,7 @@ function Tree:buildAncestryNodes(previousId: string?, ancestryIds: { string }, p
 	-- Build nodes for ancestry by going up the tree
 	previousId = previousId or "ROOT"
 
-	for i = #ancestryIds, 1, -1 do
-		local ancestorId = ancestryIds[i]
+	for _, ancestorId in ancestryIds do
 		local value = instanceMap.fromIds[ancestorId] or patch.added[ancestorId]
 		if not value then
 			Log.warn("Failed to find ancestor object for " .. ancestorId)
@@ -200,7 +199,7 @@ function PatchTree.build(patch, instanceMap, changeListHeaders)
 		end
 
 		-- Gather ancestors from existing DOM
-		local ancestryIds, ancestryIndex = {}, 0
+		local ancestryIds = {}
 		local parentObject = instance.Parent
 		local parentId = instanceMap.fromInstances[parentObject]
 		local previousId = nil
@@ -211,8 +210,7 @@ function PatchTree.build(patch, instanceMap, changeListHeaders)
 				break
 			end
 
-			ancestryIndex += 1
-			ancestryIds[ancestryIndex] = parentId
+			table.insert(ancestryIds, 1, parentId)
 			knownAncestors[parentId] = true
 			parentObject = parentObject.Parent
 			parentId = instanceMap.fromInstances[parentObject]


### PR DESCRIPTION
I really screwed this one up. Don't know how I managed that.

Tree was being built out of order, but only for some change types. This meant that some changes built a good tree, some built an upside down one. I suppose that's how it slipped past us.