### PR TITLE
Add Arm64 builds to CI/Releases + build on ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, windows-11-arm, ubuntu-24.04-arm]
+        os: [ubuntu-22.04, windows-latest, macos-latest, windows-11-arm, ubuntu-22.04-arm]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,12 +53,12 @@ jobs:
         # https://doc.rust-lang.org/rustc/platform-support.html
         include:
           - host: linux
-            os: ubuntu-latest
+            os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             label: linux-x86_64
 
           - host: linux
-            os: ubuntu-24.04-arm
+            os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             label: linux-aarch64
 


### PR DESCRIPTION
As of not very long ago, GitHub supports arm64 runners for Linux and Windows in public repositories. That's us! We should support this now that we can.

I'm defaulting to `ubuntu-24.04-arm` rather than `ubuntu-22.04-arm` because it's also the version that `ubuntu-latest` uses.