### PR TITLE
Fix the various lints

### DIFF
--- a/crates/memofs/src/in_memory_fs.rs
+++ b/crates/memofs/src/in_memory_fs.rs
@@ -228,23 +228,17 @@ impl VfsBackend for InMemoryFs {
 }
 
 fn must_be_file<T>(path: &Path) -> io::Result<T> {
-    Err(io::Error::new(
-        io::ErrorKind::Other,
-        format!(
-            "path {} was a directory, but must be a file",
-            path.display()
-        ),
-    ))
+    Err(io::Error::other(format!(
+        "path {} was a directory, but must be a file",
+        path.display()
+    )))
 }
 
 fn must_be_dir<T>(path: &Path) -> io::Result<T> {
-    Err(io::Error::new(
-        io::ErrorKind::Other,
-        format!(
-            "path {} was a file, but must be a directory",
-            path.display()
-        ),
-    ))
+    Err(io::Error::other(format!(
+        "path {} was a file, but must be a directory",
+        path.display()
+    )))
 }
 
 fn not_found<T>(path: &Path) -> io::Result<T> {

--- a/crates/memofs/src/noop_backend.rs
+++ b/crates/memofs/src/noop_backend.rs
@@ -15,45 +15,27 @@ impl NoopBackend {
 
 impl VfsBackend for NoopBackend {
     fn read(&mut self, _path: &Path) -> io::Result<Vec<u8>> {
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "NoopBackend doesn't do anything",
-        ))
+        Err(io::Error::other("NoopBackend doesn't do anything"))
     }
 
     fn write(&mut self, _path: &Path, _data: &[u8]) -> io::Result<()> {
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "NoopBackend doesn't do anything",
-        ))
+        Err(io::Error::other("NoopBackend doesn't do anything"))
     }
 
     fn read_dir(&mut self, _path: &Path) -> io::Result<ReadDir> {
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "NoopBackend doesn't do anything",
-        ))
+        Err(io::Error::other("NoopBackend doesn't do anything"))
     }
 
     fn remove_file(&mut self, _path: &Path) -> io::Result<()> {
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "NoopBackend doesn't do anything",
-        ))
+        Err(io::Error::other("NoopBackend doesn't do anything"))
     }
 
     fn remove_dir_all(&mut self, _path: &Path) -> io::Result<()> {
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "NoopBackend doesn't do anything",
-        ))
+        Err(io::Error::other("NoopBackend doesn't do anything"))
     }
 
     fn metadata(&mut self, _path: &Path) -> io::Result<Metadata> {
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "NoopBackend doesn't do anything",
-        ))
+        Err(io::Error::other("NoopBackend doesn't do anything"))
     }
 
     fn event_receiver(&self) -> crossbeam_channel::Receiver<VfsEvent> {
@@ -61,17 +43,11 @@ impl VfsBackend for NoopBackend {
     }
 
     fn watch(&mut self, _path: &Path) -> io::Result<()> {
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "NoopBackend doesn't do anything",
-        ))
+        Err(io::Error::other("NoopBackend doesn't do anything"))
     }
 
     fn unwatch(&mut self, _path: &Path) -> io::Result<()> {
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "NoopBackend doesn't do anything",
-        ))
+        Err(io::Error::other("NoopBackend doesn't do anything"))
     }
 }
 

--- a/crates/memofs/src/std_backend.rs
+++ b/crates/memofs/src/std_backend.rs
@@ -109,15 +109,13 @@ impl VfsBackend for StdBackend {
             self.watches.insert(path.to_path_buf());
             self.watcher
                 .watch(path, RecursiveMode::Recursive)
-                .map_err(|inner| io::Error::new(io::ErrorKind::Other, inner))
+                .map_err(io::Error::other)
         }
     }
 
     fn unwatch(&mut self, path: &Path) -> io::Result<()> {
         self.watches.remove(path);
-        self.watcher
-            .unwatch(path)
-            .map_err(|inner| io::Error::new(io::ErrorKind::Other, inner))
+        self.watcher.unwatch(path).map_err(io::Error::other)
     }
 }
 

