### PR TITLE
Use msgpack for API

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "plugin/Packages/Highlighter"]
 	path = plugin/Packages/Highlighter
 	url = https://github.com/boatbomber/highlighter.git
+[submodule "plugin/Packages/msgpack-luau"]
+	path = plugin/Packages/msgpack-luau
+	url = https://github.com/cipharius/msgpack-luau

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "rmp"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9860a6cc38ed1da53456442089b4dfa35e7cedaa326df63017af88385e6b20"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
 dependencies = [
  "byteorder",
  "num-traits",
@@ -1730,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "rmp-serde"
-version = "1.1.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
 dependencies = [
  "byteorder",
  "rmp",
@@ -1786,6 +1786,7 @@ dependencies = [
  "rbx_xml",
  "reqwest",
  "ritz",
+ "rmp-serde",
  "roblox_install",
  "rojo-insta-ext",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ tokio = { version = "1.36.0", features = ["rt", "rt-multi-thread"] }
 uuid = { version = "1.7.0", features = ["v4", "serde"] }
 clap = { version = "3.2.25", features = ["derive"] }
 profiling = "1.0.15"
+rmp-serde = "1.3.0"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.10.1"

--- a/aftman.toml
+++ b/aftman.toml
@@ -1,5 +1,5 @@
 [tools]
-rojo = "rojo-rbx/rojo@7.3.0"
-selene = "Kampfkarren/selene@0.26.1"
-stylua = "JohnnyMorganz/stylua@0.18.2"
+rojo = "rojo-rbx/rojo@7.4.1"
+selene = "Kampfkarren/selene@0.27.1"
+stylua = "JohnnyMorganz/stylua@0.20.0"
 run-in-roblox = "rojo-rbx/run-in-roblox@0.3.0"

--- a/build.rs
+++ b/build.rs
@@ -26,6 +26,11 @@ fn snapshot_from_fs_path(path: &Path) -> io::Result<VfsSnapshot> {
                 continue;
             }
 
+            // Ignore images in msgpack-luau because they aren't UTF-8 encoded.
+            if file_name.ends_with(".png") {
+                continue;
+            }
+
             let child_snapshot = snapshot_from_fs_path(&entry.path())?;
             children.push((file_name, child_snapshot));
         }

--- a/plugin/http/Response.lua
+++ b/plugin/http/Response.lua
@@ -1,5 +1,7 @@
 local HttpService = game:GetService("HttpService")
 
+local msgpack = require(script.Parent.Parent.msgpack)
+
 local stringTemplate = [[
 Http.Response {
 	code: %d
@@ -29,6 +31,10 @@ end
 
 function Response:json()
 	return HttpService:JSONDecode(self.body)
+end
+
+function Response:msgpack()
+	return msgpack.decode(self.body)
 end
 
 return Response

--- a/plugin/src/ApiContext.lua
+++ b/plugin/src/ApiContext.lua
@@ -122,7 +122,7 @@ function ApiContext:connect()
 
 	return Http.get(url)
 		:andThen(rejectFailedRequests)
-		:andThen(Http.Response.json)
+		:andThen(Http.Response.msgpack)
 		:andThen(rejectWrongProtocolVersion)
 		:andThen(function(body)
 			assert(validateApiInfo(body))
@@ -140,7 +140,7 @@ end
 function ApiContext:read(ids)
 	local url = ("%s/api/read/%s"):format(self.__baseUrl, table.concat(ids, ","))
 
-	return Http.get(url):andThen(rejectFailedRequests):andThen(Http.Response.json):andThen(function(body)
+	return Http.get(url):andThen(rejectFailedRequests):andThen(Http.Response.msgpack):andThen(function(body)
 		if body.sessionId ~= self.__sessionId then
 			return Promise.reject("Server changed ID")
 		end
@@ -185,11 +185,14 @@ function ApiContext:write(patch)
 
 	body = Http.jsonEncode(body)
 
-	return Http.post(url, body):andThen(rejectFailedRequests):andThen(Http.Response.json):andThen(function(responseBody)
-		Log.info("Write response: {:?}", responseBody)
+	return Http.post(url, body)
+		:andThen(rejectFailedRequests)
+		:andThen(Http.Response.msgpack)
+		:andThen(function(responseBody)
+			Log.info("Write response: {:?}", responseBody)
 
-		return responseBody
-	end)
+			return responseBody
+		end)
 end
 
 function ApiContext:retrieveMessages()
@@ -214,7 +217,7 @@ function ApiContext:retrieveMessages()
 		end)
 	end
 
-	return sendRequest():andThen(rejectFailedRequests):andThen(Http.Response.json):andThen(function(body)
+	return sendRequest():andThen(rejectFailedRequests):andThen(Http.Response.msgpack):andThen(function(body)
 		if body.sessionId ~= self.__sessionId then
 			return Promise.reject("Server changed ID")
 		end
@@ -230,7 +233,7 @@ end
 function ApiContext:open(id)
 	local url = ("%s/api/open/%s"):format(self.__baseUrl, id)
 
-	return Http.post(url, ""):andThen(rejectFailedRequests):andThen(Http.Response.json):andThen(function(body)
+	return Http.post(url, ""):andThen(rejectFailedRequests):andThen(Http.Response.msgpack):andThen(function(body)
 		if body.sessionId ~= self.__sessionId then
 			return Promise.reject("Server changed ID")
 		end

--- a/plugin/watch-build.sh
+++ b/plugin/watch-build.sh
@@ -1,2 +1,2 @@
 # Continously build the rojo plugin into the local plugin directory on Windows
-rojo build plugin/default.project.json -o $LOCALAPPDATA/Roblox/Plugins/Rojo.rbxm --watch
+rojo build plugin/default.project.json -p Rojo.rbxm --watch

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -16,7 +16,7 @@ use crate::{
             SubscribeMessage, SubscribeResponse, WriteRequest, WriteResponse, PROTOCOL_VERSION,
             SERVER_VERSION,
         },
-        util::{json, json_ok},
+        util::{json, msgpack_ok},
     },
 };
 
@@ -58,7 +58,7 @@ impl ApiService {
         let tree = self.serve_session.tree();
         let root_instance_id = tree.get_root_id();
 
-        json_ok(&ServerInfoResponse {
+        msgpack_ok(&ServerInfoResponse {
             server_version: SERVER_VERSION.to_owned(),
             protocol_version: PROTOCOL_VERSION,
             session_id: self.serve_session.session_id(),
@@ -103,7 +103,7 @@ impl ApiService {
                     .map(|patch| SubscribeMessage::from_patch_update(&tree, patch))
                     .collect();
 
-                json_ok(SubscribeResponse {
+                msgpack_ok(SubscribeResponse {
                     session_id,
                     message_cursor,
                     messages: api_messages,
@@ -159,7 +159,7 @@ impl ApiService {
             })
             .unwrap();
 
-        json_ok(WriteResponse { session_id })
+        msgpack_ok(WriteResponse { session_id })
     }
 
     async fn handle_api_read(&self, request: Request<Body>) -> Response<Body> {
@@ -193,7 +193,7 @@ impl ApiService {
             }
         }
 
-        json_ok(ReadResponse {
+        msgpack_ok(ReadResponse {
             session_id: self.serve_session.session_id(),
             message_cursor,
             instances,
@@ -271,7 +271,7 @@ impl ApiService {
             },
         };
 
-        json_ok(OpenResponse {
+        msgpack_ok(OpenResponse {
             session_id: self.serve_session.session_id(),
         })
     }

--- a/src/web/util.rs
+++ b/src/web/util.rs
@@ -1,8 +1,29 @@
 use hyper::{header::CONTENT_TYPE, Body, Response, StatusCode};
 use serde::Serialize;
 
-pub fn json_ok<T: Serialize>(value: T) -> Response<Body> {
-    json(value, StatusCode::OK)
+pub fn msgpack_ok<T: Serialize>(value: T) -> Response<Body> {
+    msgpack(value, StatusCode::OK)
+}
+
+pub fn msgpack<T: Serialize>(value: T, code: StatusCode) -> Response<Body> {
+    let mut serialized = Vec::new();
+    let mut serializer = rmp_serde::Serializer::new(&mut serialized)
+        .with_human_readable()
+        .with_struct_map();
+
+    if let Err(err) = value.serialize(&mut serializer) {
+        return Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .header(CONTENT_TYPE, "text/plain")
+            .body(Body::from(err.to_string()))
+            .unwrap();
+    };
+
+    Response::builder()
+        .status(code)
+        .header(CONTENT_TYPE, "application/msgpack")
+        .body(Body::from(serialized))
+        .unwrap()
 }
 
 pub fn json<T: Serialize>(value: T, code: StatusCode) -> Response<Body> {


### PR DESCRIPTION
Fixes #363.
Fixes #881.

# Remaining Tasks
- [ ] Test more extensively.
- [ ] Use `msgpack` for `subscribe` api request.