### PR TITLE
Fix Table diff colors

### DIFF
--- a/plugin/src/App/Components/TableDiffVisualizer/Dictionary.lua
+++ b/plugin/src/App/Components/TableDiffVisualizer/Dictionary.lua
@@ -114,7 +114,7 @@ function Dictionary:render()
 						TextXAlignment = Enum.TextXAlignment.Left,
 						FontFace = theme.Font.Main,
 						TextSize = theme.TextSize.Body,
-						TextColor3 = Color3.new(0, 0, 0),
+						TextColor3 = if line.patchType ~= "Remain" then Color3.new(0, 0, 0) else theme.Settings.Setting.DescriptionColor,
 						TextTruncate = Enum.TextTruncate.AtEnd,
 					}),
 					OldValue = e("Frame", {
@@ -125,7 +125,7 @@ function Dictionary:render()
 						e(DisplayValue, {
 							value = oldValue,
 							transparency = self.props.transparency,
-							textColor = Color3.new(0, 0, 0),
+							textColor = if line.patchType ~= "Remain" then Color3.new(0, 0, 0) else theme.Settings.Setting.DescriptionColor,
 						}),
 					}),
 					NewValue = e("Frame", {
@@ -136,7 +136,7 @@ function Dictionary:render()
 						e(DisplayValue, {
 							value = newValue,
 							transparency = self.props.transparency,
-							textColor = Color3.new(0, 0, 0),
+							textColor = if line.patchType ~= "Remain" then Color3.new(0, 0, 0) else theme.Settings.Setting.DescriptionColor,
 						}),
 					}),
 				})

--- a/plugin/src/App/Components/TableDiffVisualizer/Dictionary.lua
+++ b/plugin/src/App/Components/TableDiffVisualizer/Dictionary.lua
@@ -114,7 +114,7 @@ function Dictionary:render()
 						TextXAlignment = Enum.TextXAlignment.Left,
 						FontFace = theme.Font.Main,
 						TextSize = theme.TextSize.Body,
-						TextColor3 = theme.Settings.Setting.DescriptionColor,
+						TextColor3 = Color3.new(0, 0, 0),
 						TextTruncate = Enum.TextTruncate.AtEnd,
 					}),
 					OldValue = e("Frame", {
@@ -125,7 +125,7 @@ function Dictionary:render()
 						e(DisplayValue, {
 							value = oldValue,
 							transparency = self.props.transparency,
-							textColor = theme.Settings.Setting.DescriptionColor,
+							textColor = Color3.new(0, 0, 0),
 						}),
 					}),
 					NewValue = e("Frame", {
@@ -136,7 +136,7 @@ function Dictionary:render()
 						e(DisplayValue, {
 							value = newValue,
 							transparency = self.props.transparency,
-							textColor = theme.Settings.Setting.DescriptionColor,
+							textColor = Color3.new(0, 0, 0),
 						}),
 					}),
 				})


### PR DESCRIPTION
This PR is a fix for #943

I have updated table diffs to have proper colors in dark theme, I have added screenshots to reflect the new look. The UI forces the text to be black when a change has happened (addition, removal, edit) and in all other situations uses the same theme color as it did before, I skimmed through the theme and didn't find any colors that looked good in both light and dark theme here so that's why its forced to black. From my testing this looks pretty good but I am open to feedback!

<img width="251.5" height="175.5" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/068f1f9f-fcd1-4734-9ba4-e35d66ac33c6" />
<img width="251.5" height="175.5" alt="Table diff" src="https://github.com/user-attachments/assets/222bbf31-f5ff-4f06-a968-d95001014c5f" />
<img width="251.5" height="175.5" alt="Attrib2" src="https://github.com/user-attachments/assets/6f055b60-2eea-4468-8285-d807c71859f1" />

_(Ignore attribute name lol)_