### PR TITLE
Cache Rust Dependencies in release.yml.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,14 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
 
-    - name: Rust cache
-      uses: Swatinem/rust-cache@v2
+    - name: Restore Rust Cache
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Setup Aftman
       uses: ok-nick/setup-aftman@v0.4.2
@@ -39,6 +45,15 @@ jobs:
 
     - name: Test
       run: cargo test --locked --verbose
+
+    - name: Save Rust Cache
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
   msrv:
     name: Check MSRV
@@ -52,8 +67,14 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@1.70.0
 
-    - name: Rust cache
-      uses: Swatinem/rust-cache@v2
+    - name: Restore Rust Cache
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Setup Aftman
       uses: ok-nick/setup-aftman@v0.4.2
@@ -62,6 +83,15 @@ jobs:
 
     - name: Build
       run: cargo build --locked --verbose
+
+    - name: Save Rust Cache
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
   lint:
     name: Rustfmt, Clippy, Stylua, & Selene
@@ -77,8 +107,14 @@ jobs:
       with:
         components: rustfmt, clippy
 
-    - name: Rust cache
-      uses: Swatinem/rust-cache@v2
+    - name: Restore Rust Cache
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Setup Aftman
       uses: ok-nick/setup-aftman@v0.4.2
@@ -97,3 +133,11 @@ jobs:
     - name: Clippy
       run: cargo clippy
 
+    - name: Save Rust Cache
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,15 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Restore Rust Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            output
+          key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Setup Aftman
         uses: ok-nick/setup-aftman@v0.4.2
         with:
@@ -97,6 +106,15 @@ jobs:
           # Build into a known directory so we can find our build artifact more
           # easily.
           CARGO_TARGET_DIR: output
+
+      - name: Save Rust Cache
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            output
+          key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Generate Artifact Name
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            output
+            target
           key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Setup Aftman
@@ -102,10 +102,6 @@ jobs:
 
       - name: Build Release
         run: cargo build --release --locked --verbose --target ${{ matrix.target }}
-        env:
-          # Build into a known directory so we can find our build artifact more
-          # easily.
-          CARGO_TARGET_DIR: output
 
       - name: Save Rust Cache
         uses: actions/cache/save@v4
@@ -113,7 +109,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            output
+            target
           key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Generate Artifact Name
@@ -131,11 +127,11 @@ jobs:
           mkdir staging
 
           if [ "${{ matrix.host }}" = "windows" ]; then
-            cp "output/${{ matrix.target }}/release/$BIN.exe" staging/
+            cp "target/${{ matrix.target }}/release/$BIN.exe" staging/
             cd staging
             7z a ../$ARTIFACT_NAME *
           else
-            cp "output/${{ matrix.target }}/release/$BIN" staging/
+            cp "target/${{ matrix.target }}/release/$BIN" staging/
             cd staging
             zip ../$ARTIFACT_NAME *
           fi


### PR DESCRIPTION
Caches the rust dependencies (`~/.cargo/registry`, ` ~/.cargo/git`, `output`) used for compiling in the release.yml. It uses the matrix os and a hash of the Cargo.lock file in the key.