### PR TITLE
Backport #893 and #903 to Rojo 7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Rojo Changelog
 
 ## Unreleased Changes
+* Added Never option to Confirmation ([#893])
+* Fixed removing trailing newlines ([#903])
+
+[#893]: https://github.com/rojo-rbx/rojo/pull/893
+[#903]: https://github.com/rojo-rbx/rojo/pull/903
 
 ## [7.4.1] - February 20, 2024
 * Made the `name` field optional on project files ([#870])

--- a/plugin/src/App/StatusPages/Settings/init.lua
+++ b/plugin/src/App/StatusPages/Settings/init.lua
@@ -26,7 +26,7 @@ local function invertTbl(tbl)
 end
 
 local invertedLevels = invertTbl(Log.Level)
-local confirmationBehaviors = { "Initial", "Always", "Large Changes", "Unlisted PlaceId" }
+local confirmationBehaviors = { "Initial", "Always", "Large Changes", "Unlisted PlaceId", "Never" }
 
 local function Navbar(props)
 	return Theme.with(function(theme)

--- a/plugin/src/App/init.lua
+++ b/plugin/src/App/init.lua
@@ -516,6 +516,9 @@ function App:startSession()
 					return "Accept"
 				end
 			end
+		elseif confirmationBehavior == "Never" then
+			Log.trace("Accepting patch without confirmation because behavior is set to Never")
+			return "Accept"
 		end
 
 		-- The datamodel name gets overwritten by Studio, making confirmation of it intrusive


### PR DESCRIPTION
As part of prep for a 7.4.2 release, this backports changes to the 7.4.X branch that we can reasonably ship in 7.4.2 without too many code changes.