--- a/src/cli/upload.rs
+++ b/src/cli/upload.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
-use std::str::FromStr;
 
-use anyhow::{bail, format_err, Context};
+use anyhow::{bail, Context};
 use clap::Parser;
 use memofs::Vfs;
 use reqwest::{
@@ -87,32 +86,6 @@ impl UploadCommand {
                 // API key is provided, universe id is not.
                 bail!("--universe_id must be provided to use the Open Cloud API");
             }
-        }
-    }
-}
-
-/// The kind of asset to upload to the website. Affects what endpoints Rojo uses
-/// and changes how the asset is built.
-#[derive(Debug, Clone, Copy)]
-enum UploadKind {
-    /// Upload to a place.
-    Place,
-
-    /// Upload to a model-like asset, like a Model, Plugin, or Package.
-    Model,
-}
-
-impl FromStr for UploadKind {
-    type Err = anyhow::Error;
-
-    fn from_str(source: &str) -> Result<Self, Self::Err> {
-        match source {
-            "place" => Ok(UploadKind::Place),
-            "model" => Ok(UploadKind::Model),
-            attempted => Err(format_err!(
-                "Invalid upload kind '{}'. Valid kinds are: place, model",
-                attempted
-            )),
         }
     }
 }

--- a/src/snapshot/metadata.rs
+++ b/src/snapshot/metadata.rs
@@ -221,7 +221,7 @@ pub enum InstigatingSource {
     ProjectNode(
         #[serde(serialize_with = "path_serializer::serialize_absolute")] PathBuf,
         String,
-        ProjectNode,
+        Box<ProjectNode>,
         Option<String>,
     ),
 }

--- a/src/snapshot/tree.rs
+++ b/src/snapshot/tree.rs
@@ -73,7 +73,7 @@ impl RojoTree {
         self.inner.root_ref()
     }
 
-    pub fn get_instance(&self, id: Ref) -> Option<InstanceWithMeta> {
+    pub fn get_instance(&self, id: Ref) -> Option<InstanceWithMeta<'_>> {
         if let Some(instance) = self.inner.get_by_ref(id) {
             let metadata = self.metadata_map.get(&id).unwrap();
 
@@ -83,7 +83,7 @@ impl RojoTree {
         }
     }
 
-    pub fn get_instance_mut(&mut self, id: Ref) -> Option<InstanceWithMetaMut> {
+    pub fn get_instance_mut(&mut self, id: Ref) -> Option<InstanceWithMetaMut<'_>> {
         if let Some(instance) = self.inner.get_by_ref_mut(id) {
             let metadata = self.metadata_map.get_mut(&id).unwrap();
 

--- a/src/snapshot_middleware/project.rs
+++ b/src/snapshot_middleware/project.rs
@@ -289,7 +289,7 @@ pub fn snapshot_project_node(
     metadata.instigating_source = Some(InstigatingSource::ProjectNode(
         project_path.to_path_buf(),
         instance_name.to_string(),
-        node.clone(),
+        Box::new(node.clone()),
         parent_class.map(|name| name.to_owned()),
     ));
 

--- a/tests/rojo_test/serve_util.rs
+++ b/tests/rojo_test/serve_util.rs
@@ -160,7 +160,7 @@ impl TestServeSession {
         Ok(serde_json::from_str(&body).expect("Server returned malformed response"))
     }
 
-    pub fn get_api_read(&self, id: Ref) -> Result<ReadResponse, reqwest::Error> {
+    pub fn get_api_read(&self, id: Ref) -> Result<ReadResponse<'_>, reqwest::Error> {
         let url = format!("http://localhost:{}/api/read/{}", self.port, id);
         let body = reqwest::blocking::get(url)?.text()?;
 


### PR DESCRIPTION
The only questionable one here is `Box`ing the `ProjectNode` in `InstigatingSource::ProjectNode` to make that variant smaller. It might be worth trying to put nodes into `Arc` to reduce memory footprint, but I'm unsure whether that's actually worth exploring right now and it's potentially more involved so this is a quick-fix.