### PR TITLE
NaN deserialization patch - causes Rojo sync failure

### DIFF
--- a/plugin/rbx_dom_lua/EncodedValue.lua
+++ b/plugin/rbx_dom_lua/EncodedValue.lua
@@ -300,7 +300,7 @@ types = {
 			local keypoints = {}
 
 			for index, keypoint in ipairs(pod.keypoints) do
-				keypoints[index] = NumberSequenceKeypoint.new(keypoint.time, keypoint.value, keypoint.envelope)
+				keypoints[index] = NumberSequenceKeypoint.new(keypoint.time, keypoint.value or 0, keypoint.envelope)
 			end
 
 			return NumberSequence.new(keypoints)


### PR DESCRIPTION
Patches edge-case where the Rojo Sync will fail when the underlying rbx binary has a NaN for the NumberSequenceKeypoint value.