### PR TITLE
Release memofs 0.3.0, bump Rojo dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,7 +1063,7 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memofs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "crossbeam-channel",
  "fs-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ name = "build"
 harness = false
 
 [dependencies]
-memofs = { version = "0.2.0", path = "crates/memofs" }
+memofs = { version = "0.3.0", path = "crates/memofs" }
 
 # These dependencies can be uncommented when working on rbx-dom simultaneously
 # rbx_binary = { path = "../rbx-dom/rbx_binary" }
@@ -95,7 +95,7 @@ profiling = "1.0.15"
 winreg = "0.10.1"
 
 [build-dependencies]
-memofs = { version = "0.2.0", path = "crates/memofs" }
+memofs = { version = "0.3.0", path = "crates/memofs" }
 
 embed-resource = "1.8.0"
 anyhow = "1.0.80"

--- a/crates/memofs/CHANGELOG.md
+++ b/crates/memofs/CHANGELOG.md
@@ -1,6 +1,8 @@
 # memofs Changelog
 
 ## Unreleased Changes
+
+## 0.3.0 (2024-03-15)
 * Changed `StdBackend` file watching component to use minimal recursive watches. [#830]
 * Added `Vfs::read_to_string` and `Vfs::read_to_string_lf_normalized` [#854]
 

--- a/crates/memofs/Cargo.toml
+++ b/crates/memofs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "memofs"
 description = "Virtual filesystem with configurable backends."
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Lucien Greathouse <me@lpghatguy.com>"]
 edition = "2018"
 readme = "README.md"


### PR DESCRIPTION
This PR bumps memofs' version number to 0.3.0, and also updates Rojo's dependencies on memofs. This is necessary to have Rojo on crates.io actually contain the recent changes in memofs, because crates.io does not support path dependencies.

After this PR is merged, I'll tag the sqaush merge commit as `memofs-v0.3.0`. Then we should run `cargo publish` for memofs. Then, we should cherry pick this same commit onto the `7.4.x` branch, and make a new release for Rojo 7.4.2.