### PR TITLE
fix: apply `gameId` and `placeId` only after initial sync

### DIFF
--- a/plugin/src/ServeSession.lua
+++ b/plugin/src/ServeSession.lua
@@ -139,10 +139,9 @@ function ServeSession:start()
 	self.__apiContext
 		:connect()
 		:andThen(function(serverInfo)
-			self:__applyGameAndPlaceId(serverInfo)
-
 			return self:__initialSync(serverInfo):andThen(function()
 				self:__setStatus(Status.Connected, serverInfo.projectName)
+				self:__applyGameAndPlaceId(serverInfo)
 
 				return self:__mainSyncLoop()
 			end)


### PR DESCRIPTION
Closes #1103 