### PR TITLE
Actually include attribute-defined properties in patch computation

### DIFF
--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__ref_properties_patch_update_all-2.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__ref_properties_patch_update_all-2.snap
@@ -1,0 +1,120 @@
+---
+source: tests/tests/serve.rs
+expression: "read_response.intern_and_redact(&mut redactions, root_id)"
+---
+instances:
+  id-10:
+    Children: []
+    ClassName: ObjectValue
+    Id: id-10
+    Metadata:
+      ignoreUnknownInstances: true
+    Name: ProjectPointer
+    Parent: id-9
+    Properties:
+      Attributes:
+        Attributes:
+          Rojo_Target_Value:
+            String: project target
+      Value:
+        Ref: id-9
+  id-2:
+    Children:
+      - id-3
+    ClassName: DataModel
+    Id: id-2
+    Metadata:
+      ignoreUnknownInstances: true
+    Name: ref_properties
+    Parent: "00000000000000000000000000000000"
+    Properties: {}
+  id-3:
+    Children:
+      - id-4
+      - id-5
+      - id-7
+      - id-9
+    ClassName: Workspace
+    Id: id-3
+    Metadata:
+      ignoreUnknownInstances: true
+    Name: Workspace
+    Parent: id-2
+    Properties: {}
+  id-4:
+    Children: []
+    ClassName: ObjectValue
+    Id: id-4
+    Metadata:
+      ignoreUnknownInstances: true
+    Name: CrossFormatPointer
+    Parent: id-3
+    Properties:
+      Attributes:
+        Attributes:
+          Rojo_Target_Value:
+            String: folder target
+      Value:
+        Ref: id-5
+  id-5:
+    Children:
+      - id-6
+    ClassName: Folder
+    Id: id-5
+    Metadata:
+      ignoreUnknownInstances: false
+    Name: FolderTarget
+    Parent: id-3
+    Properties: {}
+  id-6:
+    Children: []
+    ClassName: ObjectValue
+    Id: id-6
+    Metadata:
+      ignoreUnknownInstances: false
+    Name: FolderPointer
+    Parent: id-5
+    Properties:
+      Attributes:
+        Attributes:
+          Rojo_Target_Value:
+            String: folder target
+      Value:
+        Ref: id-5
+  id-7:
+    Children:
+      - id-8
+    ClassName: Folder
+    Id: id-7
+    Metadata:
+      ignoreUnknownInstances: false
+    Name: ModelTarget
+    Parent: id-3
+    Properties: {}
+  id-8:
+    Children: []
+    ClassName: Model
+    Id: id-8
+    Metadata:
+      ignoreUnknownInstances: false
+    Name: ModelPointer
+    Parent: id-7
+    Properties:
+      Attributes:
+        Attributes:
+          Rojo_Target_PrimaryPart:
+            String: model target
+      PrimaryPart:
+        Ref: id-7
+  id-9:
+    Children:
+      - id-10
+    ClassName: Folder
+    Id: id-9
+    Metadata:
+      ignoreUnknownInstances: true
+    Name: ProjectTarget
+    Parent: id-3
+    Properties: {}
+messageCursor: 1
+sessionId: id-1

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__ref_properties_patch_update_all-2.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__ref_properties_patch_update_all-2.snap
@@ -116,5 +116,5 @@ instances:
     Name: ProjectTarget
     Parent: id-3
     Properties: {}
