### PR TITLE
Update stale README and contributor documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,11 +13,26 @@ Code contributions are welcome for features and bugs that have been reported in 
 
 You'll want these tools to work on Rojo:
 
-* Latest stable Rust compiler
+* Rust 1.88 or newer
   * Rustfmt and Clippy are used for code formatting and linting.
-* Latest stable [Rojo](https://github.com/rojo-rbx/rojo)
 * [Rokit](https://github.com/rojo-rbx/rokit)
 * [Luau Language Server](https://github.com/JohnnyMorganz/luau-lsp) (Only needed if working on the Studio plugin.)
+
+Rokit installs the pinned Rojo, Selene, StyLua, Lune, and run-in-roblox versions listed in [`rokit.toml`](rokit.toml):
+
+```bash
+rokit install
+```
+
+Before opening a pull request, run the relevant checks:
+
+```bash
+cargo test
+cargo fmt -- --check
+cargo clippy
+stylua --check plugin/src
+selene plugin/src
+```
 
 When working on the Studio plugin, we recommend using this command to automatically rebuild the plugin when you save a change:
 
@@ -29,7 +44,7 @@ bash scripts/watch-build-plugin.sh
 
 You can also run the plugin's unit tests with the following:
 
-*(Make sure you have `run-in-roblox` installed first!)*
+*(If you are not using Rokit, make sure you have `run-in-roblox` installed first!)*
 
 ```bash
 bash scripts/unit-test-plugin.sh
@@ -49,7 +64,7 @@ Please file issues and we'll try to help figure out what the best way forward is
 
 ## Local Development Gotchas
 
-If your build fails with "Error: failed to open file `D:\code\rojo\plugin\modules\roact\src`" you need to update your Git submodules.
+If your build fails with an error about a missing path under `plugin/Packages`, such as `plugin/Packages/Roact`, you need to update your Git submodules.
 Run the command and try building again: `git submodule update --init --recursive`.
 
 ## Pushing a Rojo Release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,22 +53,22 @@ If your build fails with "Error: failed to open file `D:\code\rojo\plugin\module
 Run the command and try building again: `git submodule update --init --recursive`.
 
 ## Pushing a Rojo Release
-The Rojo release process is pretty manual right now. If you need to do it, here's how:
+The Rojo release process is driven by the GitHub Actions release workflow. If you need to do it, here's how:
 
 1. Bump server version in [`Cargo.toml`](Cargo.toml)
-2. Bump plugin version in [`plugin/src/Config.lua`](plugin/src/Config.lua)
-3. Run `cargo test` to update `Cargo.lock` and run tests
+2. Bump plugin version in [`plugin/Version.txt`](plugin/Version.txt)
+   * The build checks that the Cargo and plugin versions match.
+3. Run `cargo test` to update `Cargo.lock` after the version bump and run tests
 4. Update [`CHANGELOG.md`](CHANGELOG.md)
 5. Commit!
     * `git add . && git commit -m "Release vX.Y.Z"`
 6. Tag the commit
     * `git tag vX.Y.Z`
-7. Publish the CLI
-    * `cargo publish`
-8. Publish the Plugin
-    * `cargo run -- upload plugin --asset_id 6415005344`
-9. Push commits and tags
+7. Push commits and tags
     * `git push && git push --tags`
+8. Wait for the GitHub Actions release workflow to create the draft release and upload CLI/plugin artifacts
+9. Publish the CLI crate
+    * `cargo publish`
 10. Copy GitHub release content from previous release
     * Update the leading text with a summary about the release
     * Paste the changelog notes (as-is!) from [`CHANGELOG.md`](CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -25,12 +25,11 @@ Rojo enables:
 * Versioning your game, library, or plugin using Git or another VCS
 * Streaming `rbxmx` and `rbxm` models into your game in real time
 * Packaging and deploying your project to Roblox.com from the command line
+* Pulling Instances from Roblox place and model files back into an existing Rojo project with `rojo syncback`
 
-In the future, Rojo will be able to:
+Rojo also has an optional two-way sync setting in the Studio plugin for syncing supported Studio edits back to the filesystem.
 
-* Sync instances from Roblox Studio to the filesystem
-* Automatically convert your existing game to work with Rojo
-* Import custom instances like MoonScript code
+Some workflows, like fully automatic conversion of every existing game into a Rojo project, are still limited and may require manual project configuration.
 
 ## [Documentation](https://rojo.space/docs)
 Documentation is hosted in the [rojo.space repository](https://github.com/rojo-rbx/rojo.space).


### PR DESCRIPTION
## Summary

- update the README feature section so syncback and optional two-way sync are not described as future work
- document Rokit-based contributor setup and the common local checks
- update submodule troubleshooting to reference the current `plugin/Packages` layout
- update the release checklist to point plugin version bumps at `plugin/Version.txt`
- describe the tag-triggered GitHub Actions release workflow before manual crate publication

## Why

Several docs had drifted from the current repository layout and workflow. In particular, the release checklist pointed maintainers at `plugin/src/Config.lua`, but the current plugin version is stored in `plugin/Version.txt` and validated against `Cargo.toml` during the build.

Closes #1268

## Validation

- `git diff --check`
- not run: full test suite, docs-only change