### PR TITLE
Trim plugin version string

### DIFF
--- a/plugin/src/Config.lua
+++ b/plugin/src/Config.lua
@@ -3,7 +3,8 @@ local strict = require(script.Parent.strict)
 local isDevBuild = script.Parent.Parent:FindFirstChild("ROJO_DEV_BUILD") ~= nil
 
 local Version = script.Parent.Parent.Version
-local major, minor, patch, metadata = Version.Value:match("^(%d+)%.(%d+)%.(%d+)(.*)$")
+local trimmedVersionValue = Version.Value:gsub("^%s+", ""):gsub("%s+$", "")
+local major, minor, patch, metadata = trimmedVersionValue:match("^(%d+)%.(%d+)%.(%d+)(.*)$")
 
 local realVersion = { major, minor, patch, metadata }
 for i = 1, 3 do


### PR DESCRIPTION
Duplicate of https://github.com/rojo-rbx/rojo/pull/889, but based on master as per request.

This PR is a very small change that fixes the string pattern that reads the rojo version from `Version.txt`. Currently this reads an extra new-line character which makes reading the version text in the plugin difficult.

It seems the rust side of things already trims the string when comparing, but the lua side does not.

Current:
![pO6gtOXAZq](https://github.com/rojo-rbx/rojo/assets/6201941/1a03fced-f2b5-4a4e-a82d-e11fb0a52af7)

Fix:
![RobloxStudioBeta_GHmiJKAoa3](https://github.com/rojo-rbx/rojo/assets/6201941/3ce711df-fdc6-4f20-8771-5f5118ee013f)

Apologies if I skipped over some process of submitting a bug and / or am basing on the wrong branch etc.