### PR TITLE
Fix removing trailing newlines by using str::replace in memofs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Rojo Changelog
 
 ## Unreleased Changes
+* Fixed removing trailing newlines ([#903])
 * Added Never option to Confirmation ([#893])
 * Added popout diff visualizer for table properties like Attributes and Tags ([#834])
 * Updated Theme to use Studio colors ([#838])
@@ -59,6 +60,7 @@
 [#840]: https://github.com/rojo-rbx/rojo/pull/840
 [#883]: https://github.com/rojo-rbx/rojo/pull/883
 [#893]: https://github.com/rojo-rbx/rojo/pull/893
+[#903]: https://github.com/rojo-rbx/rojo/pull/903
 
 ## [7.4.1] - February 20, 2024
 * Made the `name` field optional on project files ([#870])


### PR DESCRIPTION
This PR closes #899 by changing the implementation of `Vfs::read_to_string_lf_normalized` to use `str::replace` to replace `\r\n` with `\n`, rather than joining the result of `str::lines`. 

This is also a small performance win because less work needs to be done when the file only contains LF line endings, and we never need to collect into an intermediate `Vec<&str>`.