### PR TITLE
Update workflow and tooling versions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,12 +11,12 @@ jobs:
     name: Check Actions
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    
+    - uses: actions/checkout@v4
+
     - name: Changelog check
       uses: Zomzog/changelog-checker@v1.3.0
       with:
-        fileName: CHANGELOG.md 
+        fileName: CHANGELOG.md
         noChangelogLabel: skip changelog
         checkNotification: Simple
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - name: Setup Aftman
-      uses: ok-nick/setup-aftman@v0.3.0
+      uses: ok-nick/setup-aftman@v0.4.2
       with:
         version: 'v0.2.7'
 
@@ -56,7 +56,7 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - name: Setup Aftman
-      uses: ok-nick/setup-aftman@v0.3.0
+      uses: ok-nick/setup-aftman@v0.4.2
       with:
         version: 'v0.2.7'
 
@@ -81,7 +81,7 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - name: Setup Aftman
-      uses: ok-nick/setup-aftman@v0.3.0
+      uses: ok-nick/setup-aftman@v0.4.2
       with:
         version: 'v0.2.7'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Setup Aftman
       uses: ok-nick/setup-aftman@v0.4.2
       with:
-        version: 'v0.2.8'
+        version: 'v0.3.0'
 
     - name: Build
       run: cargo build --locked --verbose
@@ -58,7 +58,7 @@ jobs:
     - name: Setup Aftman
       uses: ok-nick/setup-aftman@v0.4.2
       with:
-        version: 'v0.2.8'
+        version: 'v0.3.0'
 
     - name: Build
       run: cargo build --locked --verbose
@@ -83,7 +83,7 @@ jobs:
     - name: Setup Aftman
       uses: ok-nick/setup-aftman@v0.4.2
       with:
-        version: 'v0.2.8'
+        version: 'v0.3.0'
 
     - name: Stylua
       run: stylua --check plugin/src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Setup Aftman
       uses: ok-nick/setup-aftman@v0.4.2
       with:
-        version: 'v0.2.7'
+        version: 'v0.2.8'
 
     - name: Build
       run: cargo build --locked --verbose
@@ -58,7 +58,7 @@ jobs:
     - name: Setup Aftman
       uses: ok-nick/setup-aftman@v0.4.2
       with:
-        version: 'v0.2.7'
+        version: 'v0.2.8'
 
     - name: Build
       run: cargo build --locked --verbose
@@ -83,7 +83,7 @@ jobs:
     - name: Setup Aftman
       uses: ok-nick/setup-aftman@v0.4.2
       with:
-        version: 'v0.2.7'
+        version: 'v0.2.8'
 
     - name: Stylua
       run: stylua --check plugin/src

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,8 @@ jobs:
           submodules: true
 
       - name: Setup Aftman
-        uses: ok-nick/setup-aftman@v0.1.0
+        uses: ok-nick/setup-aftman@v0.4.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          trust-check: false
           version: 'v0.2.6'
 
       - name: Build Plugin
@@ -89,10 +87,8 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Setup Aftman
-        uses: ok-nick/setup-aftman@v0.1.0
+        uses: ok-nick/setup-aftman@v0.4.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          trust-check: false
           version: 'v0.2.6'
 
       - name: Build Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Aftman
         uses: ok-nick/setup-aftman@v0.4.2
         with:
-          version: 'v0.2.6'
+          version: 'v0.2.8'
 
       - name: Build Plugin
         run: rojo build plugin --output Rojo.rbxm
@@ -89,7 +89,7 @@ jobs:
       - name: Setup Aftman
         uses: ok-nick/setup-aftman@v0.4.2
         with:
-          version: 'v0.2.6'
+          version: 'v0.2.8'
 
       - name: Build Release
         run: cargo build --release --locked --verbose --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Aftman
         uses: ok-nick/setup-aftman@v0.4.2
         with:
-          version: 'v0.2.8'
+          version: 'v0.3.0'
 
       - name: Build Plugin
         run: rojo build plugin --output Rojo.rbxm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Setup Aftman
         uses: ok-nick/setup-aftman@v0.4.2
         with:
-          version: 'v0.2.8'
+          version: 'v0.3.0'
 
       - name: Build Release
         run: cargo build --release --locked --verbose --target ${{ matrix.target }}

--- a/aftman.toml
+++ b/aftman.toml
@@ -1,5 +1,5 @@
 [tools]
-rojo = "rojo-rbx/rojo@7.3.0"
-selene = "Kampfkarren/selene@0.26.1"
-stylua = "JohnnyMorganz/stylua@0.18.2"
+rojo = "rojo-rbx/rojo@7.4.1"
+selene = "Kampfkarren/selene@0.27.1"
+stylua = "JohnnyMorganz/stylua@0.20.0"
 run-in-roblox = "rojo-rbx/run-in-roblox@0.3.0"

--- a/src/change_processor.rs
+++ b/src/change_processor.rs
@@ -136,7 +136,7 @@ impl JobThreadContext {
                 // created all at once.
                 let mut current_path = path.as_path();
                 let affected_ids = loop {
-                    let ids = tree.get_ids_at_path(&current_path);
+                    let ids = tree.get_ids_at_path(current_path);
 
                     log::trace!("Path {} affects IDs {:?}", current_path.display(), ids);
 

--- a/src/cli/sourcemap.rs
+++ b/src/cli/sourcemap.rs
@@ -67,7 +67,7 @@ impl SourcemapCommand {
         let vfs = Vfs::new_default();
         vfs.set_watch_enabled(self.watch);
 
-        let session = ServeSession::new(vfs, &project_path)?;
+        let session = ServeSession::new(vfs, project_path)?;
         let mut cursor = session.message_queue().cursor();
 
         let filter = if self.include_non_scripts {


### PR DESCRIPTION
- Update the `setup-aftman` action to `v0.4.2` instead of using `v0.1.0` or `v0.3.0`
- Start using Aftman v0.2.8
- Update tools versions in the Aftman.toml file
- Fix clippy lints in a few files
- Update version of `actions/checkout` to `v4` in our changelog check