### PR TITLE
Improve notification layout

### DIFF
--- a/plugin/src/App/Notifications.lua
+++ b/plugin/src/App/Notifications.lua
@@ -113,12 +113,9 @@ function Notification:render()
 		end
 
 		local paddingY, logoSize = 20, 32
-		local actionsY = if self.props.actions then 35 else 0
+		local actionsY = if self.props.actions then 37 else 0
 		local textXSpace = math.max(250, buttonsX) + 35
-		local textBounds = Vector2.new(
-			textXSpace,
-			getTextBoundsAsync(self.props.text, theme.Font.Main, theme.TextSize.Body, textXSpace).Y
-		)
+		local textBounds = getTextBoundsAsync(self.props.text, theme.Font.Main, theme.TextSize.Body, textXSpace)
 		local contentX = math.max(textBounds.X, buttonsX)
 
 		local size = self.binding:map(function(value)
@@ -162,10 +159,10 @@ function Notification:render()
 						TextColor3 = theme.Notification.InfoColor,
 						TextTransparency = transparency,
 						TextXAlignment = Enum.TextXAlignment.Left,
-						TextYAlignment = Enum.TextYAlignment.Top,
+						TextYAlignment = Enum.TextYAlignment.Center,
 						TextWrapped = true,
 
-						Size = UDim2.new(1, -35, 1, -actionsY),
+						Size = UDim2.new(0, textBounds.X, 1, -actionsY),
 						Position = UDim2.fromOffset(35, 0),
 
 						LayoutOrder = 1,


### PR DESCRIPTION
Changes:

- The width of the notification will be the minimum space required. (It used to do this, but was broken in #988.)
- The text is centered, making single line notifs feel less unbalanced.

Before & After:
![image](https://github.com/user-attachments/assets/db97ca79-0c5a-4a32-b0d6-b3dd1ea6a586)
![image](https://github.com/user-attachments/assets/f672291c-4b7b-4b96-929e-a08fbac80e89)

- The text wrapping no longer shifts around as the notification animates in.

Before & After: (Slowed to show the effect more clearly)

https://github.com/user-attachments/assets/957e692f-9807-4b17-b52e-07f7cc427653

https://github.com/user-attachments/assets/c6c7df0f-df2e-4ec4-b10f-ff8f7f42ec17