-messageCursor: 1
+messageCursor: 0
 sessionId: id-1

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__ref_properties_patch_update_all.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__ref_properties_patch_update_all.snap
@@ -1,0 +1,120 @@
+---
+source: tests/tests/serve.rs
+expression: "read_response.intern_and_redact(&mut redactions, root_id)"
+---
+instances:
+  id-10:
+    Children: []
+    ClassName: ObjectValue
+    Id: id-10
+    Metadata:
+      ignoreUnknownInstances: true
+    Name: ProjectPointer
+    Parent: id-9
+    Properties:
+      Attributes:
+        Attributes:
+          Rojo_Target_Value:
+            String: project target
+      Value:
+        Ref: id-9
+  id-2:
+    Children:
+      - id-3
+    ClassName: DataModel
+    Id: id-2
+    Metadata:
+      ignoreUnknownInstances: true
+    Name: ref_properties
+    Parent: "00000000000000000000000000000000"
+    Properties: {}
+  id-3:
+    Children:
+      - id-4
+      - id-5
+      - id-7
+      - id-9
+    ClassName: Workspace
+    Id: id-3
+    Metadata:
+      ignoreUnknownInstances: true
+    Name: Workspace
+    Parent: id-2
+    Properties: {}
+  id-4:
+    Children: []
+    ClassName: ObjectValue
+    Id: id-4
+    Metadata:
+      ignoreUnknownInstances: true
+    Name: CrossFormatPointer
+    Parent: id-3
+    Properties:
+      Attributes:
+        Attributes:
+          Rojo_Target_Value:
+            String: folder target
+      Value:
+        Ref: id-5
+  id-5:
+    Children:
+      - id-6
+    ClassName: Folder
+    Id: id-5
+    Metadata:
+      ignoreUnknownInstances: false
+    Name: FolderTarget
+    Parent: id-3
+    Properties: {}
+  id-6:
+    Children: []
+    ClassName: ObjectValue
+    Id: id-6
+    Metadata:
+      ignoreUnknownInstances: false
+    Name: FolderPointer
+    Parent: id-5
+    Properties:
+      Attributes:
+        Attributes:
+          Rojo_Target_Value:
+            String: folder target
+      Value:
+        Ref: id-5
+  id-7:
+    Children:
+      - id-8
+    ClassName: Folder
+    Id: id-7
+    Metadata:
+      ignoreUnknownInstances: false
+    Name: ModelTarget
+    Parent: id-3
+    Properties: {}
+  id-8:
+    Children: []
+    ClassName: Model
+    Id: id-8
+    Metadata:
+      ignoreUnknownInstances: false
+    Name: ModelPointer
+    Parent: id-7
+    Properties:
+      Attributes:
+        Attributes:
+          Rojo_Target_PrimaryPart:
+            String: model target
+      PrimaryPart:
+        Ref: id-7
+  id-9:
+    Children:
+      - id-10
+    ClassName: Folder
+    Id: id-9
+    Metadata:
+      ignoreUnknownInstances: true
+    Name: ProjectTarget
+    Parent: id-3
+    Properties: {}
+messageCursor: 0
+sessionId: id-1

--- a/rojo-test/serve-test-snapshots/end_to_end__tests__serve__ref_properties_patch_update_info.snap
+++ b/rojo-test/serve-test-snapshots/end_to_end__tests__serve__ref_properties_patch_update_info.snap
@@ -1,0 +1,12 @@
+---
+source: tests/tests/serve.rs
+expression: redactions.redacted_yaml(info)
+---
+expectedPlaceIds: ~
+gameId: ~
+placeId: ~
+projectName: ref_properties
+protocolVersion: 4
+rootInstanceId: id-2
+serverVersion: "[server-version]"
+sessionId: id-1

--- a/tests/tests/serve.rs
+++ b/tests/tests/serve.rs
@@ -477,3 +477,36 @@ fn ref_properties_remove() {
         );
     });
 }
+
+#[test]
+fn ref_properties_patch_update() {
+    // Reusing ref_properties is fun and easy.
+    run_serve_test("ref_properties", |session, mut redactions| {
+        let info = session.get_api_rojo().unwrap();
+        let root_id = info.root_instance_id;
+
+        assert_yaml_snapshot!(
+            "ref_properties_patch_update_info",
+            redactions.redacted_yaml(info)
+        );
+
+        let read_response = session.get_api_read(root_id).unwrap();
+        assert_yaml_snapshot!(
+            "ref_properties_patch_update_all",
+            read_response.intern_and_redact(&mut redactions, root_id)
+        );
+
+        let project_path = session.path().join("default.project.json");
+        let mut project_content = fs::read(&project_path).unwrap();
+        // Adding a newline to force the change processor to pick up a change.
+        project_content.push(b'\n');
+
+        fs::write(project_path, project_content).unwrap();
+
+        let read_response = session.get_api_read(root_id).unwrap();
+        assert_yaml_snapshot!(
+            "ref_properties_patch_update_all-2",
+            read_response.intern_and_redact(&mut redactions, root_id)
+        );
+    });
+}

--- a/tests/tests/serve.rs
+++ b/tests/tests/serve.rs
@@ -478,6 +478,12 @@ fn ref_properties_remove() {
     });
 }
 
+/// When Ref properties were first implemented, a mistake was made that resulted
+/// in Ref properties defined via attributes not being included in patch
+/// computation, which resulted in subsequent patches setting those properties
+/// to `nil`.
+///
+/// See: https://github.com/rojo-rbx/rojo/issues/929
 #[test]
 fn ref_properties_patch_update() {
     // Reusing ref_properties is fun and easy.


### PR DESCRIPTION
Closes #929.

It turns out the underlying issue was that we weren't accounting for ref properties at all in the patch computation. This resolves that issue by just collecting them during `compute_property_patch`.

Of note, I've decided to just reuse the `ref_properties` test files for this since it's ultimately academic either way. It adds noise to the snapshot files but I think it's fine because the only thing that really matters here is the `messageCursor` on the return from the read endpoint. Let me know if you'd prefer a cleaner snapshot.