### PR TITLE
Fix a grammar error and a typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -720,7 +720,7 @@ This is a general maintenance release for the Rojo 0.5.x release series.
 
 ## [0.5.0 Alpha 11](https://github.com/rojo-rbx/rojo/releases/tag/v0.5.0-alpha.11) (May 29, 2019)
 * Added support for implicit property values in JSON model files ([#154](https://github.com/rojo-rbx/rojo/pull/154))
-* `Content` propertyes can now be specified in projects and model files as regular string literals.
+* `Content` properties can now be specified in projects and model files as regular string literals.
 * Added support for `BrickColor` properties.
 * Added support for properties added in client release 384, like `Lighting.Technology` being set to `"ShadowMap"`.
 * Improved performance when working with XML models and places

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ bash scripts/unit-test-plugin.sh
 ## Documentation
 Documentation impacts way more people than the individual lines of code we write.
 
-If you find any problems in documentation, including typos, bad grammar, misleading phrasing, or missing content, feel free to file issues and pull requests to fix them.
+If you find any problems in the documentation, including typos, bad grammar, misleading phrasing, or missing content, feel free to file issues and pull requests to fix them.
 
 ## Bug Reports and Feature Requests
 Most of the tools around Rojo try to be clear when an issue is a bug. Even if they aren't, sometimes things don't work quite right.


### PR DESCRIPTION
I've found and fixed a couple of typos/grammar errors while reading through the docs:

1. propertyes -> properties in `CHANGELOG.md`
2. "problems in documentation" -> "problems in the documentation" in `CONTRIBUTING.md`

> These are only minor changes. Expect no semantic change.
