### PR TITLE
Correct issue with default.project.json files with no name being named `default` after change

### DIFF
--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__no_name_top_level_project_all-2.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__no_name_top_level_project_all-2.snap
@@ -10,10 +10,10 @@ instances:
     Id: id-2
     Metadata:
       ignoreUnknownInstances: true
-    Name: default
+    Name: no_name_top_level_project
     Parent: "00000000000000000000000000000000"
     Properties:
       Value:
         String: "If this isn't named `no_name_top_level_project`, something went wrong!"
-messageCursor: 1
+messageCursor: 0
 sessionId: id-1

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__no_name_top_level_project_all-2.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__no_name_top_level_project_all-2.snap
@@ -1,0 +1,19 @@
+---
+source: tests/tests/serve.rs
+assertion_line: 370
+expression: "read_response.intern_and_redact(&mut redactions, root_id)"
+---
+instances:
+  id-2:
+    Children: []
+    ClassName: StringValue
+    Id: id-2
+    Metadata:
+      ignoreUnknownInstances: true
+    Name: default
+    Parent: "00000000000000000000000000000000"
+    Properties:
+      Value:
+        String: "If this isn't named `no_name_top_level_project`, something went wrong!"
+messageCursor: 1
+sessionId: id-1

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__sync_rule_no_name_project_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__sync_rule_no_name_project_all.snap
@@ -1,0 +1,41 @@
+---
+source: tests/tests/serve.rs
+assertion_line: 389
+expression: "read_response.intern_and_redact(&mut redactions, root_id)"
+---
+instances:
+  id-2:
+    Children:
+      - id-3
+    ClassName: StringValue
+    Id: id-2
+    Metadata:
+      ignoreUnknownInstances: true
+    Name: sync_rule_no_name_project
+    Parent: "00000000000000000000000000000000"
+    Properties:
+      Value:
+        String: "This should be named `sync_rule_no_name_project` and have a child at `src/not_a_project`"
+  id-3:
+    Children:
+      - id-4
+    ClassName: Folder
+    Id: id-3
+    Metadata:
+      ignoreUnknownInstances: false
+    Name: src
+    Parent: id-2
+    Properties: {}
+  id-4:
+    Children: []
+    ClassName: StringValue
+    Id: id-4
+    Metadata:
+      ignoreUnknownInstances: true
+    Name: not_a_project
+    Parent: id-3
+    Properties:
+      Value:
+        String: "If this isn't named `not_a_project`, something has gone wrong!"
+messageCursor: 0
+sessionId: id-1

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__sync_rule_no_name_project_info.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__sync_rule_no_name_project_info.snap
@@ -1,0 +1,13 @@
+---
+source: tests/tests/serve.rs
+assertion_line: 383
+expression: redactions.redacted_yaml(info)
+---
+expectedPlaceIds: ~
+gameId: ~
+placeId: ~
+projectName: sync_rule_no_name_project
+protocolVersion: 4
+rootInstanceId: id-2
+serverVersion: "[server-version]"
+sessionId: id-1

--- a/rojo-test/serve-tests/sync_rule_no_name_project/default.project.json
+++ b/rojo-test/serve-tests/sync_rule_no_name_project/default.project.json
@@ -1,0 +1,17 @@
+{
+  "tree": {
+    "$className": "StringValue",
+    "$properties": {
+      "Value": "This should be named `sync_rule_no_name_project` and have a child at `src/not_a_project`"
+    },
+    "src": {
+      "$path": "src"
+    }
+  },
+  "syncRules": [
+    {
+      "use": "project",
+      "pattern": "*.rojo"
+    }
+  ]
+}

--- a/rojo-test/serve-tests/sync_rule_no_name_project/src/not_a_project.rojo
+++ b/rojo-test/serve-tests/sync_rule_no_name_project/src/not_a_project.rojo
@@ -1,0 +1,8 @@
+{
+    "tree": {
+        "$className": "StringValue",
+        "$properties": {
+            "Value": "If this isn't named `not_a_project`, something has gone wrong!"
+        }
+    }
+}

--- a/src/cli/fmt_project.rs
+++ b/src/cli/fmt_project.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use clap::Parser;
+use memofs::Vfs;
 
 use crate::project::Project;
 
