### PR TITLE
Use `WeakDom::full_path_of`

### DIFF
--- a/src/syncback/ref_properties.rs
+++ b/src/syncback/ref_properties.rs
@@ -8,10 +8,8 @@ use rbx_dom_weak::{
     ustr, Instance, Ustr, WeakDom,
 };
 
-use crate::{
-    multimap::MultiMap, syncback::snapshot::inst_path, REF_ID_ATTRIBUTE_NAME,
-    REF_POINTER_ATTRIBUTE_PREFIX,
-};
+use crate::syncback::snapshot::inst_path;
+use crate::{multimap::MultiMap, REF_ID_ATTRIBUTE_NAME, REF_POINTER_ATTRIBUTE_PREFIX};
 
 pub struct RefLinks {
     /// A map of referents to each of their Ref properties.

--- a/src/syncback/snapshot.rs
+++ b/src/syncback/snapshot.rs
@@ -222,19 +222,7 @@ pub fn filter_out_property(inst: &Instance, prop_name: &str) -> bool {
 }
 
 pub fn inst_path(dom: &WeakDom, referent: Ref) -> String {
-    let mut path = Vec::new();
-
-    let mut inst = dom.get_by_ref(referent);
-    while let Some(instance) = inst {
-        path.push(instance.name.as_str());
-        inst = dom.get_by_ref(instance.parent());
-    }
-    // This is to avoid the root's name from appearing in the path. Not
-    // optimal, but should be fine.
-    path.pop();
-
-    path.reverse();
-    path.join("/")
+    dom.full_name_for(referent, "/")
 }
 
 #[cfg(test)]

--- a/src/syncback/snapshot.rs
+++ b/src/syncback/snapshot.rs
@@ -222,7 +222,7 @@ pub fn filter_out_property(inst: &Instance, prop_name: &str) -> bool {
 }
 
 pub fn inst_path(dom: &WeakDom, referent: Ref) -> String {
-    dom.full_name_for(referent, "/")
+    dom.full_path_of(referent, "/")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Depends on https://github.com/rojo-rbx/rbx-dom/pull/580

Changes `syncback::snapshot::inst_path` to use `WeakDom::full_path_of`.  I'm open to changing the function name before it's merged upstream. `full_name_for` was what the private function it's making public was called.

### Lore

I wrote rbx-dom#580 yesterday, and today I found a bug (in other new rbx-dom code I wrote) related to not using a standardized "GetFullName" function while changing the WeakDom internals while running the Rojo tests.  That also meant that I learned about this function that looks suspiciously similar to the one in my pull request.