### PR TITLE
Change background color of web UI to gray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Rojo Changelog
 
 ## Unreleased
+* Changed the background of the server's in-browser UI to be gray instead of white ([#1080]) 
 * Fixed `Auto Connect Playtest Server` no longer functioning due to Roblox change ([#1066])
 * Added an update indicator to the version header when a new version of the plugin is available. ([#1069])
 
+[#1080]: https://github.com/rojo-rbx/rojo/pull/1080
 [#1049]: https://github.com/rojo-rbx/rojo/pull/1066
 [#1069]: https://github.com/rojo-rbx/rojo/pull/1069
 

--- a/assets/index.css
+++ b/assets/index.css
@@ -17,6 +17,10 @@ html {
   line-height: 1.4;
 }
 
+body {
+  background-color: #e7e7e7
+}
+
 img {
   max-width:100%;
   max-height:100%;


### PR DESCRIPTION
closes #839

This does not add a dark theme to the server website, but that's more complicated than just adding a CSS property. 

Before:
<img width="625" height="372" alt="image" src="https://github.com/user-attachments/assets/009dc85d-6fc2-4db5-b153-855d66c2f797" />

After:
<img width="676" height="373" alt="image" src="https://github.com/user-attachments/assets/22ea2b26-e306-4a45-a222-0b6c254af0f2" />