### PR TITLE
Put Rojo version in crash message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,10 @@ fn main() {
             },
         };
 
-        log::error!("Rojo crashed!");
+        log::error!(
+            "Rojo crashed! You are running Rojo {}.",
+            env!("CARGO_PKG_VERSION")
+        );
         log::error!("This is probably a Rojo bug.");
         log::error!("");
         log::error!(


### PR DESCRIPTION
We get a lot of bug reports that are just people posting the crash they got from Rojo. Including the version number will make debugging those faster, as we'll be able to tell immediately if someone is running an out of date version.