### PR TITLE
Return 400 for missing /api/serialize IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Making a new release? Simply add the new header with the version and date undern
 * Fixed the sync fallback scrambling sibling order; replacements are now re-parented ancestors-first and in their original child order. ([#1265])
 * Instances that share a name and class are now robustly matched on resync by comparing their properties, instead of relying on child order alone. ([#1266])
 * Rojo now reports a clear error instead of panicking in several cases, including when the `serve` port is already in use, when a synced file is read-only or locked, when the filesystem watcher can't be created, and when the working directory is inaccessible. ([#1267])
+* Fixed `/api/serialize` returning success when a requested instance ID is missing from the serve session tree. ([#1272])
 
 [#1176]: https://github.com/rojo-rbx/rojo/pull/1176
 [#1179]: https://github.com/rojo-rbx/rojo/pull/1179
@@ -54,6 +55,7 @@ Making a new release? Simply add the new header with the version and date undern
 [#1265]: https://github.com/rojo-rbx/rojo/pull/1265
 [#1266]: https://github.com/rojo-rbx/rojo/pull/1266
 [#1267]: https://github.com/rojo-rbx/rojo/pull/1267
+[#1272]: https://github.com/rojo-rbx/rojo/pull/1272
 
 ## [7.7.0-rc.1] (November 27th, 2025)
 

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -267,7 +267,7 @@ impl ApiService {
 
                 response_dom.transfer_within(child_ref, object_value);
             } else {
-                msgpack(
+                return msgpack(
                     ErrorResponse::bad_request(format!("provided id {id} is not in the tree")),
                     StatusCode::BAD_REQUEST,
                 );

--- a/tests/rojo_test/serve_util.rs
+++ b/tests/rojo_test/serve_util.rs
@@ -224,16 +224,6 @@ impl TestServeSession {
         }
     }
 
-    pub fn get_api_serialize(
-        &self,
-        ids: &[Ref],
-        session_id: SessionId,
-    ) -> Result<SerializeResponse, reqwest::Error> {
-        let body = self.post_api_serialize(ids, session_id)?.bytes()?;
-
-        Ok(deserialize_msgpack(&body).expect("Server returned malformed response"))
-    }
-
     pub fn post_api_serialize(
         &self,
         ids: &[Ref],
@@ -262,7 +252,7 @@ fn serialize_msgpack<T: Serialize>(value: T) -> Result<Vec<u8>, rmp_serde::encod
     Ok(serialized)
 }
 
-fn deserialize_msgpack<'a, T: Deserialize<'a>>(
+pub fn deserialize_msgpack<'a, T: Deserialize<'a>>(
     input: &'a [u8],
 ) -> Result<T, rmp_serde::decode::Error> {
     let mut deserializer = rmp_serde::Deserializer::new(input).with_human_readable();

--- a/tests/rojo_test/serve_util.rs
+++ b/tests/rojo_test/serve_util.rs
@@ -229,6 +229,16 @@ impl TestServeSession {
         ids: &[Ref],
         session_id: SessionId,
     ) -> Result<SerializeResponse, reqwest::Error> {
+        let body = self.post_api_serialize(ids, session_id)?.bytes()?;
+
+        Ok(deserialize_msgpack(&body).expect("Server returned malformed response"))
+    }
+
+    pub fn post_api_serialize(
+        &self,
+        ids: &[Ref],
+        session_id: SessionId,
+    ) -> Result<reqwest::blocking::Response, reqwest::Error> {
         let client = reqwest::blocking::Client::new();
         let url = format!("http://localhost:{}/api/serialize", self.port);
         let body = serialize_msgpack(&SerializeRequest {
@@ -237,9 +247,7 @@ impl TestServeSession {
         })
         .unwrap();
 
-        let body = client.post(url).body(body).send()?.bytes()?;
-
-        Ok(deserialize_msgpack(&body).expect("Server returned malformed response"))
+        client.post(url).body(body).send()
     }
 }
 

--- a/tests/tests/serve.rs
+++ b/tests/tests/serve.rs
@@ -7,10 +7,10 @@ use tempfile::tempdir;
 
 use crate::rojo_test::{
     internable::InternAndRedact,
-    serve_util::{run_serve_test, serialize_to_xml_model},
+    serve_util::{deserialize_msgpack, run_serve_test, serialize_to_xml_model},
 };
 
-use librojo::web_api::SocketPacketType;
+use librojo::web_api::{SerializeResponse, SocketPacketType};
 
 #[test]
 fn empty() {
@@ -647,9 +647,13 @@ fn meshpart_with_id() {
             .find(|(_, inst)| inst.class_name == "ObjectValue")
             .unwrap();
 
-        let serialize_response = session
-            .get_api_serialize(&[*meshpart, *objectvalue], info.session_id)
+        let body = session
+            .post_api_serialize(&[*meshpart, *objectvalue], info.session_id)
+            .unwrap()
+            .bytes()
             .unwrap();
+        let serialize_response: SerializeResponse =
+            deserialize_msgpack(&body).expect("Server returned malformed response");
 
         // We don't assert a snapshot on the SerializeResponse because the model includes the
         // Refs from the DOM as names, which means it will obviously be different every time
@@ -689,9 +693,13 @@ fn forced_parent() {
             read_response.intern_and_redact(&mut redactions, root_id)
         );
 
-        let serialize_response = session
-            .get_api_serialize(&[root_id], info.session_id)
+        let body = session
+            .post_api_serialize(&[root_id], info.session_id)
+            .unwrap()
+            .bytes()
             .unwrap();
+        let serialize_response: SerializeResponse =
+            deserialize_msgpack(&body).expect("Server returned malformed response");
 
         assert_eq!(serialize_response.session_id, info.session_id);
 

--- a/tests/tests/serve.rs
+++ b/tests/tests/serve.rs
@@ -1,6 +1,8 @@
 use std::fs;
 
 use insta::{assert_snapshot, assert_yaml_snapshot, with_settings};
+use rbx_dom_weak::types::Ref;
+use reqwest::StatusCode;
 use tempfile::tempdir;
 
 use crate::rojo_test::{
@@ -656,6 +658,20 @@ fn meshpart_with_id() {
 
         let model = serialize_to_xml_model(&serialize_response, &redactions);
         assert_snapshot!("meshpart_with_id_serialize_model", model);
+    });
+}
+
+#[test]
+fn serialize_missing_id() {
+    run_serve_test("empty", |session, _| {
+        let info = session.get_api_rojo().unwrap();
+        let missing_id = Ref::new();
+
+        let response = session
+            .post_api_serialize(&[missing_id], info.session_id)
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     });
 }
 


### PR DESCRIPTION
## Summary

- return the bad-request response when `/api/serialize` receives an ID that is not in the serve session tree
- add a raw `/api/serialize` POST helper for serve tests that need to inspect HTTP status codes
- add a regression test for missing serialize IDs returning `400 Bad Request`

## Validation

- `cargo test --locked serialize_missing_id`
- `git diff --check`

Closes #1271
