### PR TITLE
Skip writing of unserializable number props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,12 @@ Making a new release? Simply add the new header with the version and date undern
 -->
 
 ## Unreleased
+
 * Fixed a bug caused by having reference properties (such as `ObjectValue.Value`) that point to an Instance not included in syncback. ([#1179])
+* Fixed number properties containing Infinity/NaN being overwritten with nil. ([#1189])
 
 [#1179]: https://github.com/rojo-rbx/rojo/pull/1179
+[#1189]: https://github.com/rojo-rbx/rojo/pull/1189
 
 ## [7.7.0-rc.1] (November 27th, 2025)
 

--- a/plugin/src/Reconciler/setProperty.lua
+++ b/plugin/src/Reconciler/setProperty.lua
@@ -7,7 +7,7 @@ local Log = require(Packages.Log)
 local RbxDom = require(Packages.RbxDom)
 local Error = require(script.Parent.Error)
 
-local function setProperty(instance, propertyName, value)
+local function setProperty(instance: Instance, propertyName: string, value: unknown): boolean
 	local descriptor = RbxDom.findCanonicalPropertyDescriptor(instance.ClassName, propertyName)
 
 	-- We can skip unknown properties; they're not likely reflected to Lua.
@@ -26,6 +26,15 @@ local function setProperty(instance, propertyName, value)
 				className = instance.ClassName,
 				propertyName = propertyName,
 			})
+	end
+
+	-- TODO: Remove when port to MessagePack is complete, fixes overwriting of NaN/Infinity number props
+	-- See #363, #953, #955, #1041
+	if value == nil then
+		if descriptor.dataType == "Float32" or descriptor.dataType == "Float64" then
+			Log.trace("Skipping nil {} property {}.{}", descriptor.dataType, instance.ClassName, propertyName)
+			return true
+		end
 	end
 
 	local writeSuccess, err = descriptor:write(instance, value)


### PR DESCRIPTION
This is a direct port of #955, which was removed some time around 7.5.0 because MessagePack support was going in to replace JSON. Unfortunately, it didn't make it in time, and now we're on 7.7.0-rc1, partially because of Roblox updates forcing new releases.

Closes #1041 