### PR TITLE
Add publish job to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,3 +133,19 @@ jobs:
         with:
           path: ${{ env.ARTIFACT_NAME }}
           name: ${{ env.ARTIFACT_NAME }}
+
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run publish action
+        uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
This PR adds an additional job to the release workflow that publishes both memofs and rojo to crates.io, using https://github.com/katyo/publish-crates. For this job to work, we'll need to add a crates.io API token with the required access permissions for both memofs and Rojo to this repository's secrets.

I chose this action because it can publish all crates in a workspace in the right order, and performs several important consistency checks to ensure safety. 