### PR TITLE
Release workflow maintenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     name: Build Roblox Studio Plugin
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -89,7 +89,7 @@ jobs:
     env:
       BIN: rojo
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -101,12 +101,9 @@ jobs:
           echo "Version is: ${{ env.PROJECT_VERSION }}"
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          target: ${{ matrix.target }}
-          override: true
-          profile: minimal
+          targets: ${{ matrix.target }}
 
       - name: Setup Aftman
         uses: ok-nick/setup-aftman@v0.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,12 +91,12 @@ jobs:
         with:
           submodules: true
 
-      - name: Get Version from Tag
-        shell: bash
-        # https://github.community/t/how-to-get-just-the-tag-name/16241/7#M1027
-        run: |
-          echo "PROJECT_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
-          echo "Version is: ${{ env.PROJECT_VERSION }}"
+      - name: Get Version
+        uses: SebRollen/toml-action@v1.2.0
+        id: get_version
+        with:
+          file: Cargo.toml
+          field: package.version
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -139,11 +139,11 @@ jobs:
         with:
           upload_url: ${{ needs.create-release.outputs.upload_url }}
           asset_path: release.zip
-          asset_name: ${{ env.BIN }}-${{ env.PROJECT_VERSION }}-${{ matrix.label }}.zip
+          asset_name: ${{ env.BIN }}-${{ steps.get_version.outputs.value }}-${{ matrix.label }}.zip
           asset_content_type: application/octet-stream
 
       - name: Upload Archive to Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.BIN }}-${{ env.PROJECT_VERSION }}-${{ matrix.label }}.zip
+          name: ${{ env.BIN }}-${{ steps.get_version.outputs.value }}-${{ matrix.label }}.zip
           path: release.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,8 @@ jobs:
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - name: Create Release
-        id: create_release
         uses: softprops/action-gh-release@v2
         with:
           name: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,10 @@ jobs:
     steps:
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
+          name: ${{ github.ref_name }}
           tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
           draft: true
           prerelease: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,12 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          name: ${{ github.ref_name }}
-          tag_name: ${{ github.ref }}
-          draft: true
-          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.ref_name }} --draft --verify-tag --title ${{ github.ref_name }}
 
   build-plugin:
     needs: ["create-release"]
@@ -40,7 +39,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ github.ref }} Rojo.rbxm
+          gh release upload ${{ github.ref_name }} Rojo.rbxm
 
       - name: Upload Plugin to Artifacts
         uses: actions/upload-artifact@v4
@@ -127,7 +126,7 @@ jobs:
             zip ../$ARTIFACT_NAME *
           fi
 
-          gh release upload ${{ github.ref }} ../$ARTIFACT_NAME
+          gh release upload ${{ github.ref_name }} ../$ARTIFACT_NAME
 
       - name: Upload Archive to Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,13 +84,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Get Version
-        uses: SebRollen/toml-action@v1.2.0
-        id: get_version
-        with:
-          file: Cargo.toml
-          field: package.version
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -112,8 +105,10 @@ jobs:
 
       - name: Generate Artifact Name
         shell: bash
+        env:
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          echo "ARTIFACT_NAME=$BIN-${{ steps.get_version.outputs.value }}-${{ matrix.label }}.zip" >> "$GITHUB_ENV"
+          echo "ARTIFACT_NAME=$BIN-${TAG_NAME#v}-${{ matrix.label }}.zip" >> "$GITHUB_ENV"
 
       - name: Create Archive and Upload to Release
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,11 @@ jobs:
           # easily.
           CARGO_TARGET_DIR: output
 
+      - name: Generate Artifact Name
+        shell: bash
+        run: |
+          echo "ARTIFACT_NAME=$BIN-${{ steps.get_version.outputs.value }}-${{ matrix.label }}.zip" >> "$GITHUB_ENV"
+
       - name: Create Release Archive
         shell: bash
         run: |
