### PR TITLE
Add current maintainers to author field of Cargo.toml files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,11 @@
 name = "rojo"
 version = "7.5.1"
 rust-version = "1.70.0"
-authors = ["Lucien Greathouse <me@lpghatguy.com>"]
+authors = [
+    "Lucien Greathouse <me@lpghatguy.com>",
+    "Micah Reid <git@dekkonot.com>",
+    "Ken Loeffler <kenloef@gmail.com>",
+]
 description = "Enables professional-grade development tools for Roblox developers"
 license = "MPL-2.0"
 homepage = "https://rojo.space"

--- a/crates/memofs/Cargo.toml
+++ b/crates/memofs/Cargo.toml
@@ -2,7 +2,11 @@
 name = "memofs"
 description = "Virtual filesystem with configurable backends."
 version = "0.3.0"
-authors = ["Lucien Greathouse <me@lpghatguy.com>"]
+authors = [
+    "Lucien Greathouse <me@lpghatguy.com>",
+    "Micah Reid <git@dekkonot.com>",
+    "Ken Loeffler <kenloef@gmail.com>",
+]
 edition = "2018"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Suggested by Lucien, we should add the current maintainers to the Authors field of the Cargo.tomls

Nobody but Lucien has contributed to `cargo-insta-ext` yet, but this adds @kennethloeffler and myself to the Authors field for Rojo and memofs.