### PR TITLE
Remove maplit dependency and stop using a macro for hashmaps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ humantime = "2.1.0"
 hyper = { version = "0.14.28", features = ["server", "tcp", "http1"] }
 jod-thread = "0.1.2"
 log = "0.4.21"
-maplit = "1.0.2"
 num_cpus = "1.16.0"
 opener = "0.5.2"
 rayon = "1.9.0"

--- a/src/snapshot/patch_apply.rs
+++ b/src/snapshot/patch_apply.rs
@@ -304,7 +304,6 @@ mod test {
 
     use std::borrow::Cow;
 
-    use maplit::hashmap;
     use rbx_dom_weak::types::Variant;
 
     use super::super::PatchAdd;
@@ -322,9 +321,7 @@ mod test {
             metadata: Default::default(),
             name: Cow::Borrowed("Foo"),
             class_name: Cow::Borrowed("Bar"),
-            properties: hashmap! {
-                "Baz".to_owned() => Variant::Int32(5),
-            },
+            properties: [("Baz".to_owned(), Variant::Int32(5))].into(),
             children: Vec::new(),
         };
 
@@ -367,16 +364,15 @@ mod test {
             id: root_id,
             changed_name: Some("Foo".to_owned()),
             changed_class_name: Some("NewClassName".to_owned()),
-            changed_properties: hashmap! {
+            changed_properties: [
                 // The value of Foo has changed
-                "Foo".to_owned() => Some(Variant::Int32(8)),
-
+                ("Foo".to_owned(), Some(Variant::Int32(8))),
                 // Bar has been deleted
-                "Bar".to_owned() => None,
-
+                ("Bar".to_owned(), None),
                 // Baz has been added
-                "Baz".to_owned() => Some(Variant::Int32(10)),
-            },
+                ("Baz".to_owned(), Some(Variant::Int32(10))),
+            ]
+            .into(),
             changed_metadata: None,
         };
 
@@ -387,11 +383,12 @@ mod test {
 
         apply_patch_set(&mut tree, patch_set);
 
-        let expected_properties = hashmap! {
-            "Foo".to_owned() => Variant::Int32(8),
-            "Baz".to_owned() => Variant::Int32(10),
-            "Unchanged".to_owned() => Variant::Int32(-5),
-        };
+        let expected_properties = [
+            ("Foo".to_owned(), Variant::Int32(8)),
+            ("Baz".to_owned(), Variant::Int32(10)),
+            ("Unchanged".to_owned(), Variant::Int32(-5)),
+        ]
+        .into();
 
         let root_instance = tree.get_instance(root_id).unwrap();
         assert_eq!(root_instance.name(), "Foo");

--- a/src/snapshot/patch_compute.rs
+++ b/src/snapshot/patch_compute.rs
@@ -299,8 +299,6 @@ mod test {
 
     use std::borrow::Cow;
 
-    use maplit::hashmap;
-
     /// This test makes sure that rewriting refs in instance update patches to
     /// instances that already exists works. We should be able to correlate the
     /// snapshot ID and instance ID during patch computation and replace the
@@ -316,9 +314,7 @@ mod test {
         let snapshot_id = Ref::new();
         let snapshot = InstanceSnapshot {
             snapshot_id: snapshot_id,
-            properties: hashmap! {
-                "Self".to_owned() => Variant::Ref(snapshot_id),
-            },
+            properties: [("Self".to_owned(), Variant::Ref(snapshot_id))].into(),
 
             metadata: Default::default(),
             name: Cow::Borrowed("foo"),
@@ -333,9 +329,7 @@ mod test {
                 id: root_id,
                 changed_name: None,
                 changed_class_name: None,
-                changed_properties: hashmap! {
-                    "Self".to_owned() => Some(Variant::Ref(root_id)),
-                },
+                changed_properties: [("Self".to_owned(), Some(Variant::Ref(root_id)))].into(),
                 changed_metadata: None,
             }],
             added_instances: Vec::new(),
@@ -359,9 +353,7 @@ mod test {
         let snapshot = InstanceSnapshot {
             snapshot_id: snapshot_id,
             children: vec![InstanceSnapshot {
-                properties: hashmap! {
-                    "Self".to_owned() => Variant::Ref(snapshot_id),
-                },
+                properties: [("Self".to_owned(), Variant::Ref(snapshot_id))].into(),
 
                 snapshot_id: Ref::none(),
                 metadata: Default::default(),
@@ -384,9 +376,7 @@ mod test {
                 instance: InstanceSnapshot {
                     snapshot_id: Ref::none(),
                     metadata: Default::default(),
-                    properties: hashmap! {
-                        "Self".to_owned() => Variant::Ref(root_id),
-                    },
+                    properties: [("Self".to_owned(), Variant::Ref(root_id))].into(),
                     name: Cow::Borrowed("child"),
                     class_name: Cow::Borrowed("child"),
                     children: Vec::new(),

--- a/src/snapshot/tests/apply.rs
+++ b/src/snapshot/tests/apply.rs
@@ -1,5 +1,4 @@
 use insta::assert_yaml_snapshot;
-use maplit::hashmap;
 
 use rojo_insta_ext::RedactionMap;
 
@@ -47,9 +46,7 @@ fn add_property() {
             id: tree.get_root_id(),
             changed_name: None,
             changed_class_name: None,
-            changed_properties: hashmap! {
-                "Foo".to_owned() => Some("Value of Foo".into()),
-            },
+            changed_properties: [("Foo".to_owned(), Some("Value of Foo".into()))].into(),
             changed_metadata: None,
         }],
         ..Default::default()
@@ -88,9 +85,7 @@ fn remove_property() {
             id: tree.get_root_id(),
             changed_name: None,
             changed_class_name: None,
-            changed_properties: hashmap! {
-                "Foo".to_owned() => None,
-            },
+            changed_properties: [("Foo".to_owned(), None).into()].into(),
             changed_metadata: None,
         }],
         ..Default::default()

--- a/src/snapshot/tests/compute.rs
+++ b/src/snapshot/tests/compute.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
 use insta::assert_yaml_snapshot;
-use maplit::hashmap;
 
 use rbx_dom_weak::types::Ref;
 use rojo_insta_ext::RedactionMap;
@@ -42,9 +41,7 @@ fn set_property() {
         metadata: Default::default(),
         name: Cow::Borrowed("ROOT"),
         class_name: Cow::Borrowed("ROOT"),
-        properties: hashmap! {
-            "PropertyName".to_owned() => "Hello, world!".into(),
-        },
+        properties: [("PropertyName".into(), "Hello, world!".into())].into(),
         children: Vec::new(),
     };
 

--- a/src/snapshot_middleware/csv.rs
+++ b/src/snapshot_middleware/csv.rs
@@ -1,7 +1,6 @@
 use std::{collections::BTreeMap, path::Path};
 
 use anyhow::Context;
-use maplit::hashmap;
 use memofs::{IoResultExt, Vfs};
 use serde::Serialize;
 
@@ -31,9 +30,7 @@ pub fn snapshot_csv(
     let mut snapshot = InstanceSnapshot::new()
         .name(name)
         .class_name("LocalizationTable")
-        .properties(hashmap! {
-            "Contents".to_owned() => table_contents.into(),
-        })
+        .properties([("Contents".to_owned(), table_contents.into())])
         .metadata(
             InstanceMetadata::new()
                 .instigating_source(path)

--- a/src/snapshot_middleware/dir.rs
+++ b/src/snapshot_middleware/dir.rs
@@ -108,7 +108,6 @@ pub fn snapshot_dir_no_meta(
 mod test {
     use super::*;
 
-    use maplit::hashmap;
     use memofs::{InMemoryFs, VfsSnapshot};
 
     #[test]
@@ -132,9 +131,7 @@ mod test {
         let mut imfs = InMemoryFs::new();
         imfs.load_snapshot(
             "/foo",
-            VfsSnapshot::dir(hashmap! {
-                "Child" => VfsSnapshot::empty_dir(),
-            }),
+            VfsSnapshot::dir([("Child", VfsSnapshot::empty_dir())]),
         )
         .unwrap();
 

--- a/src/snapshot_middleware/json.rs
+++ b/src/snapshot_middleware/json.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 
 use anyhow::Context;
-use maplit::hashmap;
 use memofs::{IoResultExt, Vfs};
 
 use crate::{
@@ -24,9 +23,7 @@ pub fn snapshot_json(
 
     let as_lua = json_to_lua(value).to_string();
 
-    let properties = hashmap! {
-        "Source".to_owned() => as_lua.into(),
-    };
+    let properties = [("Source".to_owned(), as_lua.into())];
 
     let meta_path = path.with_file_name(format!("{}.meta.json", name));
 

--- a/src/snapshot_middleware/lua.rs
+++ b/src/snapshot_middleware/lua.rs
@@ -116,7 +116,6 @@ pub fn snapshot_lua_init(
 mod test {
     use super::*;
 
-    use maplit::hashmap;
     use memofs::{InMemoryFs, VfsSnapshot};
 
     #[test]
@@ -263,9 +262,7 @@ mod test {
         let mut imfs = InMemoryFs::new();
         imfs.load_snapshot(
             "/root",
-            VfsSnapshot::dir(hashmap! {
-                "init.lua" => VfsSnapshot::file("Hello!"),
-            }),
+            VfsSnapshot::dir([("init.lua", VfsSnapshot::file("Hello!"))]),
         )
         .unwrap();
 

--- a/src/snapshot_middleware/project.rs
+++ b/src/snapshot_middleware/project.rs
@@ -340,7 +340,6 @@ fn infer_class_name(name: &str, parent_class: Option<&str>) -> Option<Cow<'stati
 mod test {
     use super::*;
 
-    use maplit::hashmap;
     use memofs::{InMemoryFs, VfsSnapshot};
 
     #[ignore = "Functionality moved to root snapshot middleware"]
@@ -351,16 +350,19 @@ mod test {
         let mut imfs = InMemoryFs::new();
         imfs.load_snapshot(
             "/foo",
-            VfsSnapshot::dir(hashmap! {
-                "default.project.json" => VfsSnapshot::file(r#"
+            VfsSnapshot::dir([(
+                "default.project.json",
+                VfsSnapshot::file(
+                    r#"
                     {
                         "name": "indirect-project",
                         "tree": {
                             "$className": "Folder"
                         }
                     }
-                "#),
-            }),
+                "#,
+                ),
+            )]),
         )
         .unwrap();
 
@@ -385,16 +387,19 @@ mod test {
         let mut imfs = InMemoryFs::new();
         imfs.load_snapshot(
             "/foo",
-            VfsSnapshot::dir(hashmap! {
-                "hello.project.json" => VfsSnapshot::file(r#"
+            VfsSnapshot::dir([(
+                "hello.project.json",
+                VfsSnapshot::file(
+                    r#"
                     {
                         "name": "direct-project",
                         "tree": {
                             "$className": "Model"
                         }
                     }
-                "#),
-            }),
+                "#,
+                ),
+            )]),
         )
         .unwrap();
 
@@ -533,17 +538,22 @@ mod test {
         let mut imfs = InMemoryFs::new();
         imfs.load_snapshot(
             "/foo",
-            VfsSnapshot::dir(hashmap! {
-                "default.project.json" => VfsSnapshot::file(r#"
+            VfsSnapshot::dir([
+                (
+                    "default.project.json",
+                    VfsSnapshot::file(
+                        r#"
                     {
                         "name": "path-project",
                         "tree": {
                             "$path": "other.txt"
                         }
                     }
-                "#),
-                "other.txt" => VfsSnapshot::file("Hello, world!"),
-            }),
+                "#,
+                    ),
+                ),
+                ("other.txt", VfsSnapshot::file("Hello, world!")),
+            ]),
         )
         .unwrap();
 
@@ -568,24 +578,34 @@ mod test {
         let mut imfs = InMemoryFs::new();
         imfs.load_snapshot(
             "/foo",
-            VfsSnapshot::dir(hashmap! {
-                "default.project.json" => VfsSnapshot::file(r#"
+            VfsSnapshot::dir([
+                (
+                    "default.project.json",
+                    VfsSnapshot::file(
+                        r#"
                     {
                         "name": "path-project",
                         "tree": {
                             "$path": "other.project.json"
                         }
                     }
-                "#),
-                "other.project.json" => VfsSnapshot::file(r#"
+                "#,
+                    ),
+                ),
+                (
+                    "other.project.json",
+                    VfsSnapshot::file(
+                        r#"
                     {
                         "name": "other-project",
                         "tree": {
                             "$className": "Model"
                         }
                     }
-                "#),
-            }),
+                "#,
+                    ),
+                ),
+            ]),
         )
         .unwrap();
 
@@ -610,16 +630,24 @@ mod test {
         let mut imfs = InMemoryFs::new();
         imfs.load_snapshot(
             "/foo",
-            VfsSnapshot::dir(hashmap! {
-                "default.project.json" => VfsSnapshot::file(r#"
+            VfsSnapshot::dir([
+                (
+                    "default.project.json",
+                    VfsSnapshot::file(
+                        r#"
                     {
                         "name": "path-child-project",
                         "tree": {
                             "$path": "other.project.json"
                         }
                     }
-                "#),
-                "other.project.json" => VfsSnapshot::file(r#"
+                "#,
+                    ),
+                ),
+                (
+                    "other.project.json",
+                    VfsSnapshot::file(
+                        r#"
                     {
                         "name": "other-project",
                         "tree": {
@@ -630,8 +658,10 @@ mod test {
                             }
                         }
                     }
-                "#),
-            }),
+                "#,
+                    ),
+                ),
+            ]),
         )
         .unwrap();
 
@@ -659,8 +689,11 @@ mod test {
         let mut imfs = InMemoryFs::new();
         imfs.load_snapshot(
             "/foo",
-            VfsSnapshot::dir(hashmap! {
-                "default.project.json" => VfsSnapshot::file(r#"
+            VfsSnapshot::dir([
+                (
+                    "default.project.json",
+                    VfsSnapshot::file(
+                        r#"
                     {
                         "name": "path-property-override",
                         "tree": {
@@ -670,8 +703,13 @@ mod test {
                             }
                         }
                     }
-                "#),
-                "other.project.json" => VfsSnapshot::file(r#"
+                "#,
+                    ),
+                ),
+                (
+                    "other.project.json",
+                    VfsSnapshot::file(
+                        r#"
                     {
                         "name": "other-project",
                         "tree": {
@@ -681,8 +719,10 @@ mod test {
                             }
                         }
                     }
-                "#),
-            }),
+                "#,
+                    ),
+                ),
+            ]),
         )
         .unwrap();
 
@@ -707,15 +747,18 @@ mod test {
         let mut imfs = InMemoryFs::new();
         imfs.load_snapshot(
             "/foo",
-            VfsSnapshot::dir(hashmap! {
-                "default.project.json" => VfsSnapshot::file(r#"
+            VfsSnapshot::dir([(
+                "default.project.json",
+                VfsSnapshot::file(
+                    r#"
                     {
                         "tree": {
                             "$className": "Model"
                         }
                     }
-                "#),
-            }),
+                "#,
+                ),
+            )]),
         )
         .unwrap();
 

--- a/src/snapshot_middleware/toml.rs
+++ b/src/snapshot_middleware/toml.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 
 use anyhow::Context;
-use maplit::hashmap;
 use memofs::{IoResultExt, Vfs};
 
 use crate::{
@@ -24,9 +23,7 @@ pub fn snapshot_toml(
 
     let as_lua = toml_to_lua(value).to_string();
 
-    let properties = hashmap! {
-        "Source".to_owned() => as_lua.into(),
-    };
+    let properties = [("Source".to_owned(), as_lua.into())];
 
     let meta_path = path.with_file_name(format!("{}.meta.json", name));
 

--- a/src/snapshot_middleware/txt.rs
+++ b/src/snapshot_middleware/txt.rs
@@ -1,6 +1,5 @@
 use std::{path::Path, str};
 
-use maplit::hashmap;
 use memofs::{IoResultExt, Vfs};
 
 use crate::snapshot::{InstanceContext, InstanceMetadata, InstanceSnapshot};
@@ -16,9 +15,7 @@ pub fn snapshot_txt(
     let contents = vfs.read_to_string(path)?;
     let contents_str = contents.as_str();
 
-    let properties = hashmap! {
-        "Value".to_owned() => contents_str.into(),
-    };
+    let properties = [("Value".to_owned(), contents_str.into())];
 
     let meta_path = path.with_file_name(format!("{}.meta.json", name));
 

--- a/src/web/ui.rs
+++ b/src/web/ui.rs
@@ -7,7 +7,6 @@
 use std::{borrow::Cow, sync::Arc, time::Duration};
 
 use hyper::{header, Body, Method, Request, Response, StatusCode};
-use maplit::hashmap;
 use rbx_dom_weak::types::{Ref, Variant};
 use ritz::{html, Fragment, HtmlContent, HtmlSelfClosingTag};
 
@@ -296,11 +295,12 @@ impl<'a> ExpandableSection<'a> {
         // support for conditional attributes like `checked`.
         let mut input = HtmlSelfClosingTag {
             name: Cow::Borrowed("input"),
-            attributes: hashmap! {
-                Cow::Borrowed("class") => Cow::Borrowed("expandable-input"),
-                Cow::Borrowed("id") => Cow::Owned(input_id.clone()),
-                Cow::Borrowed("type") => Cow::Borrowed("checkbox"),
-            },
+            attributes: [
+                (Cow::Borrowed("class"), Cow::Borrowed("expandable-input")),
+                (Cow::Borrowed("id"), Cow::Owned(input_id.clone())),
+                (Cow::Borrowed("type"), Cow::Borrowed("checkbox")),
+            ]
+            .into(),
         };
 
         if self.expanded {


### PR DESCRIPTION
I'm tired of this macro. It will cause us trouble down the line when we try to swap to a faster hashmap, and it's just not idiomatic.

So, I have removed it. In practice this mostly impacts tests.