@@ -125,11 +130,11 @@ jobs:
           if [ "${{ matrix.host }}" = "windows" ]; then
             cp "output/${{ matrix.target }}/release/$BIN.exe" staging/
             cd staging
-            7z a ../release.zip *
+            7z a ../$ARTIFACT_NAME *
           else
             cp "output/${{ matrix.target }}/release/$BIN" staging/
             cd staging
-            zip ../release.zip *
+            zip ../$ARTIFACT_NAME *
           fi
 
       - name: Upload Archive to Release
@@ -138,12 +143,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: release.zip
-          asset_name: ${{ env.BIN }}-${{ steps.get_version.outputs.value }}-${{ matrix.label }}.zip
+          asset_path: ${{ env.ARTIFACT_NAME }}
+          asset_name: ${{ env.ARTIFACT_NAME }}
           asset_content_type: application/octet-stream
 
       - name: Upload Archive to Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.BIN }}-${{ steps.get_version.outputs.value }}-${{ matrix.label }}.zip
+          name: ${{ env.ARTIFACT_NAME }}
           path: release.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           gh release upload ${{ github.ref }} Rojo.rbxm
 
       - name: Upload Plugin to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Rojo.rbxm
           path: Rojo.rbxm
@@ -138,7 +138,7 @@ jobs:
           gh release upload ${{ github.ref }} ../$ARTIFACT_NAME
 
       - name: Upload Archive to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ${{ env.ARTIFACT_NAME }}
           name: ${{ env.ARTIFACT_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,14 +40,10 @@ jobs:
         run: rojo build plugin --output Rojo.rbxm
 
       - name: Upload Plugin to Release
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: Rojo.rbxm
-          asset_name: Rojo.rbxm
-          asset_content_type: application/octet-stream
+        run: |
+          gh release upload ${{ github.ref }} Rojo.rbxm
 
       - name: Upload Plugin to Artifacts
         uses: actions/upload-artifact@v3
@@ -122,8 +118,10 @@ jobs:
         run: |
           echo "ARTIFACT_NAME=$BIN-${{ steps.get_version.outputs.value }}-${{ matrix.label }}.zip" >> "$GITHUB_ENV"
 
-      - name: Create Release Archive
+      - name: Create Archive and Upload to Release
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir staging
 
@@ -137,18 +135,10 @@ jobs:
             zip ../$ARTIFACT_NAME *
           fi
 
-      - name: Upload Archive to Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ${{ env.ARTIFACT_NAME }}
-          asset_name: ${{ env.ARTIFACT_NAME }}
-          asset_content_type: application/octet-stream
+          gh release upload ${{ github.ref }} ../$ARTIFACT_NAME
 
       - name: Upload Archive to Artifacts
         uses: actions/upload-artifact@v3
         with:
+          path: ${{ env.ARTIFACT_NAME }}
           name: ${{ env.ARTIFACT_NAME }}
-          path: release.zip


### PR DESCRIPTION
This PR performs a number of relatively straightforward maintenance tasks and improvements for the "Release" workflow:

* Upgrades to actions/checkout@v4 and switches to dtolnay/rust-toolchain instead in favor of actions-rs/toolchain

    Reasoning is the same as #900 

* Switches to softprops/create-gh-release

    actions/create-release is unmaintained and has been archived for more than three years. 

    I considered using the GitHub CLI's (which is preinstalled on GitHub-hosted runners)`gh release create` to do this so we wouldn't have to pull in another third-party action, but it requires a checkout first - but doing this only adds a few more seconds before the release is created comapred to create-gh-release, so it may be acceptable?

* Switches to using preinstalled GitHub CLI to upload release archives

    There's absolutely no point in using a third party action for this, so we won't!

* Simplifies the and consolidates the way we generate names for release archives

Here's an example of the results of this workflow on my fork:
https://github.com/kennethloeffler/rojo/actions/runs/8642870695
https://github.com/kennethloeffler/rojo/releases/tag/v7.4.0-releasevvv-workflow-tewstingsbvv