### PR TITLE
In the plugin, don't write properties if they're nil and also a number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased Changes
 
+* Fixed `value of type nil cannot be converted to number` warning spam in output. [#955]
+
+[#955]: https://github.com/rojo-rbx/rojo/pull/893
+
 ## [7.4.2] - July 23, 2024
 * Added Never option to Confirmation ([#893])
 * Fixed removing trailing newlines ([#903])

--- a/aftman.toml
+++ b/aftman.toml
@@ -1,5 +1,5 @@
 [tools]
-rojo = "rojo-rbx/rojo@7.3.0"
+rojo = "rojo-rbx/rojo@7.4.1"
 selene = "Kampfkarren/selene@0.26.1"
 stylua = "JohnnyMorganz/stylua@0.18.2"
 run-in-roblox = "rojo-rbx/run-in-roblox@0.3.0"

--- a/plugin/src/Reconciler/setProperty.lua
+++ b/plugin/src/Reconciler/setProperty.lua
@@ -7,7 +7,7 @@ local Log = require(Packages.Log)
 local RbxDom = require(Packages.RbxDom)
 local Error = require(script.Parent.Error)
 
-local function setProperty(instance, propertyName, value)
+local function setProperty(instance: Instance, propertyName: string, value: unknown): boolean
 	local descriptor = RbxDom.findCanonicalPropertyDescriptor(instance.ClassName, propertyName)
 
 	-- We can skip unknown properties; they're not likely reflected to Lua.
@@ -26,6 +26,13 @@ local function setProperty(instance, propertyName, value)
 				className = instance.ClassName,
 				propertyName = propertyName,
 			})
+	end
+
+	if value == nil then
+		if descriptor.dataType == "Float32" or descriptor.dataType == "Float64" then
+			Log.trace("Skipping nil {} property {}.{}", descriptor.dataType, instance.ClassName, propertyName)
+			return true
+		end
 	end
 
 	local writeSuccess, err = descriptor:write(instance, value)


### PR DESCRIPTION
When sent through the network, NaN and Infinity become `nil` due to JSON not supporting them. This results in two problems:

- An annoying `value of type nil cannot be converted to number` warning in the output
- The value being reset to `0` instead of whatever value it was before


Neither of these are desirable, so this PR fixes that behavior. It does so by explicitly ignoring `nil` updates for `Float32` and `Float64` updates. This is explicitly on the 7.4.x branch because I don't want it to become permanent. Long-term, we want to swap to a different network protocol which should fix this issue.

See #953 for some discussion on this subject.