### PR TITLE
Fix auto connect for play mode

### DIFF
--- a/plugin/src/App/init.lua
+++ b/plugin/src/App/init.lua
@@ -403,7 +403,8 @@ function App:releaseSyncLock()
 end
 
 function App:isAutoConnectPlaytestServerAvailable()
-	return RunService:IsRunMode()
+	return RunService:IsRunning()
+		and RunService:IsStudio()
 		and RunService:IsServer()
 		and Settings:get("autoConnectPlaytestServer")
 		and workspace:GetAttribute("__Rojo_ConnectionUrl")


### PR DESCRIPTION
Recently, [a change was made to :IsRunMode()](https://devforum.roblox.com/t/runserviceisrunmode-always-returns-true-even-when-using-play-hereplay-in-roblox-studio/534992/15), breaking the plugin's auto-connect in play mode.

This PR resolves #1049 by changing the plugin to check for :IsRunning() and :IsStudio() instead of :IsRunMode().