### PR TITLE
Use history recording and don't do anything permanent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Rojo Changelog
 
 ## Unreleased Changes
+* Updated Undo/Redo history to be more robust ([#915])
 * Fixed removing trailing newlines ([#903])
 * Added Never option to Confirmation ([#893])
 * Added popout diff visualizer for table properties like Attributes and Tags ([#834])
@@ -65,6 +66,7 @@
 [#893]: https://github.com/rojo-rbx/rojo/pull/893
 [#903]: https://github.com/rojo-rbx/rojo/pull/903
 [#911]: https://github.com/rojo-rbx/rojo/pull/911
+[#915]: https://github.com/rojo-rbx/rojo/pull/915
 
 ## [7.4.1] - February 20, 2024
 * Made the `name` field optional on project files ([#870])

--- a/plugin/src/InstanceMap.lua
+++ b/plugin/src/InstanceMap.lua
@@ -112,9 +112,12 @@ end
 
 function InstanceMap:destroyInstance(instance)
 	local id = self.fromInstances[instance]
-
 	local descendants = instance:GetDescendants()
-	instance:Destroy()
+
+	-- Because the user might want to Undo this change, we cannot use Destroy
+	-- since that locks that parent and prevents ChangeHistoryService from
+	-- ever bringing it back. Instead, we parent to nil.
+	instance.Parent = nil
 
 	-- After the instance is successfully destroyed,
 	-- we can remove all the id mappings

--- a/plugin/src/Reconciler/applyPatch.lua
+++ b/plugin/src/Reconciler/applyPatch.lua
@@ -173,11 +173,11 @@ local function applyPatch(instanceMap, patch)
 
 			-- Because the user might want to Undo this change, we cannot use Destroy
 			-- since that locks that parent and prevents ChangeHistoryService from
-			-- ever bringing it back. Instead, we use Remove.
+			-- ever bringing it back. Instead, we parent to nil.
 
 			-- TODO: Can this fail? Some kinds of instance may not appreciate
-			-- being Removed, like services.
-			instance:Remove()
+			-- being reparented, like services.
+			instance.Parent = nil
 
 			-- This completes your rebuilding a plane mid-flight safety
 			-- instruction. Please sit back, relax, and enjoy your flight.

--- a/plugin/src/Reconciler/applyPatch.lua
+++ b/plugin/src/Reconciler/applyPatch.lua
@@ -20,6 +20,12 @@ local setProperty = require(script.Parent.setProperty)
 
 local function applyPatch(instanceMap, patch)
 	local patchTimestamp = DateTime.now():FormatLocalTime("LTS", "en-us")
+	local historyRecording = ChangeHistoryService:TryBeginRecording("Rojo: Patch " .. patchTimestamp)
+	if not historyRecording then
+		-- There can only be one recording at a time
+		Log.debug("Failed to begin history recording for " .. patchTimestamp .. ". Another recording is in progress.")
+		return
+	end
 
 	-- Tracks any portions of the patch that could not be applied to the DOM.
 	local unappliedPatch = PatchSet.newEmpty()
@@ -214,7 +220,9 @@ local function applyPatch(instanceMap, patch)
 		end
 	end
 
-	ChangeHistoryService:SetWaypoint("Rojo: Patch " .. patchTimestamp)
+	if historyRecording then
+		ChangeHistoryService:FinishRecording(historyRecording, Enum.FinishRecordingOperation.Commit)
+	end
 
 	return unappliedPatch
 end

--- a/plugin/src/Reconciler/applyPatch.lua
+++ b/plugin/src/Reconciler/applyPatch.lua
@@ -170,10 +170,14 @@ local function applyPatch(instanceMap, patch)
 			end
 
 			-- See you later, original instance.
-			--
+
+			-- Because the user might want to Undo this change, we cannot use Destroy
+			-- since that locks that parent and prevents ChangeHistoryService from
+			-- ever bringing it back. Instead, we use Remove.
+
 			-- TODO: Can this fail? Some kinds of instance may not appreciate
-			-- being destroyed, like services.
-			instance:Destroy()
+			-- being Removed, like services.
+			instance:Remove()
 
 			-- This completes your rebuilding a plane mid-flight safety
 			-- instruction. Please sit back, relax, and enjoy your flight.


### PR DESCRIPTION
Adopts the latest ChangeHistoryService APIs.  Our Undo/Redo notification warnings (to prevent accidentally undoing a Rojo patch) still work fine with this new API.

Avoids the permanent Destroy action, uses Remove instead. This closes #914.