### PR TITLE
Allow openScriptsExternally option to be changed during sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Updated Theme to use Studio colors ([#838])
 * Improved patch visualizer UX ([#883])
 * Added experimental setting for Auto Connect in playtests ([#840])
+* `Open Scripts Externally` option can now be changed while syncing ([#911])
 * Projects may now specify rules for syncing files as if they had a different file extension. ([#813])
  	This is specified via a new field on project files, `syncRules`:
 
@@ -61,6 +62,7 @@
 [#883]: https://github.com/rojo-rbx/rojo/pull/883
 [#893]: https://github.com/rojo-rbx/rojo/pull/893
 [#903]: https://github.com/rojo-rbx/rojo/pull/903
+[#911]: https://github.com/rojo-rbx/rojo/pull/911
 
 ## [7.4.1] - February 20, 2024
 * Made the `name` field optional on project files ([#870])

--- a/plugin/src/App/StatusPages/Settings/init.lua
+++ b/plugin/src/App/StatusPages/Settings/init.lua
@@ -175,7 +175,6 @@ function SettingsPage:render()
 					id = "openScriptsExternally",
 					name = "Open Scripts Externally",
 					description = "Attempt to open scripts in an external editor",
-					locked = self.props.syncActive,
 					experimental = true,
 					transparency = self.props.transparency,
 					layoutOrder = layoutIncrement(),

--- a/plugin/src/App/init.lua
+++ b/plugin/src/App/init.lua
@@ -425,11 +425,6 @@ function App:startSession()
 
 	local host, port = self:getHostAndPort()
 
-	local sessionOptions = {
-		openScriptsExternally = Settings:get("openScriptsExternally"),
-		twoWaySync = Settings:get("twoWaySync"),
-	}
-
 	local baseUrl = if string.find(host, "^https?://")
 		then string.format("%s:%s", host, port)
 		else string.format("http://%s:%s", host, port)
@@ -437,8 +432,7 @@ function App:startSession()
 
 	local serveSession = ServeSession.new({
 		apiContext = apiContext,
-		openScriptsExternally = sessionOptions.openScriptsExternally,
-		twoWaySync = sessionOptions.twoWaySync,
+		twoWaySync = Settings:get("twoWaySync"),
 	})
 
 	self.cleanupPrecommit = serveSession.__reconciler:hookPrecommit(function(patch, instanceMap)

--- a/plugin/src/ServeSession.lua
+++ b/plugin/src/ServeSession.lua
@@ -13,6 +13,7 @@ local InstanceMap = require(script.Parent.InstanceMap)
 local PatchSet = require(script.Parent.PatchSet)
 local Reconciler = require(script.Parent.Reconciler)
 local strict = require(script.Parent.strict)
+local Settings = require(script.Parent.Settings)
 
 local Status = strict("Session.Status", {
 	NotStarted = "NotStarted",
@@ -50,7 +51,6 @@ ServeSession.Status = Status
 
 local validateServeOptions = t.strictInterface({
 	apiContext = t.table,
-	openScriptsExternally = t.boolean,
 	twoWaySync = t.boolean,
 })
 
@@ -89,7 +89,6 @@ function ServeSession.new(options)
 	self = {
 		__status = Status.NotStarted,
 		__apiContext = options.apiContext,
-		__openScriptsExternally = options.openScriptsExternally,
 		__twoWaySync = options.twoWaySync,
 		__reconciler = reconciler,
 		__instanceMap = instanceMap,
@@ -170,7 +169,7 @@ function ServeSession:__applyGameAndPlaceId(serverInfo)
 end
 
 function ServeSession:__onActiveScriptChanged(activeScript)
-	if not self.__openScriptsExternally then
+	if not Settings:get("openScriptsExternally") then
 		Log.trace("Not opening script {} because feature not enabled.", activeScript)
 
 		return


### PR DESCRIPTION
Locking this setting during sync is unnecessarily restrictive. I usually keep this option on so it's very annoying to have to disconnect when I want to quickly open a script in Studio.