@@ -17,8 +18,11 @@ pub struct FmtProjectCommand {
 
 impl FmtProjectCommand {
     pub fn run(self) -> anyhow::Result<()> {
+        let vfs = Vfs::new_default();
+        vfs.set_watch_enabled(false);
+
         let base_path = resolve_path(&self.project);
-        let project = Project::load_fuzzy(&base_path)?
+        let project = Project::load_fuzzy(&vfs, &base_path)?
             .context("A project file is required to run 'rojo fmt-project'")?;
 
         let serialized = serde_json::to_string_pretty(&project)

--- a/src/project.rs
+++ b/src/project.rs
@@ -177,22 +177,15 @@ impl Project {
         } else if let Some(fallback) = fallback {
             self.name = Some(fallback.to_string());
         } else {
-            for rule in self.sync_rules.iter().chain(default_sync_rules()) {
-                // I don't believe there's any way to get here without the
-                // matching middleware being a Project middleware.
-                if rule.matches(&self.file_location) {
-                    self.name = Some(
-                        rule.file_name_for_path(&self.file_location)
-                            .map_err(|_| Error::ProjectNameInvalid {
-                                path: self.file_location.clone(),
-                            })?
-                            .to_string(),
-                    )
-                }
-            }
-            return Err(Error::ProjectNameInvalid {
-                path: std::mem::take(&mut self.file_location),
-            });
+            // As of the time of writing (July 10, 2024) there is no way for
+            // this code path to be reachable. It can in theory be reached from
+            // both `load_fuzzy` and `load_exact` but in practice it's never
+            // invoked.
+            // If you're adding this codepath, make sure a test for it exists
+            // and that it handles sync rules appropriately.
+            todo!(
+                "set_file_name doesn't support loading project files that aren't default.project.json without a fallback provided"
+            );
         }
 
         Ok(())

--- a/src/serve_session.rs
+++ b/src/serve_session.rs
@@ -109,7 +109,7 @@ impl ServeSession {
 
         log::debug!("Loading project file from {}", project_path.display());
 
-        let mut root_project = match Project::load_exact(&vfs, &project_path) {
+        let root_project = match Project::load_exact(&vfs, &project_path, None) {
             Ok(project) => project,
             Err(_) => {
                 return Err(ServeSessionError::NoProjectFound {
@@ -117,36 +117,6 @@ impl ServeSession {
                 })
             }
         };
-
-        if root_project.name.is_none() {
-            if let Some(file_name) = project_path.file_name().and_then(|s| s.to_str()) {
-                if file_name == "default.project.json" {
-                    let folder_name = project_path
-                        .parent()
-                        .and_then(Path::file_name)
-                        .and_then(|s| s.to_str());
-                    if let Some(folder_name) = folder_name {
-                        root_project.name = Some(folder_name.to_string());
-                    } else {
-                        return Err(ServeSessionError::FolderNameInvalid {
-                            path: project_path.to_path_buf(),
-                        });
-                    }
-                } else if let Some(trimmed) = file_name.strip_suffix(".project.json") {
-                    root_project.name = Some(trimmed.to_string());
-                } else {
-                    return Err(ServeSessionError::ProjectNameInvalid {
-                        path: project_path.to_path_buf(),
-                    });
-                }
-            } else {
-                return Err(ServeSessionError::ProjectNameInvalid {
-                    path: project_path.to_path_buf(),
-                });
-            }
-        }
-        // Rebind it to make it no longer mutable
-        let root_project = root_project;
 
         let mut tree = RojoTree::new(InstanceSnapshot::new());
 
@@ -262,14 +232,6 @@ pub enum ServeSessionError {
         .path.display()
     )]
     NoProjectFound { path: PathBuf },
-
-    #[error("The folder for the provided project cannot be used as a project name: {}\n\
-            Consider setting the `name` field on this project.", .path.display())]
-    FolderNameInvalid { path: PathBuf },
-
-    #[error("The file name of the provided project cannot be used as a project name: {}.\n\
-            Consider setting the `name` field on this project.", .path.display())]
-    ProjectNameInvalid { path: PathBuf },
 
     #[error(transparent)]
     Io {

--- a/src/snapshot_middleware/mod.rs
+++ b/src/snapshot_middleware/mod.rs
@@ -63,6 +63,9 @@ pub fn snapshot_from_vfs(
     if meta.is_dir() {
         if let Some(init_path) = get_init_path(vfs, path)? {
             // TODO: support user-defined init paths
+            // If and when we do, make sure to go support it in
+            // `Project::load_from_slice`, as right now it special-cases
+            // `default.project.json` as an `init` path.
             for rule in default_sync_rules() {
                 if rule.matches(&init_path) {
                     return match rule.middleware {
@@ -274,7 +277,7 @@ macro_rules! sync_rule {
 /// Defines the 'default' syncing rules that Rojo uses.
 /// These do not broadly overlap, but the order matters for some in the case of
 /// e.g. JSON models.
-fn default_sync_rules() -> &'static [SyncRule] {
+pub fn default_sync_rules() -> &'static [SyncRule] {
     static DEFAULT_SYNC_RULES: OnceLock<Vec<SyncRule>> = OnceLock::new();
 
     DEFAULT_SYNC_RULES.get_or_init(|| {

--- a/src/snapshot_middleware/mod.rs
+++ b/src/snapshot_middleware/mod.rs
@@ -64,7 +64,7 @@ pub fn snapshot_from_vfs(
         if let Some(init_path) = get_init_path(vfs, path)? {
             // TODO: support user-defined init paths
             // If and when we do, make sure to go support it in
-            // `Project::load_from_slice`, as right now it special-cases
+            // `Project::set_file_name`, as right now it special-cases
             // `default.project.json` as an `init` path.
             for rule in default_sync_rules() {
                 if rule.matches(&init_path) {

--- a/src/snapshot_middleware/project.rs
+++ b/src/snapshot_middleware/project.rs
@@ -21,7 +21,7 @@ pub fn snapshot_project(
     path: &Path,
     name: &str,
 ) -> anyhow::Result<Option<InstanceSnapshot>> {
-    let project = Project::load_from_slice(&vfs.read(path)?, path)
+    let project = Project::load_exact(vfs, path)
         .with_context(|| format!("File was not a valid Rojo project: {}", path.display()))?;
     let project_name = match project.name.as_deref() {
         Some(name) => name,

--- a/src/snapshot_middleware/project.rs
+++ b/src/snapshot_middleware/project.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap, path::Path};
+use std::{borrow::Cow, collections::HashMap, ffi::OsStr, path::Path};
 
 use anyhow::{bail, Context};
 use memofs::Vfs;
@@ -23,7 +23,17 @@ pub fn snapshot_project(
 ) -> anyhow::Result<Option<InstanceSnapshot>> {
     let project = Project::load_from_slice(&vfs.read(path)?, path)
         .with_context(|| format!("File was not a valid Rojo project: {}", path.display()))?;
-    let project_name = project.name.as_deref().unwrap_or(name);
+    let project_name = match project.name.as_deref() {
+        Some(name) => name,
+        None => match path.file_name().and_then(OsStr::to_str) {
+            Some("default.project.json") => project
+                .folder_location()
+                .file_name()
+                .and_then(OsStr::to_str)
+                .unwrap_or(name),
+            _ => name,
+        },
+    };
 
     let mut context = context.clone();
     context.clear_sync_rules();

--- a/src/snapshot_middleware/project.rs
+++ b/src/snapshot_middleware/project.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap, ffi::OsStr, path::Path};
+use std::{borrow::Cow, collections::HashMap, path::Path};
 
 use anyhow::{bail, Context};
 use memofs::Vfs;
@@ -21,18 +21,11 @@ pub fn snapshot_project(
     path: &Path,
     name: &str,
 ) -> anyhow::Result<Option<InstanceSnapshot>> {
-    let project = Project::load_exact(vfs, path)
+    let project = Project::load_exact(vfs, path, Some(name))
         .with_context(|| format!("File was not a valid Rojo project: {}", path.display()))?;
     let project_name = match project.name.as_deref() {
         Some(name) => name,
-        None => match path.file_name().and_then(OsStr::to_str) {
-            Some("default.project.json") => project
-                .folder_location()
-                .file_name()
-                .and_then(OsStr::to_str)
-                .unwrap_or(name),
-            _ => name,
-        },
+        None => panic!("Project is missing a name"),
     };
 
     let mut context = context.clone();

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__no_name_project.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__no_name_project.snap
@@ -1,6 +1,6 @@
 ---
 source: src/snapshot_middleware/project.rs
-assertion_line: 735
+assertion_line: 728
 expression: instance_snapshot
 ---
 snapshot_id: "00000000000000000000000000000000"
@@ -12,7 +12,7 @@ metadata:
     - /foo/default.project.json
   context:
     emit_legacy_scripts: true
-name: foo
+name: no_name_project
 class_name: Model
 properties: {}
 children: []

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__no_name_project.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__no_name_project.snap
@@ -1,6 +1,5 @@
 ---
 source: src/snapshot_middleware/project.rs
-assertion_line: 728
 expression: instance_snapshot
 ---
 snapshot_id: "00000000000000000000000000000000"
@@ -12,8 +11,8 @@ metadata:
     - /foo/default.project.json
   context:
     emit_legacy_scripts: true
-name: foo
   specified_id: ~
+name: foo
 class_name: Model
 properties: {}
 children: []

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__no_name_project.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__no_name_project.snap
@@ -1,6 +1,6 @@
 ---
 source: src/snapshot_middleware/project.rs
-assertion_line: 725
+assertion_line: 735
 expression: instance_snapshot
 ---
 snapshot_id: "00000000000000000000000000000000"
@@ -12,8 +12,7 @@ metadata:
     - /foo/default.project.json
   context:
     emit_legacy_scripts: true
-name: no_name_project
+name: foo
 class_name: Model
 properties: {}
 children: []
-

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__no_name_project.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__no_name_project.snap
@@ -12,7 +12,7 @@ metadata:
     - /foo/default.project.json
   context:
     emit_legacy_scripts: true
-name: no_name_project
+name: foo
 class_name: Model
 properties: {}
 children: []

--- a/tests/rojo_test/serve_util.rs
+++ b/tests/rojo_test/serve_util.rs
@@ -87,7 +87,7 @@ impl TestServeSession {
         let port_string = port.to_string();
 
         let rojo_process = Command::new(ROJO_PATH)
-            .args(&[
+            .args([
                 "serve",
                 project_path.to_str().unwrap(),
                 "--port",
@@ -145,14 +145,14 @@ impl TestServeSession {
 
     pub fn get_api_rojo(&self) -> Result<ServerInfoResponse, reqwest::Error> {
         let url = format!("http://localhost:{}/api/rojo", self.port);
-        let body = reqwest::blocking::get(&url)?.text()?;
+        let body = reqwest::blocking::get(url)?.text()?;
 
         Ok(serde_json::from_str(&body).expect("Server returned malformed response"))
     }
 
     pub fn get_api_read(&self, id: Ref) -> Result<ReadResponse, reqwest::Error> {
         let url = format!("http://localhost:{}/api/read/{}", self.port, id);
-        let body = reqwest::blocking::get(&url)?.text()?;
+        let body = reqwest::blocking::get(url)?.text()?;
 
         Ok(serde_json::from_str(&body).expect("Server returned malformed response"))
     }
@@ -163,7 +163,7 @@ impl TestServeSession {
     ) -> Result<SubscribeResponse<'static>, reqwest::Error> {
         let url = format!("http://localhost:{}/api/subscribe/{}", self.port, cursor);
 
-        reqwest::blocking::get(&url)?.json()
+        reqwest::blocking::get(url)?.json()
     }
 }
 

--- a/tests/tests/serve.rs
+++ b/tests/tests/serve.rs
@@ -373,3 +373,22 @@ fn no_name_top_level_project() {
         );
     });
 }
+
+#[test]
+fn sync_rule_no_name_project() {
+    run_serve_test("sync_rule_no_name_project", |session, mut redactions| {
+        let info = session.get_api_rojo().unwrap();
+        let root_id = info.root_instance_id;
+
+        assert_yaml_snapshot!(
+            "sync_rule_no_name_project_info",
+            redactions.redacted_yaml(info)
+        );
+
+        let read_response = session.get_api_read(root_id).unwrap();
+        assert_yaml_snapshot!(
+            "sync_rule_no_name_project_all",
+            read_response.intern_and_redact(&mut redactions, root_id)
+        );
+    });
+}

--- a/tests/tests/serve.rs
+++ b/tests/tests/serve.rs
@@ -358,5 +358,18 @@ fn no_name_top_level_project() {
             "no_name_top_level_project_all",
             read_response.intern_and_redact(&mut redactions, root_id)
         );
+
+        let project_path = session.path().join("default.project.json");
+        let mut project_contents = fs::read_to_string(&project_path).unwrap();
+        project_contents.push('\n');
+        fs::write(&project_path, project_contents).unwrap();
+
+        // The cursor shouldn't be changing so this snapshot is fine for testing
+        // the response.
+        let read_response = session.get_api_read(root_id).unwrap();
+        assert_yaml_snapshot!(
+            "no_name_top_level_project_all-2",
+            read_response.intern_and_redact(&mut redactions, root_id)
+        );
     });
 }


### PR DESCRIPTION
Closes #916.

Turns out we had a test that should've caught this, it's just that nobody caught it when this feature was implemented. We'll likely want to backport this into the 7.4.x branch as well.

Let me know if you have a better way to calculate project names in the middleware, I'm not in love with the way it's implemented here.