### PR TITLE
Fix init.plugin.lua/init.plugin.luau not being supported 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Making a new release? Simply add the new header with the version and date undern
 * Fixed a bug where the notification timeout thread would fail to cancel on unmount ([#1211])
 * Added a "Forget" option to the sync reminder notification to avoid being reminded for that place in the future ([#1215])
 * Improves relative path calculation for sourcemap generation to avoid issues with Windows UNC paths. ([#1217])
+* Fixed missing support for init.plugin.lua and init.plugin.luau. ([#1252])
 
 [#1176]: https://github.com/rojo-rbx/rojo/pull/1176
 [#1179]: https://github.com/rojo-rbx/rojo/pull/1179
@@ -48,6 +49,7 @@ Making a new release? Simply add the new header with the version and date undern
 [#1211]: https://github.com/rojo-rbx/rojo/pull/1211
 [#1215]: https://github.com/rojo-rbx/rojo/pull/1215
 [#1217]: https://github.com/rojo-rbx/rojo/pull/1217
+[#1252]: https://github.com/rojo-rbx/rojo/pull/1252
 
 ## [7.7.0-rc.1] (November 27th, 2025)
 

--- a/rojo-test/build-test-snapshots/end_to_end__tests__build__plugin_init.snap
+++ b/rojo-test/build-test-snapshots/end_to_end__tests__build__plugin_init.snap
@@ -1,0 +1,27 @@
+---
+source: tests/tests/build.rs
+expression: contents
+---
+<roblox version="4">
+  <Item class="Folder" referent="0">
+    <Properties>
+      <string name="Name">plugin_init</string>
+    </Properties>
+    <Item class="Script" referent="1">
+      <Properties>
+        <string name="Name">lua</string>
+        <token name="RunContext">3</token>
+        <string name="Source"><![CDATA[return "From folder/lua/init.plugin.lua"
+]]></string>
+      </Properties>
+    </Item>
+    <Item class="Script" referent="2">
+      <Properties>
+        <string name="Name">luau</string>
+        <token name="RunContext">3</token>
+        <string name="Source"><![CDATA[return "From folder/luau/init.plugin.luau"
+]]></string>
+      </Properties>
+    </Item>
+  </Item>
+</roblox>

--- a/rojo-test/build-tests/plugin_init/default.project.json
+++ b/rojo-test/build-tests/plugin_init/default.project.json
@@ -1,0 +1,6 @@
+{
+  "name": "plugin_init",
+  "tree": {
+    "$path": "folder"
+  }
+}

--- a/rojo-test/build-tests/plugin_init/folder/lua/init.plugin.lua
+++ b/rojo-test/build-tests/plugin_init/folder/lua/init.plugin.lua
@@ -1,0 +1,1 @@
+return "From folder/lua/init.plugin.lua"

--- a/rojo-test/build-tests/plugin_init/folder/luau/init.plugin.luau
+++ b/rojo-test/build-tests/plugin_init/folder/luau/init.plugin.luau
@@ -1,0 +1,1 @@
+return "From folder/luau/init.plugin.luau"

--- a/src/snapshot_middleware/dir.rs
+++ b/src/snapshot_middleware/dir.rs
@@ -74,6 +74,8 @@ pub fn snapshot_dir_no_meta(
         normalized_path.join("init.server.luau"),
         normalized_path.join("init.client.lua"),
         normalized_path.join("init.client.luau"),
+        normalized_path.join("init.plugin.lua"),
+        normalized_path.join("init.plugin.luau"),
         normalized_path.join("init.csv"),
     ];
 

--- a/src/snapshot_middleware/lua.rs
+++ b/src/snapshot_middleware/lua.rs
@@ -182,6 +182,7 @@ pub fn syncback_lua_init<'sync>(
         ScriptType::Server => "init.server.luau",
         ScriptType::Client => "init.client.luau",
         ScriptType::Module => "init.luau",
+        ScriptType::Plugin => "init.plugin.luau",
         _ => anyhow::bail!("syncback is not yet implemented for {script_type:?}"),
     });
 

--- a/src/snapshot_middleware/mod.rs
+++ b/src/snapshot_middleware/mod.rs
@@ -91,7 +91,9 @@ pub fn snapshot_from_vfs(
         // TODO: Is this even necessary anymore?
         match file_name {
             "init.server.luau" | "init.server.lua" | "init.client.luau" | "init.client.lua"
-            | "init.luau" | "init.lua" | "init.csv" => return Ok(None),
+            | "init.plugin.luau" | "init.plugin.lua" | "init.luau" | "init.lua" | "init.csv" => {
+                return Ok(None)
+            }
             _ => {}
         }
 
@@ -124,6 +126,8 @@ fn get_dir_middleware<'path>(
             (Middleware::ServerScriptDir, "init.server.lua"),
             (Middleware::ClientScriptDir, "init.client.luau"),
             (Middleware::ClientScriptDir, "init.client.lua"),
+            (Middleware::PluginScriptDir, "init.plugin.lua"),
+            (Middleware::PluginScriptDir, "init.plugin.luau"),
             (Middleware::CsvDir, "init.csv"),
         ]
     });
@@ -205,6 +209,8 @@ pub enum Middleware {
     #[serde(skip_deserializing)]
     ClientScriptDir,
     #[serde(skip_deserializing)]
+    PluginScriptDir,
+    #[serde(skip_deserializing)]
     ModuleScriptDir,
     #[serde(skip_deserializing)]
     CsvDir,
@@ -255,6 +261,9 @@ impl Middleware {
             Self::ClientScriptDir => {
                 snapshot_lua_init(context, vfs, path, name, ScriptType::Client)
             }
+            Self::PluginScriptDir => {
+                snapshot_lua_init(context, vfs, path, name, ScriptType::Plugin)
+            }
             Self::ModuleScriptDir => {
                 snapshot_lua_init(context, vfs, path, name, ScriptType::Module)
             }
@@ -297,6 +306,7 @@ impl Middleware {
             Middleware::Dir => syncback_dir(snapshot),
             Middleware::ServerScriptDir => syncback_lua_init(ScriptType::Server, snapshot),
             Middleware::ClientScriptDir => syncback_lua_init(ScriptType::Client, snapshot),
+            Middleware::PluginScriptDir => syncback_lua_init(ScriptType::Plugin, snapshot),
             Middleware::ModuleScriptDir => syncback_lua_init(ScriptType::Module, snapshot),
             Middleware::CsvDir => syncback_csv_init(snapshot),
 
@@ -318,6 +328,7 @@ impl Middleware {
             Middleware::Dir
                 | Middleware::ServerScriptDir
                 | Middleware::ClientScriptDir
+                | Middleware::PluginScriptDir
                 | Middleware::ModuleScriptDir
                 | Middleware::CsvDir
         )

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__csv__test__csv_init.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__csv__test__csv_init.snap
@@ -15,6 +15,8 @@ metadata:
     - /root/init.server.luau
     - /root/init.client.lua
     - /root/init.client.luau
+    - /root/init.plugin.lua
+    - /root/init.plugin.luau
     - /root/init.csv
     - /root/init.meta.json
     - /root/init.meta.jsonc

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__csv__test__csv_init_with_meta.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__csv__test__csv_init_with_meta.snap
@@ -15,6 +15,8 @@ metadata:
     - /root/init.server.luau
     - /root/init.client.lua
     - /root/init.client.luau
+    - /root/init.plugin.lua
+    - /root/init.plugin.luau
     - /root/init.csv
     - /root/init.meta.json
     - /root/init.meta.jsonc

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__dir__test__empty_folder.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__dir__test__empty_folder.snap
@@ -15,6 +15,8 @@ metadata:
     - /foo/init.server.luau
     - /foo/init.client.lua
     - /foo/init.client.luau
+    - /foo/init.plugin.lua
+    - /foo/init.plugin.luau
     - /foo/init.csv
     - /foo/init.meta.json
     - /foo/init.meta.jsonc

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__dir__test__folder_in_folder.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__dir__test__folder_in_folder.snap
@@ -15,6 +15,8 @@ metadata:
     - /foo/init.server.luau
     - /foo/init.client.lua
     - /foo/init.client.luau
+    - /foo/init.plugin.lua
+    - /foo/init.plugin.luau
     - /foo/init.csv
     - /foo/init.meta.json
     - /foo/init.meta.jsonc
@@ -40,6 +42,8 @@ children:
         - /foo/Child/init.server.luau
         - /foo/Child/init.client.lua
         - /foo/Child/init.client.luau
+        - /foo/Child/init.plugin.lua
+        - /foo/Child/init.plugin.luau
         - /foo/Child/init.csv
         - /foo/Child/init.meta.json
         - /foo/Child/init.meta.jsonc

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__init_module_from_vfs.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__init_module_from_vfs.snap
@@ -15,6 +15,8 @@ metadata:
     - /root/init.server.luau
     - /root/init.client.lua
     - /root/init.client.luau
+    - /root/init.plugin.lua
+    - /root/init.plugin.luau
     - /root/init.csv
     - /root/init.meta.json
     - /root/init.meta.jsonc

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__init_module_from_vfs_with_meta.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__lua__test__init_module_from_vfs_with_meta.snap
@@ -15,6 +15,8 @@ metadata:
     - /root/init.server.luau
     - /root/init.client.lua
     - /root/init.client.luau
+    - /root/init.plugin.lua
+    - /root/init.plugin.luau
     - /root/init.csv
     - /root/init.meta.json
     - /root/init.meta.jsonc

--- a/src/syncback/file_names.rs
+++ b/src/syncback/file_names.rs
@@ -35,6 +35,7 @@ pub fn name_for_inst<'old>(
             | Middleware::CsvDir
             | Middleware::ServerScriptDir
             | Middleware::ClientScriptDir
+            | Middleware::PluginScriptDir
             | Middleware::ModuleScriptDir => Cow::Owned(new_inst.name.clone()),
             _ => {
                 let extension = extension_for_middleware(middleware);
@@ -78,6 +79,7 @@ pub fn extension_for_middleware(middleware: Middleware) -> &'static str {
         | Middleware::CsvDir
         | Middleware::ServerScriptDir
         | Middleware::ClientScriptDir
+        | Middleware::PluginScriptDir
         | Middleware::ModuleScriptDir => {
             unimplemented!("directory middleware requires special treatment")
         }

--- a/src/syncback/mod.rs
+++ b/src/syncback/mod.rs
@@ -359,6 +359,7 @@ pub fn get_best_middleware(snapshot: &SyncbackSnapshot) -> Middleware {
         middleware = match middleware {
             Middleware::ServerScript => Middleware::ServerScriptDir,
             Middleware::ClientScript => Middleware::ClientScriptDir,
+            Middleware::PluginScript => Middleware::PluginScriptDir,
             Middleware::ModuleScript => Middleware::ModuleScriptDir,
             Middleware::Csv => Middleware::CsvDir,
             Middleware::JsonModel | Middleware::Text => Middleware::Dir,

--- a/tests/tests/build.rs
+++ b/tests/tests/build.rs
@@ -65,6 +65,7 @@ gen_build_tests! {
     no_name_default_project,
     no_name_project,
     no_name_top_level_project,
+    plugin_init,
 }
 
 fn run_build_test(test_name: &str) {


### PR DESCRIPTION
Closes #1242.

It looks like when we added #1008, we did not add support for init.plugin.lua/init.plugin.luau. This PR adds the necessary logic to support this pattern, and a build test to make sure it continues working.