### PR TITLE
Make sync reminder more detailed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Added experimental setting for Auto Connect in playtests ([#840])
 * Improved settings UI ([#886])
 * `Open Scripts Externally` option can now be changed while syncing ([#911])
+* The sync reminder notification will now tell you what was last synced and when ([#987])
 * Projects may now specify rules for syncing files as if they had a different file extension. ([#813])
  	This is specified via a new field on project files, `syncRules`:
 
@@ -87,6 +88,7 @@
 [#911]: https://github.com/rojo-rbx/rojo/pull/911
 [#915]: https://github.com/rojo-rbx/rojo/pull/915
 [#974]: https://github.com/rojo-rbx/rojo/pull/974
+[#987]: https://github.com/rojo-rbx/rojo/pull/987
 
 ## [7.4.3] - August 6th, 2024
 * Fixed issue with building binary files introduced in 7.4.2


### PR DESCRIPTION
Closes #986.

The sync reminder notification will now tell you what you synced and when you synced it.

Example: `You synced project 'LuaLearning' to this place 2 hours ago. Would you like to reconnect?`

If there's no known project name, it'll fallback to: `You synced localhost:34872 to this place 2 hours ago. Would you like to reconnect?`
This should only happen once per place, since the existing save data you have before this update didn't store the project name.