### PR TITLE
Use GuiState instead of manual calculation for tooltips

### DIFF
--- a/plugin/src/App/Components/Tooltip.lua
+++ b/plugin/src/App/Components/Tooltip.lua
@@ -195,14 +195,7 @@ end
 function Trigger:isHovering()
 	local rbx = self.ref.current
 	if rbx then
-		local pos = rbx.AbsolutePosition
-		local size = rbx.AbsoluteSize
-		local mousePos = self.mousePos
-
-		return mousePos.X >= pos.X
-			and mousePos.X <= pos.X + size.X
-			and mousePos.Y >= pos.Y
-			and mousePos.Y <= pos.Y + size.Y
+		return rbx.GuiState == Enum.GuiState.Hover
 	end
 	return false
 end
@@ -215,6 +208,14 @@ function Trigger:managePopup()
 		end
 
 		self.showDelayThread = task.delay(DELAY, function()
+			local rbx = self.ref.current
+			if rbx then
+				local widget = rbx:FindFirstAncestorOfClass("DockWidgetPluginGui")
+				if widget then
+					self.mousePos = widget:GetRelativeMousePosition()
+				end
+			end
+
 			self.props.context.addTip(self.id, {
 				Text = self.props.text,
 				Position = self.mousePos,
@@ -234,13 +235,7 @@ function Trigger:managePopup()
 end
 
 function Trigger:render()
-	local function recalculate(rbx)
-		local widget = rbx:FindFirstAncestorOfClass("DockWidgetPluginGui")
-		if not widget then
-			return
-		end
-		self.mousePos = widget:GetRelativeMousePosition()
-
+	local function recalculate()
 		self:managePopup()
 	end
 
@@ -250,11 +245,9 @@ function Trigger:render()
 		ZIndex = self.props.zIndex or 100,
 		[Roact.Ref] = self.ref,
 
+		[Roact.Change.GuiState] = recalculate,
 		[Roact.Change.AbsolutePosition] = recalculate,
 		[Roact.Change.AbsoluteSize] = recalculate,
-		[Roact.Event.MouseMoved] = recalculate,
-		[Roact.Event.MouseLeave] = recalculate,
-		[Roact.Event.MouseEnter] = recalculate,
 	})
 end
 

--- a/plugin/src/App/Components/Tooltip.lua
+++ b/plugin/src/App/Components/Tooltip.lua
@@ -163,7 +163,6 @@ local Trigger = Roact.Component:extend("TooltipTrigger")
 function Trigger:init()
 	self.id = HttpService:GenerateGUID(false)
 	self.ref = Roact.createRef()
-	self.mousePos = Vector2.zero
 	self.showingPopup = false
 
 	self.destroy = function()
@@ -200,6 +199,17 @@ function Trigger:isHovering()
 	return false
 end
 
+function Trigger:getMousePos()
+	local rbx = self.ref.current
+	if rbx then
+		local widget = rbx:FindFirstAncestorOfClass("DockWidgetPluginGui")
+		if widget then
+			return widget:GetRelativeMousePosition()
+		end
+	end
+	return Vector2.zero
+end
+
 function Trigger:managePopup()
 	if self:isHovering() then
 		if self.showingPopup or self.showDelayThread then
@@ -208,17 +218,9 @@ function Trigger:managePopup()
 		end
 
 		self.showDelayThread = task.delay(DELAY, function()
-			local rbx = self.ref.current
-			if rbx then
-				local widget = rbx:FindFirstAncestorOfClass("DockWidgetPluginGui")
-				if widget then
-					self.mousePos = widget:GetRelativeMousePosition()
-				end
-			end
-
 			self.props.context.addTip(self.id, {
 				Text = self.props.text,
-				Position = self.mousePos,
+				Position = self:getMousePos(),
 				Trigger = self.ref,
 			})
 			self.showDelayThread = nil


### PR DESCRIPTION
This ends up being more reliable and less wasteful. GuiState seems to update more reliably than MouseEnter/Leave.
The alternative way to make this more reliable would be to run our manual mouse bounds check every frame, which I'd like to avoid.