### PR TITLE
Set linguist language of lua files to luau

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.lua linguist-language=Luau


### PR DESCRIPTION
This PR sets linguist language of lua files to luau for syntax highlighting on github. 