### PR TITLE
Change release build linux version to ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         # https://doc.rust-lang.org/rustc/platform-support.html
         include:
           - host: linux
-            os: ubuntu-20.04
+            os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             label: linux-x86_64
 


### PR DESCRIPTION
May have consequences - it's possible that the binary will be ran on systems with an out-of-date glibc