### PR TITLE
Use dtolnay/rust-toolchain and upgrade to checkout v4 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - master
-    - ci-workflow-maintenence
 
   pull_request:
     branches:
@@ -97,3 +96,4 @@ jobs:
 
     - name: Clippy
       run: cargo clippy
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - ci-workflow-maintenence
 
   pull_request:
     branches:
@@ -106,4 +107,3 @@ jobs:
 
     - name: Clippy
       run: cargo clippy
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,7 @@ jobs:
         submodules: true
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-        profile: minimal
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Rust cache
       uses: Swatinem/rust-cache@v2
@@ -55,11 +51,7 @@ jobs:
         submodules: true
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 1.70.0
-        override: true
-        profile: minimal
+      uses: dtolnay/rust-toolchain@1.70.0
 
     - name: Rust cache
       uses: Swatinem/rust-cache@v2
@@ -82,10 +74,8 @@ jobs:
         submodules: true
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        override: true
         components: rustfmt, clippy
 
     - name: Rust cache


### PR DESCRIPTION
This PR performs some routine maintenance on our CI workflow:

* Replaces `actions-rs/toolchain` with `dtolnay/rust-toolchain`. The actions at `actions-rs` are no longer maintained, and they use deprecated GitHub Actions APIs. dtolnay's action does not support the `override` option, but we didn't actually need to use it anyway. 
* Upgrades `actions/checkout` to v4, because v3 causes some warnings since it uses Node.js 16, which is deprecated.