### PR TITLE
Lock 'Check for Updates' setting if user blocks access to `api.github.com`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,10 @@ Making a new release? Simply add the new header with the version and date undern
 * Fixed `$path` values that point outside the project folder failing to match `syncRule`s on Windows, which broke `rojo sourcemap` with a "could not be turned into a Roblox Instance" error. ([#1290])
 * Fixed `rojo serve` silently stopping syncing file changes on Windows when the served project path was a verbatim (`\\?\`) path, because tree paths and file-watcher event paths were canonicalized to different forms. ([#1290])
 * Fixed `rojo sourcemap --absolute` emitting verbatim (`\\?\`) paths on Windows, which broke require types in luau-lsp. ([#1290])
+* The plugin now disables the `Check for Updates` setting if you block access to `api.github.com`. ([#1297])
 
 [#1290]: https://github.com/rojo-rbx/rojo/pull/1290
+[#1297]: https://github.com/rojo-rbx/rojo/pull/1297
 
 ## [7.7.0] (July 1st, 2026)
 

--- a/plugin/src/App/StatusPages/Settings/init.lua
+++ b/plugin/src/App/StatusPages/Settings/init.lua
@@ -8,6 +8,7 @@ local Log = require(Packages.Log)
 local Assets = require(Plugin.Assets)
 local Settings = require(Plugin.Settings)
 local Theme = require(Plugin.App.Theme)
+local Version = require(Plugin.Version)
 
 local IconButton = require(Plugin.App.Components.IconButton)
 local ScrollingFrame = require(Plugin.App.Components.ScrollingFrame)
@@ -193,6 +194,8 @@ function SettingsPage:render()
 				id = "checkForUpdates",
 				name = "Check For Updates",
 				description = "Notify about newer compatible Rojo releases",
+				locked = Version.isApiBlocked(),
+				lockedTooltip = "(HTTP requests to api.github.com are blocked, Rojo cannot fetch what the latest version is.)",
 				transparency = self.props.transparency,
 				layoutOrder = layoutIncrement(),
 			}),

--- a/plugin/src/Version.lua
+++ b/plugin/src/Version.lua
@@ -113,7 +113,8 @@ Version._cachedLatestCompatible = nil :: {
 
 --[[
 	A user may choose to reject requests to api.github.com. If they do, we want
-	to disable the option to enable checks altogether.
+	to disable the setting for checking for updates to indicate that it does
+	nothing.
 ]]
 Version._apiBlocked = nil :: boolean?
 

--- a/plugin/src/Version.lua
+++ b/plugin/src/Version.lua
@@ -111,6 +111,23 @@ Version._cachedLatestCompatible = nil :: {
 	timestamp: number,
 }?
 
+--[[
+	A user may choose to reject requests to api.github.com. If they do, we want
+	to disable the option to enable checks altogether.
+]]
+Version._apiBlocked = nil :: boolean?
+
+function Version.isApiBlocked(): boolean
+	if Version._apiBlocked == nil then
+		local isLocalInstall = string.find(debug.traceback(), "\n[^\n]-user_.-$") ~= nil
+		Version.retrieveLatestCompatible({
+			version = Config.version,
+			includePrereleases = isLocalInstall and Settings:get("checkForPrereleases"),
+		})
+	end
+	return Version._apiBlocked
+end
+
 function Version.retrieveLatestCompatible(options: {
 	version: { number },
 	includePrereleases: boolean?,
@@ -136,8 +153,15 @@ function Version.retrieveLatestCompatible(options: {
 		:await()
 
 	if success == false or type(releases) ~= "table" or next(releases) ~= 1 then
+		-- Roblox's HTTP errors are weird!
+		if string.find(tostring(releases), "^Unknown HTTP error: HttpService permission denied") then
+			Log.debug("Requests to api.github were denied by user, disabling update check")
+			Settings:set("checkForUpdates", false)
+			Version._apiBlocked = true
+		end
 		return nil
 	end
+	Version._apiBlocked = false
 
 	-- Iterate through releases, looking for the latest compatible version
 	local latestCompatible: LatestReleaseInfo? = nil

--- a/plugin/src/Version.lua
+++ b/plugin/src/Version.lua
@@ -155,8 +155,6 @@ function Version.retrieveLatestCompatible(options: {
 	if success == false or type(releases) ~= "table" or next(releases) ~= 1 then
 		-- Roblox's HTTP errors are weird!
 		if string.find(tostring(releases), "^Unknown HTTP error: HttpService permission denied") then
-			Log.debug("Requests to api.github were denied by user, disabling update check")
-			Settings:set("checkForUpdates", false)
 			Version._apiBlocked = true
 		end
 		return nil


### PR DESCRIPTION
It is possible to block API requests sent to `api.github.com` due to Roblox's security layer on plugins. This doesn't currently break the plugin, but it does mean that if you block access to it, the "Check for updates" feature does zero work without any indication to you. This is my attempt at fixing that.

It's not the cleanest solution in the world, but I think just a simple lock on the setting if you block our access to `api.github.com` should make it clear what's going on. Initially this also disabled the setting, but I have concerns that people won't know to or won't remember to re-enable it if they unblock `api.github.com`. I foresee a world where someone blocks it on instinct, goes to audit the code, and then unblocks it when they see that the request is benign, as an example.