### PR TITLE
Use lossy conversion for msgpack UInt64 decode in plugin

### DIFF
--- a/plugin/http/init.lua
+++ b/plugin/http/init.lua
@@ -14,6 +14,13 @@ local Http = {}
 Http.Error = HttpError
 Http.Response = HttpResponse
 
+-- Monkey patch msgpack.UInt64.new to lossily convert the low and high bits of the integer
+-- to a native Luau number. We should change the upstream decoder to emit a native
+-- integer, once those are live.
+function msgpack.UInt64.new(mostSignificantPart: number, leastSignificantPart: number): number
+	return mostSignificantPart * 2 ^ 32 + (leastSignificantPart % 2 ^ 32)
+end
+
 local function performRequest(requestParams)
 	local requestId = lastRequestId + 1
 	lastRequestId = requestId

--- a/plugin/http/init.lua
+++ b/plugin/http/init.lua
@@ -18,7 +18,7 @@ Http.Response = HttpResponse
 -- to a native Luau number. We should change the upstream decoder to emit a native
 -- integer, once those are live.
 function msgpack.UInt64.new(mostSignificantPart: number, leastSignificantPart: number): number
-	return mostSignificantPart * 2 ^ 32 + (leastSignificantPart % 2 ^ 32)
+	return (mostSignificantPart % 2 ^ 32) * 2 ^ 32 + (leastSignificantPart % 2 ^ 32)
 end
 
 local function performRequest(requestParams)


### PR DESCRIPTION
Closes #1250.

This PR monkey patches the msgpack-luau library to lossily decode uint64 values as native Luau numbers. Once Luau natvie integers are live, we should look to make changes upstream to msgpack-luau so that it decodes 64 bit integers as native Luau integers where appropriate. 

