### PR TITLE
Add missing CHANGELOG entry for 7.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,10 @@
 [#988]: https://github.com/rojo-rbx/rojo/pull/988
 [#1008]: https://github.com/rojo-rbx/rojo/pull/1008
 
+## [7.4.4] - August 22nd, 2024
+* Fixed issue with reading attributes from `Lighting` in new place files
+* `Instance.Archivable` will now default to `true` when building a project into a binary (`rbxm`/`rbxl`) file rather than `false`.
+
 ## [7.4.3] - August 6th, 2024
 * Fixed issue with building binary files introduced in 7.4.2
 * Fixed `value of type nil cannot be converted to number` warning spam in output. [#955]


### PR DESCRIPTION
Appears in the last 7.4.4 release we forgot to add the changelog entry into master. We stay silly.