### PR TITLE
Fix returning NoProjectFound session for any project load error

### DIFF
--- a/src/serve_session.rs
+++ b/src/serve_session.rs
@@ -3,7 +3,7 @@ use std::{
     collections::HashSet,
     io,
     net::IpAddr,
-    path::{Path, PathBuf},
+    path::Path,
     sync::{Arc, Mutex, MutexGuard},
     time::Instant,
 };
@@ -109,14 +109,7 @@ impl ServeSession {
 
         log::debug!("Loading project file from {}", project_path.display());
 
-        let root_project = match Project::load_exact(&vfs, &project_path, None) {
-            Ok(project) => project,
-            Err(_) => {
-                return Err(ServeSessionError::NoProjectFound {
-                    path: project_path.to_path_buf(),
-                })
-            }
-        };
+        let root_project = Project::load_exact(&vfs, &project_path, None)?;
 
         let mut tree = RojoTree::new(InstanceSnapshot::new());
 
@@ -226,13 +219,6 @@ impl ServeSession {
 
 #[derive(Debug, Error)]
 pub enum ServeSessionError {
-    #[error(
-        "Rojo requires a project file, but no project file was found in path {}\n\
-        See https://rojo.space/docs/ for guides and documentation.",
-        .path.display()
-    )]
-    NoProjectFound { path: PathBuf },
-
     #[error(transparent)]
     Io {
         #[from]


### PR DESCRIPTION
In #917, we accidentally changed ServeSession::new's project loading logic so that it always returns `ServeSession::ProjectNotFound` if the load fails for any reason. This PR fixes this so that it returns the right error when there is an error loading the project, and moves the `NoProjectFound` error to `project::Error`, since I think it makes more sense there.