### PR TITLE
Add place ID blacklist config

### DIFF
--- a/plugin/src/ApiContext.lua
+++ b/plugin/src/ApiContext.lua
@@ -43,16 +43,22 @@ local function rejectWrongProtocolVersion(infoResponseBody)
 	return Promise.resolve(infoResponseBody)
 end
 
+local function findPlaceId(placeIds)
+	local foundId = false
+
+    for _, id in ipairs(placeIds) do
+        if id == game.PlaceId then
+            foundId = true
+            break
+        end
+    end
+
+    return foundId
+end
+
 local function rejectWrongPlaceId(infoResponseBody)
 	if infoResponseBody.expectedPlaceIds ~= nil then
-		local foundId = false
-
-		for _, id in ipairs(infoResponseBody.expectedPlaceIds) do
-			if id == game.PlaceId then
-				foundId = true
-				break
-			end
-		end
+		local foundId = findPlaceId(infoResponseBody.expectedPlaceIds)
 
 		if not foundId then
 			local idList = {}
@@ -65,6 +71,26 @@ local function rejectWrongPlaceId(infoResponseBody)
 				.. "\nYour place ID is %s, but needs to be one of these:"
 				.. "\n%s"
 				.. "\n\nTo change this list, edit 'servePlaceIds' in your .project.json file."
+			):format(tostring(game.PlaceId), table.concat(idList, "\n"))
+
+			return Promise.reject(message)
+		end
+	end
+
+	if infoResponseBody.unexpectedPlaceIds ~= nil then
+		local foundId = findPlaceId(infoResponseBody.unexpectedPlaceIds)
+
+		if foundId then
+			local idList = {}
+			for _, id in ipairs(infoResponseBody.unexpectedPlaceIds) do
+				table.insert(idList, "- " .. tostring(id))
+			end
+
+			local message = (
+				"Found a Rojo server, but its project is set to not be used with a specific list of places."
+				.. "\nYour place ID is %s, but needs to not be one of these:"
+				.. "\n%s"
+				.. "\n\nTo change this list, edit 'avoidPlaceIds' in your .project.json file."
 			):format(tostring(game.PlaceId), table.concat(idList, "\n"))
 
 			return Promise.reject(message)

--- a/src/project.rs
+++ b/src/project.rs
@@ -78,6 +78,14 @@ pub struct Project {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub serve_place_ids: Option<HashSet<u64>>,
 
+    /// If specified, contains a set of place IDs that this project is
+    /// not compatible with when doing live sync.
+    ///
+    /// This setting is intended to help prevent syncing a Rojo project into the
+    /// wrong Roblox place.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avoid_place_ids: Option<HashSet<u64>>,
+
     /// If specified, sets the current place's place ID when connecting to the
     /// Rojo server from Roblox Studio.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/serve_session.rs
+++ b/src/serve_session.rs
@@ -208,6 +208,10 @@ impl ServeSession {
         self.root_project.serve_place_ids.as_ref()
     }
 
+    pub fn avoid_place_ids(&self) -> Option<&HashSet<u64>> {
+        self.root_project.avoid_place_ids.as_ref()
+    }
+
     pub fn serve_address(&self) -> Option<IpAddr> {
         self.root_project.serve_address
     }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -64,6 +64,7 @@ impl ApiService {
             session_id: self.serve_session.session_id(),
             project_name: self.serve_session.project_name().to_owned(),
             expected_place_ids: self.serve_session.serve_place_ids().cloned(),
+            unexpected_place_ids: self.serve_session.avoid_place_ids().cloned(),
             place_id: self.serve_session.place_id(),
             game_id: self.serve_session.game_id(),
             root_instance_id,

--- a/src/web/interface.rs
+++ b/src/web/interface.rs
@@ -157,6 +157,7 @@ pub struct ServerInfoResponse {
     pub protocol_version: u64,
     pub project_name: String,
     pub expected_place_ids: Option<HashSet<u64>>,
+    pub unexpected_place_ids: Option<HashSet<u64>>,
     pub game_id: Option<u64>,
     pub place_id: Option<u64>,
     pub root_instance_id: Ref,


### PR DESCRIPTION
Addresses #961 

Along with `servePlaceIds`, this adds an `avoidPlaceIds` option to the project config that allows development teams to block certain place ids from being synced to, such as a production place.