### PR TITLE
Fix MeshPart/UnionOperation losing mesh data on initial sync

### DIFF
--- a/plugin/src/Reconciler/reify.lua
+++ b/plugin/src/Reconciler/reify.lua
@@ -46,7 +46,16 @@ function reifyInstanceInner(unappliedPatch, deferredRefs, instanceMap, virtualIn
 	-- something that requires higher security than we have.
 	local createSuccess, instance = pcall(Instance.new, virtualInstance.ClassName)
 
-	if not createSuccess then
+	-- MeshPart and UnionOperation require SerializationService to properly
+	-- set their mesh data (MeshId/MeshContent). Instance.new() now succeeds
+	-- for these classes but creates empty meshes, and the mesh properties
+	-- are read-only after creation. Force these to use the fallback mechanism.
+	local requiresFallback = virtualInstance.ClassName == "MeshPart"
+		or virtualInstance.ClassName == "UnionOperation"
+		or virtualInstance.ClassName == "IntersectOperation"
+		or virtualInstance.ClassName == "NegateOperation"
+
+	if not createSuccess or requiresFallback then
 		addAllToPatch(unappliedPatch, virtualInstances, id)
 		return
 	end


### PR DESCRIPTION
This fix addresses two issues that cause MeshPart and UnionOperation instances to lose their mesh data (MeshId/MeshContent) when reconnecting:

1. Force fallback for mesh-based classes: Instance.new("MeshPart") now succeeds in Roblox (behavior change) but creates an empty mesh with read-only MeshContent property. Force MeshPart, UnionOperation, IntersectOperation, and NegateOperation to use SerializationService fallback mechanism which can properly create these instances with their mesh data.

2. Batch serialize/refPatch API calls: The fallback mechanism was failing with "URL too long" errors when many instances needed serialization because all IDs were concatenated into a single URL. Now processes IDs in batches of 50 to stay within URL length limits.

Fix for this issue: https://github.com/rojo-rbx/rojo/issues/1182

**NOTE: Maybe how it's coded can be coded better?**

(PS: Untested)
(Only copied code from our working forked Repo)