### PR TITLE
Add musl release builds for x86_64 and aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,16 @@ jobs:
             target: aarch64-unknown-linux-gnu
             label: linux-aarch64
 
+          - host: linux
+            os: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
+            label: linux-x86_64-musl
+
+          - host: linux
+            os: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-musl
+            label: linux-aarch64-musl
+
           - host: windows
             os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -90,6 +100,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+
+      - name: Install musl build dependencies
+        if: contains(matrix.target, 'musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends musl-tools
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Add musl static linking build support for Linux x86_64 and aarch64, providing better portability (no glibc dependency, closes #1118)