### PR TITLE
Sleep between file copies and serve for macOS serve tests

### DIFF
--- a/tests/rojo_test/serve_util.rs
+++ b/tests/rojo_test/serve_util.rs
@@ -83,6 +83,15 @@ impl TestServeSession {
                 .expect("Couldn't copy project to temporary directory");
         };
 
+        // This is an ugly workaround for FSEvents sometimes reporting events
+        // for the above copy operations, similar to this Stack Overflow question:
+        // https://stackoverflow.com/questions/47679298/howto-avoid-receiving-old-events-in-fseventstream-callback-fsevents-framework-o
+        // We'll hope that 100ms is enough for FSEvents to get whatever it is
+        // out of its system.
+        // TODO: find a better way to avoid processing these spurious events.
+        #[cfg(target_os = "macos")]
+        std::thread::sleep(Duration::from_millis(100));
+
         let port = get_port_number();
         let port_string = port.to_string();
 


### PR DESCRIPTION
This PR adds a 100ms sleep between copying test files and starting the Rojo server in macOS serve tests. I added a comment explaining the addition - I'm not sure why it happens, there's very scant information about this issue on the internet, and this isn't quite a proper way to fix it. Ideally, we could somehow get FSEvents to flush its event stream before starting to process events, but that will probably require changes to notify.